### PR TITLE
Change the default java version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,6 +25,8 @@
     <screenshot>https://raw.githubusercontent.com/LibreSign/libresign/main/img/LibreSign.png</screenshot>
     <dependencies>
         <nextcloud min-version="26" max-version="26"/>
+        <architecture>x86_64</architecture>
+        <architecture>aarch64</architecture>
     </dependencies>
     <commands>
         <command>OCA\Libresign\Command\Configure\Check</command>

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -199,7 +199,6 @@ class InstallService {
 				$compressedFileName = 'OpenJDK17U-jre_aarch64_linux_hotspot_' . $version . '.tar.gz';
 				$url = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/' . $compressedFileName;
 			}
-			$executableExtension = '';
 			$class = TAR::class;
 		} else {
 			throw new RuntimeException(sprintf('OS_FAMILY %s is incompatible with LibreSign.', PHP_OS_FAMILY));
@@ -220,7 +219,7 @@ class InstallService {
 		$extractor = new $class($comporessedInternalFileName);
 		$extractor->extract($extractDir);
 
-		$this->config->setAppValue(Application::APP_ID, 'java_path', $extractDir . '/jdk-17.0.5+8-jre/bin/java' . $executableExtension);
+		$this->config->setAppValue(Application::APP_ID, 'java_path', $extractDir . '/jdk-17.0.5+8-jre/bin/java');
 		$this->removeDownloadProgress();
 	}
 

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -202,10 +202,7 @@ class InstallService {
 			$executableExtension = '';
 			$class = TAR::class;
 		} else {
-			throw new RuntimeException(sprintf(
-				'OS_FAMILY %s is incompatible with homologated.',
-				[PHP_OS_FAMILY]
-			));
+			throw new RuntimeException(sprintf('OS_FAMILY %s is incompatible with homologated.', PHP_OS_FAMILY));
 		}
 		$folder = $this->getFolder();
 		$checksumUrl = $url . '.sha256.txt';

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -189,19 +189,27 @@ class InstallService {
 		 * URL used to get the MD5 and URL to download:
 		 * https://jdk.java.net/java-se-ri/8-MR3
 		 */
-		if (PHP_OS_FAMILY === 'Windows') {
-			$compressedFileName = 'openjdk-8u41-b04-windows-i586-14_jan_2020.zip';
-			$url = 'https://download.java.net/openjdk/jdk8u41/ri/' . $compressedFileName;
-			$executableExtension = '.exe';
-			$class = ZIP::class;
-			$hash = '48ac2152d1fb0ad1d343104be210d532';
-		} else {
-			$compressedFileName = 'openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz';
-			$url = 'https://download.java.net/openjdk/jdk8u41/ri/' . $compressedFileName;
+		if (PHP_OS_FAMILY === 'Linux') {
+			$architecture = php_uname('m');
+			$version = '17.0.5_8';
+			if ($architecture === 'x86_64') {
+				$compressedFileName = 'OpenJDK17U-jre_x64_linux_hotspot_' . $version . '.tar.gz';
+				$url = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/' . $compressedFileName;
+			} elseif ($architecture === 'aarch64') {
+				$compressedFileName = 'OpenJDK17U-jre_aarch64_linux_hotspot_' . $version . '.tar.gz';
+				$url = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/' . $compressedFileName;
+			}
 			$executableExtension = '';
 			$class = TAR::class;
-			$hash = '35f515e9436f4fefad091db2c1450c5f';
+		} else {
+			throw new RuntimeException(sprintf(
+				'OS_FAMILY %s is incompatible with homologated.',
+				[PHP_OS_FAMILY]
+			));
 		}
+		$folder = $this->getFolder();
+		$checksumUrl = $url . '.sha256.txt';
+		$hash = $this->getHash($folder, 'java', $compressedFileName, $version, $checksumUrl);
 		if (!$javaFolder->nodeExists($compressedFileName)) {
 			$compressedFile = $javaFolder->newFile($compressedFileName);
 		} else {
@@ -209,13 +217,13 @@ class InstallService {
 		}
 		$comporessedInternalFileName = $this->getDataDir() . DIRECTORY_SEPARATOR . $compressedFile->getInternalPath();
 
-		$this->download($url, 'java', $comporessedInternalFileName, $hash);
+		$this->download($url, 'java', $comporessedInternalFileName, $hash, 'sha256');
 
 		$this->config->deleteAppValue(Application::APP_ID, 'java_path');
 		$extractor = new $class($comporessedInternalFileName);
 		$extractor->extract($extractDir);
 
-		$this->config->setAppValue(Application::APP_ID, 'java_path', $extractDir . '/java-se-8u41-ri/bin/java' . $executableExtension);
+		$this->config->setAppValue(Application::APP_ID, 'java_path', $extractDir . '/jdk-17.0.5+8-jre/bin/java' . $executableExtension);
 		$this->removeDownloadProgress();
 	}
 
@@ -266,7 +274,7 @@ class InstallService {
 		$zip = new ZIP($extractDir . DIRECTORY_SEPARATOR . $compressedFileName);
 		$zip->extract($extractDir);
 
-		$fullPath = $extractDir . DIRECTORY_SEPARATOR. 'jsignpdf-' . JSignPdfHandler::VERSION . DIRECTORY_SEPARATOR. 'JSignPdf.jar';
+		$fullPath = $extractDir . DIRECTORY_SEPARATOR . 'jsignpdf-' . JSignPdfHandler::VERSION . DIRECTORY_SEPARATOR . 'JSignPdf.jar';
 		$this->config->setAppValue(Application::APP_ID, 'jsignpdf_jar_path', $fullPath);
 		$this->removeDownloadProgress();
 	}
@@ -551,7 +559,7 @@ class InstallService {
 			$this->cfsslHandler->setBinary($binary);
 			$this->cfsslHandler->genkey();
 		}
-		for ($i = 1;$i <= 4;$i++) {
+		for ($i = 1; $i <= 4; $i++) {
 			if ($this->cfsslHandler->health($cfsslUri)) {
 				break;
 			}

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -202,7 +202,7 @@ class InstallService {
 			$executableExtension = '';
 			$class = TAR::class;
 		} else {
-			throw new RuntimeException(sprintf('OS_FAMILY %s is incompatible with homologated.', PHP_OS_FAMILY));
+			throw new RuntimeException(sprintf('OS_FAMILY %s is incompatible with LibreSign.', PHP_OS_FAMILY));
 		}
 		$folder = $this->getFolder();
 		$checksumUrl = $url . '.sha256.txt';


### PR DESCRIPTION
The page of project JSignPdf have a link to project Adoptium, because this I changed to this package and fixed the archtecture to intersection of architectures of Nextcloud Server allowed in info.xml architecture tag and architectures of Adoptium

https://jsignpdf.sourceforge.net/

Ref: https://github.com/LibreSign/libresign/issues/1170