### PR TITLE
getPdf() should also return NOT_FOUND if the file aquired from the accounts-service is empty.

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -6,6 +6,7 @@ use OC\Security\CSP\ContentSecurityPolicy;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Service\AccountService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
@@ -118,7 +119,7 @@ class PageController extends Controller {
 	public function getPdf($uuid) {
 		try {
 			$file = $this->accountService->getPdfByUuid($uuid);
-		} catch (\Throwable $th) {
+		} catch (DoesNotExistException $th) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -17,6 +17,7 @@ use OCA\Libresign\Handler\Pkcs12Handler;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\Http\Client\IClientService;
@@ -309,6 +310,9 @@ class AccountService {
 			$file = $userFolder->getById($fileData->getSignedNodeId())[0];
 		} else {
 			$file = $userFolder->getById($fileData->getNodeId())[0];
+		}
+		if (empty($file)) {
+			throw new DoesNotExistException('Not found');
 		}
 		return $file;
 	}

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -4,6 +4,7 @@ namespace OCA\Libresign\Tests\Unit;
 
 use OCA\Libresign\Controller\PageController;
 use OCA\Libresign\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -71,7 +72,7 @@ final class PageControllerTest extends TestCase {
 		$file = $this->createMock(\OCP\Files\File::class);
 		$this->accountService
 			->method('getPdfByUuid')
-			->willThrowException($this->createMock(\Exception::class));
+			->willThrowException($this->createMock(DoesNotExistException::class));
 
 		$response = $this->controller->getPdf('uuid');
 		$this->assertInstanceOf(\OCP\AppFramework\Http\DataResponse::class, $response);


### PR DESCRIPTION
Close #579