### PR TITLE
Download binaries from admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,25 @@ Nextcloud app to sign PDF documents.
 
 **Table of contents**
 - [Setup](#setup)
-  - [Standalone](#standalone)
-  - [Admin settings](#admin-settings)
+  - [Check setup](#check-setup)
 - [Integrations](#integrations)
 - [Full documentation](#full-documentation)
 - [Contributing](#contributing)
 
 ## Setup
 
-### Standalone
-After installing LibreSign, is necessary to run the following commands
+After installing LibreSign, is necessary go to `Administration Settings > LibreSign` and:
+* Download binareis
+* Configure root certificate
 
-Install commands, replace all between < and > by your data. For more information you could run the commands with `--help`:
-```bash
-occ libresign:install --all
-occ libresign:configure:cfssl --cn=<yourCN> --ou=<yourOU> --o=<yourO> --c=<yourCountry>
-```
+Go to `Administration Settings > Basic Settings` and configure email settings. Is mandatory.
+
+### Check setup
+
 Check install:
 ```bash
 occ libresign:configure:check
 ```
-
-### Admin settings
-
-Go to `Settings > Basic Settings` and configure email settings. Is mandatory.
 
 ## Integrations
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,6 @@
     <description><![CDATA[**This is a libre digital PDF signature app for Nextcloud**
 
 * ✍️ Sign PDF documents using digital signature
-* ⚠️ Setup of this app requires access to terminal and even getting your hands dirty with installation of additional software. See [setup instructions](https://github.com/LibreSign/libresign/blob/main/README.md#setup) for details.
 
 ]]>
     </description>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -60,6 +60,7 @@ return [
 		// Admin config
 		['name' => 'admin#generateCertificate',       'url' => '/api/0.1/admin/certificate', 'verb' => 'POST'],
 		['name' => 'admin#loadCertificate',           'url' => '/api/0.1/admin/certificate', 'verb' => 'GET'],
+		['name' => 'admin#downloadBinaries',          'url' => '/api/0.1/admin/download-binaries', 'verb' => 'GET'],
 
 		// Pages - restricted
 		['name' => 'page#index',                      'url' => '/', 'verb' => 'GET'],

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -79,4 +79,27 @@ class AdminController extends Controller {
 		}
 		return trim($value);
 	}
+
+	/**
+	 * @NoCSRFRequired
+	 */
+	public function downloadBinaries(): DataResponse {
+		try {
+			$this->installService->installJava();
+			$this->installService->installJSignPdf();
+			$this->installService->installCfssl();
+			$this->installService->installCli();
+			return new DataResponse([
+				'success' => true
+			]);
+		} catch (\Exception $exception) {
+			return new DataResponse(
+				[
+					'success' => false,
+					'message' => $exception->getMessage()
+				],
+				Http::STATUS_UNAUTHORIZED
+			);
+		}
+	}
 }

--- a/lib/Handler/CfsslHandler.php
+++ b/lib/Handler/CfsslHandler.php
@@ -234,6 +234,7 @@ class CfsslHandler {
 			if (!file_exists($binary)) {
 				throw new LibresignException('Binary of CFSSL not found. Install binaries.');
 			}
+			$this->binary = $binary;
 		}
 		return $this;
 	}

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -423,6 +423,7 @@ class InstallService {
 		if ($cfsslUri) {
 			$this->cfsslHandler->setCfsslUri($cfsslUri);
 		} else {
+			$this->cfsslHandler->setCfsslUri(CfsslHandler::CFSSL_URI);
 			if (!$binary) {
 				$binary = $this->config->getAppValue(Application::APP_ID, 'cfssl_bin');
 				if ($binary && !file_exists($binary)) {

--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -44,7 +44,7 @@ class PdfParserService {
 		$fullPath = $this->getDataDir() . $filePath;
 		$fullPath = realpath($fullPath);
 		if ($fullPath === false) {
-			throw new LibresignException('Impossible get metadata from this file. Check if you installed correctly the libresign-cli.');
+			throw new LibresignException('File not found on specified place.');
 		}
 		$cliPath = $this->getLibesignCli();
 		$json = shell_exec($cliPath . ' info ' . escapeshellarg($fullPath));

--- a/src/Components/File/File.vue
+++ b/src/Components/File/File.vue
@@ -2,8 +2,8 @@
 	<div class="content-file" @click="openSidebar">
 		<img :src="srcImg">
 		<div class="enDot">
-			<div :class="status!== 'none' ? 'dot ' + status : '' " />
-			<span>{{ status !== 'none' ? statusToUppercase(status) : '' }}</span>
+			<div :class="status_text!== 'none' ? 'dot ' + statusToClass(status) : '' " />
+			<span>{{ status_text !== 'none' ? statusToUppercase(status_text) : '' }}</span>
 		</div>
 		<h1>{{ file.name }}</h1>
 	</div>
@@ -20,10 +20,15 @@ export default {
 			required: true,
 		},
 		status: {
+			type: [Number, String],
+			required: true,
+			default: 0,
+		},
+		status_text: {
 			type: String,
 			required: true,
-			default: 'done',
-			validator: () => ['signed', 'canceled', 'pending', 'none'],
+			default: 'none',
+			validator: () => ['signed', 'no signers', 'pending', 'none'],
 		},
 	},
 	data() {
@@ -35,9 +40,21 @@ export default {
 		openSidebar() {
 			this.$emit('sidebar', this.file)
 		},
-		statusToUppercase(status) {
-			return status[0].toUpperCase() + status.substr(1)
+		statusToUppercase(status_text) {
+			return status_text[0].toUpperCase() + status_text.substr(1)
 		},
+		statusToClass(status) {
+			switch (Number(status)) {
+				case 0:
+					return 'no-signers'
+				case 1:
+					return 'signed'
+				case 2:
+					return 'pending'
+				default:
+					return ''
+			}
+		}
 	},
 }
 </script>
@@ -83,7 +100,7 @@ export default {
 			background: #008000;
 		}
 
-		.canceled{
+		.no-signers{
 			background: #ff0000;
 		}
 

--- a/src/views/Request.vue
+++ b/src/views/Request.vue
@@ -8,7 +8,8 @@
 			<div class="content-request">
 				<File v-show="!isEmptyFile"
 					:file="file"
-					status="none"
+					status=0
+					status_text="none"
 					@sidebar="setSidebarStatus(true)" />
 				<button class="icon icon-folder" @click="getFile">
 					{{ t('libresign', 'Choose from Files') }}

--- a/src/views/Settings/AdminFormLibresign.vue
+++ b/src/views/Settings/AdminFormLibresign.vue
@@ -25,7 +25,7 @@
 	<SettingsSection :title="title" :description="description">
 		<div id="formLibresign" class="form-libresign">
 			<div class="form-group">
-				<label for="commonName">{{ t('libresign', 'Name (CN)') }}</label>
+				<label for="commonName" class="form-heading--required">{{ t('libresign', 'Name (CN)') }}</label>
 				<input id="commonName"
 					ref="commonName"
 					v-model="certificate.commonName"
@@ -33,7 +33,7 @@
 					:disabled="formDisabled">
 			</div>
 			<div class="form-group">
-				<label for="country">{{ t('libresign', 'Country (C)') }}</label>
+				<label for="country" class="form-heading--required">{{ t('libresign', 'Country (C)') }}</label>
 				<input id="country"
 					ref="country"
 					v-model="certificate.country"
@@ -41,7 +41,7 @@
 					:disabled="formDisabled">
 			</div>
 			<div class="form-group">
-				<label for="organization">{{ t('libresign', 'Organization (O)') }}</label>
+				<label for="organization" class="form-heading--required">{{ t('libresign', 'Organization (O)') }}</label>
 				<input id="organization"
 					ref="organization"
 					v-model="certificate.organization"
@@ -49,7 +49,7 @@
 					:disabled="formDisabled">
 			</div>
 			<div class="form-group">
-				<label for="organizationUnit">{{ t('libresign', 'Organization Unit (OU)') }}</label>
+				<label for="organizationUnit" class="form-heading--required">{{ t('libresign', 'Organization Unit (OU)') }}</label>
 				<input id="organizationUnit"
 					ref="organizationUnit"
 					v-model="certificate.organizationUnit"
@@ -101,8 +101,6 @@ export default {
 				country: '',
 				organization: '',
 				organizationUnit: '',
-				cfsslUri: '',
-				configPath: '',
 			},
 			title: t('libresign', 'Root certificate data.'),
 			description: t('libresign', 'To generate new signatures, you must first generate the root certificate.'),
@@ -119,8 +117,6 @@ export default {
                 && this.certificate.country !== ''
                 && this.certificate.organization !== ''
                 && this.certificate.organizationUnit !== ''
-                && this.certificate.cfsslUri !== ''
-                && this.certificate.configPath !== ''
 			)
 		},
 	},
@@ -172,8 +168,6 @@ export default {
 				&& response.data.country
 				&& response.data.organization
 				&& response.data.organizationUnit
-				&& response.data.cfsslUri
-				&& response.data.configPath
 				) {
 					this.certificate = response.data
 					this.submitLabel = t('libresign', 'Generated certificate!')
@@ -197,6 +191,10 @@ export default {
 
 .form-group > input[type='text'] {
 	width: 100%;
+}
+
+.form-heading--required:after {
+	content:" *";
 }
 
 </style>

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -64,7 +64,9 @@ export default {
 			const response = await axios.get(
 				generateOcsUrl('/apps/provisioning_api/api/v1', 2) + '/config/apps' + '/' + 'libresign' + '/' + 'webhook_authorized', {}
 			)
-			this.groupsSelected = JSON.parse(response.data.ocs.data.data)
+			if (response.data.ocs.data.data !== '') {
+				this.groupsSelected = JSON.parse(response.data.ocs.data.data)
+			}
 		},
 
 		saveGroups() {

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -23,7 +23,7 @@
 
 <template>
 	<SettingsSection :title="title" :description="description">
-		<MulutiSelect :key="idKey"
+		<Multiselect :key="idKey"
 			v-model="groupsSelected"
 			:options="groups"
 			:close-on-select="false"
@@ -35,7 +35,7 @@
 <script>
 import { translate as t } from '@nextcloud/l10n'
 import SettingsSection from '@nextcloud/vue/dist/Components/SettingsSection'
-import MulutiSelect from '@nextcloud/vue/dist/Components/Multiselect'
+import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
@@ -43,7 +43,7 @@ export default {
 	name: 'AllowedGroups',
 	components: {
 		SettingsSection,
-		MulutiSelect,
+		Multiselect,
 	},
 
 	data: () => ({

--- a/src/views/Settings/DownloadBinaries.vue
+++ b/src/views/Settings/DownloadBinaries.vue
@@ -24,7 +24,7 @@ export default {
 	},
 	data: () => ({
 		title: t('libresign', 'Download binaries'),
-		description: t('libresign', 'Binaries required to work.'),
+		description: t('libresign', 'Binaries required to work. Could be near by 340Mb to download, wait a moment.'),
 		submitLabel: t('libresign', 'Download binaries'),
 	}),
 	created() {

--- a/src/views/Settings/DownloadBinaries.vue
+++ b/src/views/Settings/DownloadBinaries.vue
@@ -1,0 +1,76 @@
+<template>
+	<SettingsSection :title="title" :description="description">
+		<div class="settings-section">
+		<input type="button"
+			class="primary"
+			:value="submitLabel"
+			:disabled="formDisabled"
+			@click="downloadBinaries">
+		</div>
+	</SettingsSection>
+</template>
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import SettingsSection from '@nextcloud/vue/dist/Components/SettingsSection'
+import '@nextcloud/dialogs/styles/toast.scss'
+import { generateUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+
+export default {
+	name: 'DownloadBinaries',
+	components: {
+		SettingsSection,
+	},
+	data: () => ({
+		title: t('libresign', 'Download binaries'),
+		description: t('libresign', 'Binaries required to work.'),
+		submitLabel: t('libresign', 'Download binaries'),
+	}),
+	created() {
+		this.formDisabled = true
+		this.isBinariesInstalled();
+	},
+	methods: {
+		async isBinariesInstalled() {
+			const java = await axios.get(generateOcsUrl('/apps/provisioning_api/api/v1', 2) + '/config/apps/libresign/java_path', {})
+			const jsignpdf = await axios.get(generateOcsUrl('/apps/provisioning_api/api/v1', 2) + '/config/apps/libresign/jsignpdf_jar_path', {})
+			const libresign_cli = await axios.get(generateOcsUrl('/apps/provisioning_api/api/v1', 2) + '/config/apps/libresign/libresign_cli_path', {})
+			if (java.data.ocs.data.data !== ''
+				&& jsignpdf.data.ocs.data.data !== ''
+				&& libresign_cli.data.ocs.data.data !== ''
+			) {
+				this.submitLabel = t('libresign', 'Binaries downloaded')
+				return
+			}
+			this.formDisabled = false
+		},
+		async downloadBinaries() {
+			this.formDisabled = true
+			this.submitLabel = t('libresign', 'Downloading binaries')
+			try {
+				const response = await axios.get(
+					generateUrl('/apps/libresign/api/0.1/admin/download-binaries')
+				)
+
+				if (!response.data || response.data.message) {
+					throw new Error(response.data)
+				}
+				this.submitLabel = t('libresign', 'Binaries downloaded')
+
+				return
+			} catch (e) {
+				console.error(e)
+				if (e.response.data.message) {
+					showError(t('libresign', 'Could not download binaries.') + '\n' + e.response.data.message)
+				} else {
+					showError(t('libresign', 'Could not download binaries.'))
+				}
+				this.submitLabel = t('libresign', 'Download binaries')
+
+			}
+			this.formDisabled = false
+		},
+	},
+}
+</script>

--- a/src/views/Settings/DownloadBinaries.vue
+++ b/src/views/Settings/DownloadBinaries.vue
@@ -26,9 +26,9 @@ export default {
 		title: t('libresign', 'Download binaries'),
 		description: t('libresign', 'Binaries required to work. Could be near by 340Mb to download, wait a moment.'),
 		submitLabel: t('libresign', 'Download binaries'),
+		formDisabled: true,
 	}),
 	created() {
-		this.formDisabled = true
 		this.isBinariesInstalled();
 	},
 	methods: {

--- a/src/views/Settings/Settings.vue
+++ b/src/views/Settings/Settings.vue
@@ -23,6 +23,7 @@
 
 <template>
 	<SettingsSection :title="title">
+		<DownloadBinaries />
 		<AdminFormLibresign />
 		<UrlValidation />
 		<AllowedGroups />
@@ -40,6 +41,7 @@
 
 <script>
 import AdminFormLibresign from './AdminFormLibresign.vue'
+import DownloadBinaries from './DownloadBinaries.vue'
 import AllowedGroups from './AllowedGroups.vue'
 import UrlValidation from './UrlValidation.vue'
 import Textarea from '../../Components/Textarea/Textarea.vue'
@@ -51,6 +53,7 @@ export default {
 	name: 'Settings',
 	components: {
 		AdminFormLibresign,
+		DownloadBinaries,
 		SettingsSection,
 		UrlValidation,
 		AllowedGroups,

--- a/src/views/Timeline/Timeline.spec.js
+++ b/src/views/Timeline/Timeline.spec.js
@@ -79,7 +79,8 @@ describe('Timeline', () => {
 						me: false,
 					},
 				],
-				status: 'pending',
+				status: 2,
+				status_text: 'pending',
 			},
 		]
 
@@ -125,7 +126,8 @@ describe('Timeline', () => {
 					me: false,
 				},
 			],
-			status: 'pending',
+			status: 2,
+			status_text: 'pending',
 		}
 
 		wrapper.vm.$emit('sidebar', file)

--- a/src/views/Timeline/Timeline.vue
+++ b/src/views/Timeline/Timeline.vue
@@ -17,6 +17,7 @@
 					:key="file.uuid"
 					class="file-details"
 					:status="file.status"
+					:status_text="file.status_text"
 					:file="file"
 					@sidebar="setSidebar" />
 			</ul>

--- a/tests/Api/Controller/AdminControllerTest.php
+++ b/tests/Api/Controller/AdminControllerTest.php
@@ -93,7 +93,7 @@ final class AdminControllerTest extends ApiTestCase {
 				'country' => 'Brazil',
 				'organization' => 'Organization',
 				'organizationUnit' => 'organizationUnit',
-				'cfsslUri' => '',
+				'cfsslUri' => 'invalidUri',
 				'configPath' => ''
 			])
 			->assertResponseCode(401);


### PR DESCRIPTION
## Feature
Download binaries from admin settings
Mark required fields

## Definition
* cfsslUri & configPath isn't more required when using standalone files. Only is necessary to run a custom setup.
* Added button to download binaries
  * Verify when load if all binaries were downloaded to identify if is necessary to enable download button