### PR TITLE
Fix newcert request when names array is empty

### DIFF
--- a/lib/Handler/CfsslHandler.php
+++ b/lib/Handler/CfsslHandler.php
@@ -128,12 +128,16 @@ class CfsslHandler {
 						'algo' => 'rsa',
 						'size' => 2048,
 					],
-					'names' => [
-						$this->getNames(),
-					],
+					'names' => [],
 				],
 			],
 		];
+
+		$names = $this->getNames();
+		if (!empty($names)) {
+			$json['json']['request']['names'][] = $names;
+		}
+
 		try {
 			$response = $this->getClient()
 				->request('post',


### PR DESCRIPTION
Previously, an empty item was sent inside the names array when no names other than CN were set. This was making CFSSL API fail with an 400 BAD REQUEST response.

To reproduce the issue and verify the fix:

- Make sure you are in the main branch
- Regenerate the root certificate, setting the CN field only.
- Try to update your LibreSign password, it should fail.
- Switch to this branch and try to update the password again, it should succeed.