### PR TITLE
Add new command to validate setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,9 @@ appstore: clean
 		CHANGELOG.md \
 		LICENSE \
 		$(appstore_sign_dir)/$(app_name)
-	rm $(appstore_sign_dir)/$(app_name)/vendor/endroid/qr-code/assets/* \
+	rm $(appstore_sign_dir)/$(app_name)/vendor/endroid/qr-code/assets/*
+	mkdir -p $(appstore_sign_dir)/$(app_name)/tests/fixtures
+	cp tests/fixtures/small_valid.pdf $(appstore_sign_dir)/$(app_name)/tests/fixtures \
 
 	@if [ -z "$$GITHUB_ACTION" ]; then \
 		chown -R www-data:www-data $(appstore_sign_dir)/$(app_name) ; \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Install commands:
 occ libresign:install --all
 occ libresign:configure:cfssl --cn=<yourCN> --ou=<yourOU> --o=<yourO> --c=<yourCountry>
 ```
+Check install:
+```bash
+occ libresign:configure:check
+```
 
 ### Admin settings
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,9 @@ Nextcloud app to sign PDF documents.
 ## Setup
 
 ### Standalone
-Help to usage in configure cfssl command:
-```
-yourCN: CommonName
-yourOU: OrganizationalUnit
-yourO: Organization
-yourCountry: CountryName
-```
-After install LibreSign, will be necessary to run these follows commands
+After installing LibreSign, is necessary to run the following commands
 
-Install commands:
+Install commands, replace all between < and > by your data. For more information you could run the commands with `--help`:
 ```bash
 occ libresign:install --all
 occ libresign:configure:cfssl --cn=<yourCN> --ou=<yourOU> --o=<yourO> --c=<yourCountry>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,6 +28,7 @@
         <nextcloud min-version="26" max-version="26"/>
     </dependencies>
     <commands>
+        <command>OCA\Libresign\Command\Configure\Check</command>
         <command>OCA\Libresign\Command\Configure\Cfssl</command>
         <command>OCA\Libresign\Command\Install</command>
         <command>OCA\Libresign\Command\Uninstall</command>

--- a/lib/Command/Configure/Check.php
+++ b/lib/Command/Configure/Check.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Libresign\Command\Configure;
+
+use OC\Core\Command\Base;
+use OCA\Libresign\Service\ConfigureCheckService;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Check extends Base {
+	private ConfigureCheckService $configureCheckService;
+	public function __construct(
+		ConfigureCheckService $configureCheckService
+	) {
+		parent::__construct();
+		$this->configureCheckService = $configureCheckService;
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('libresign:configure:check')
+			->setDescription('Check configure')
+			->addOption('preview',
+				'p',
+				InputOption::VALUE_NONE,
+				'Check requirements to generate image preview'
+			)
+			->addOption('sign',
+				's',
+				InputOption::VALUE_NONE,
+				'Check requirements to sign document'
+			)
+			->addOption('cfssl',
+				'c',
+				InputOption::VALUE_NONE,
+				'Check requirements to use CFSSL API'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$preview = $input->getOption('preview');
+		$sign = $input->getOption('sign');
+		$cfssl = $input->getOption('cfssl');
+		$all = (!$preview && !$sign && !$cfssl);
+
+		$result = [];
+		if ($all || $preview) {
+			$result = array_merge_recursive($result, $this->configureCheckService->canPreview());
+		}
+		if ($all || $sign) {
+			$result = array_merge_recursive($result, $this->configureCheckService->checkSign());
+		}
+		if ($all || $cfssl) {
+			$result = array_merge_recursive($result, $this->configureCheckService->checkCfssl());
+		}
+
+		$table = new Table($output);
+		if (count($result)) {
+			if (array_key_exists('errors', $result)) {
+				foreach ($result['errors'] as $error) {
+					$table->addRow(['🔴', $error]);
+				}
+			}
+			if (array_key_exists('success', $result)) {
+				foreach ($result['success'] as $success) {
+					$table->addRow(['🟢', $success]);
+				}
+			}
+			$table
+				->setHeaders(['Status', 'Description'])
+				->setStyle('compact')
+				->render();
+		}
+		return 0;
+	}
+}

--- a/lib/Handler/CfsslHandler.php
+++ b/lib/Handler/CfsslHandler.php
@@ -30,6 +30,8 @@ use OCA\Libresign\Exception\LibresignException;
  * @method string getCfsslUri()
  * @method CfsslHandler setClient(ClientInterface $client)
  * @method Client getClient()
+ * @method string getConfigPath()
+ * @method CfsslHandler setConfigPath()
  */
 class CfsslHandler {
 	private $commonName;
@@ -40,6 +42,7 @@ class CfsslHandler {
 	private $organizationUnit;
 	private $cfsslUri;
 	private $password;
+	private $configPath;
 	private $binary;
 	/** @var ClientInterface */
 	private $client;
@@ -178,7 +181,7 @@ class CfsslHandler {
 		if (!file_exists($binary)) {
 			throw new LibresignException('Binary of CFSSL not found');
 		}
-		$configPath = trim($binary, '.exe') . '_config' . DIRECTORY_SEPARATOR;
+		$configPath = $this->getConfigPath();
 		$cmd = 'nohup ' . $binary . ' serve -address=127.0.0.1 ' .
 			'-ca-key ' . $configPath . 'ca-key.pem ' .
 			'-ca ' . $configPath . 'ca.pem '.
@@ -237,7 +240,7 @@ class CfsslHandler {
 		if (!$binary) {
 			return;
 		}
-		$configPath = trim($binary, '.exe') . '_config' . DIRECTORY_SEPARATOR;
+		$configPath = $this->getConfigPath();
 		$cmd = $binary . ' genkey ' .
 			'-initca=true ' . $configPath . 'csr_server.json | ' .
 			$binary . 'json -bare ' . $configPath . 'ca;';

--- a/lib/Handler/Pkcs12Handler.php
+++ b/lib/Handler/Pkcs12Handler.php
@@ -284,6 +284,9 @@ class Pkcs12Handler extends SignEngineHandler {
 		if (!$this->cfsslHandler->getCfsslUri()) {
 			$this->cfsslHandler->setCfsslUri($this->config->getAppValue(Application::APP_ID, 'cfsslUri'));
 		}
+		if (!$this->cfsslHandler->getConfigPath()) {
+			$this->cfsslHandler->setConfigPath($this->config->getAppValue(Application::APP_ID, 'configPath'));
+		}
 		if (!$this->cfsslHandler->getBinary()) {
 			$binary = $this->config->getAppValue(Application::APP_ID, 'cfssl_bin');
 			if ($binary) {

--- a/lib/Service/AdminSignatureService.php
+++ b/lib/Service/AdminSignatureService.php
@@ -58,6 +58,7 @@ class AdminSignatureService {
 					Application::APP_ID . DIRECTORY_SEPARATOR .
 					'cfssl'
 				);
+			$this->cfsslHandler->setConfigPath($configPath);
 			$this->cfsslHandler->genkey();
 		}
 		$this->cfsslHandler

--- a/lib/Service/ConfigureCheckService.php
+++ b/lib/Service/ConfigureCheckService.php
@@ -35,12 +35,12 @@ class ConfigureCheckService {
 		} catch (ImagickException $ie) {
 			if ($ie->getCode() === 499) {
 				return [
-					'errors' => ['Necessary configure the security policy of ImageMagick to work with PDF. More informations: https://github.com/LibreSign/libresign/issues/829'],
+					'errors' => ['Is necessary to configure the ImageMagick security policy to work with PDF. More information on: https://github.com/LibreSign/libresign/issues/829'],
 				];
 			}
 		}
 		return [
-			'success' => ['Can generate preview'],
+			'success' => ['Can generate the preview'],
 		];
 	}
 

--- a/lib/Service/ConfigureCheckService.php
+++ b/lib/Service/ConfigureCheckService.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace OCA\Libresign\Service;
+
+use ImagickException;
+use OC\SystemConfig;
+use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Handler\JSignPdfHandler;
+use OCP\IConfig;
+
+class ConfigureCheckService {
+	private IConfig $config;
+	private SystemConfig $systemConfig;
+
+	public function __construct(
+		IConfig $config,
+		SystemConfig $systemConfig
+	) {
+		$this->config = $config;
+		$this->systemConfig = $systemConfig;
+	}
+
+	public function canPreview(): array {
+		if (!extension_loaded('imagick')) {
+			return [
+				'errors' => ['Extension Imagick required'],
+			];
+		}
+
+		$imagick = new \Imagick();
+		$imagick->setResolution(100, 100);
+		$pdf = file_get_contents(__DIR__ . '/../../tests/fixtures/small_valid.pdf');
+		try {
+			$imagick->readImageBlob($pdf);
+		} catch (ImagickException $ie) {
+			if ($ie->getCode() === 499) {
+				return [
+					'errors' => ['Necessary configure the security policy of ImageMagick to work with PDF. More informations: https://github.com/LibreSign/libresign/issues/829'],
+				];
+			}
+		}
+		return [
+			'success' => ['Can generate preview'],
+		];
+	}
+
+	public function checkSign(): array {
+		$return = [];
+		$return = array_merge_recursive($return, $this->checkJava());
+		$return = array_merge_recursive($return, $this->checkJSignPdf());
+		$return = array_merge_recursive($return, $this->checkLibresignCli());
+		return $return;
+	}
+
+	public function checkJSignPdf(): array {
+		$jsignpdJarPath = $this->config->getAppValue(Application::APP_ID, 'jsignpdf_jar_path');
+		if ($jsignpdJarPath) {
+			if (file_exists($jsignpdJarPath)) {
+				return [
+					'success' => [
+						'JSignPdf version: ' . JSignPdfHandler::VERSION,
+						'JSignPdf path: ' . $jsignpdJarPath,
+					]
+				];
+			}
+			return ['errors' => ['JSignPdf binary not found: ' . $jsignpdJarPath . ' run occ libresign:install --jsignpdf']];
+		}
+		return ['errors' => ['JSignPdf not found. run occ libresign:install --jsignpdf']];
+	}
+
+	private function checkJava(): array {
+		$javaPath = $this->config->getAppValue(Application::APP_ID, 'java_path');
+		if ($javaPath) {
+			if (file_exists($javaPath)) {
+				$javaVersion = exec($javaPath . " -version 2>&1");
+				return [
+					'success' => [
+						'Java version: ' . $javaVersion,
+						'Java binary: ' . $javaPath,
+					]
+				];
+			}
+			return ['errors' => ['Java binary not found: ' . $javaPath . ' run occ libresign:install --java']];
+		}
+		$javaVersion = exec("java -version 2>&1");
+		$hasJavaVersion = strpos($javaVersion, 'not found') === false;
+		if ($hasJavaVersion) {
+			return ['success' => ['Using java from operational system. Version: ' . $javaVersion]];
+		}
+		return ['errors' => ['Java not installed.']];
+	}
+
+	private function checkLibresignCli(): array {
+		$path = $this->config->getAppValue(Application::APP_ID, 'libresign_cli_path');
+		if (!file_exists($path) || !is_executable($path)) {
+			return ['errors' => ['LibreSign cli tools not found or without execute permission. Run occ libresign:install --cli']];
+		}
+		return ['success' => ['LibreSign cli tools found in path: ' . $path]];
+	}
+
+	public function checkCfssl(): array {
+		if (PHP_OS_FAMILY === 'Windows') {
+			return ['errors' => ['CFSSL is incompatible with Windows']];
+		}
+		$cfsslInstalled = $this->config->getAppValue(Application::APP_ID, 'cfssl_bin');
+		if (!$cfsslInstalled) {
+			return ['errors' => ['CFSSL not installed. Run occ libresign:install --cfssl']];
+		}
+
+		$instanceId = $this->systemConfig->getValue('instanceid', null);
+		$binary = $this->systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data/') . DIRECTORY_SEPARATOR .
+			'appdata_' . $instanceId . DIRECTORY_SEPARATOR .
+			Application::APP_ID . DIRECTORY_SEPARATOR .
+			'cfssl';
+		if (!file_exists($binary)) {
+			return ['errors' => ['CFSSL not found. Run occ libresign:install --cfssl']];
+		}
+		$return = ['success' => ['CFSSL binary path: ' . $binary]];
+		$version = str_replace("\n", ', ', trim(`$binary version`));
+		$return = ['success' => ['CFSSL: ' . $version]];
+		$configPath = $this->config->getAppValue(Application::APP_ID, 'configPath');
+		if (!is_dir($configPath)) {
+			$return = array_merge_recursive(
+				$return,
+				['errors' => ['CFSSL not configured. Run occ libresign:configure --cfssl']]
+			);
+		}
+		return $return;
+	}
+}


### PR DESCRIPTION
Add new command:
```
occ libresign:configure:check
```

Output:
```
Status Description
🟢      Can generate the preview                                                                           
🟢      Java version: OpenJDK 64-Bit Server VM (build 25.40-b25, mixed mode)                               
🟢      Java binary: /var/www/html/data/appdata_oci5yur91drs/libresign/java-se-8u41-ri/bin/java            
🟢      JSignPdf version: 2.1.0                                                                            
🟢      JSignPdf path: /var/www/html/data/appdata_oci5yur91drs/libresign/jsignpdf-2.1.0/JSignPdf.jar       
🟢      LibreSign cli tools found in path: /var/www/html/data/appdata_oci5yur91drs/libresign/libresign-cli 
🟢      CFSSL: Version: 1.6.1, Runtime: go1.12.12
```

I don't know if this format and text are the best, but for a first version I think is ok.

I also updated the README file of the project to add the new command and remove old settings.

Solve #860