### PR TITLE
Update Application.php

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		include_once __DIR__ . '/../../vendor/autoload.php';
 		$context->registerEventListener(LoadSidebar::class, LoadSidebarListener::class);
 		$context->registerEventListener(BeforeNodeDeletedEvent::class, BeforeNodeDeletedListener::class);
 		$context->registerEventListener(SignedEvent::class, SignedListener::class);


### PR DESCRIPTION
Foi necessario inserir a linha: include_once __DIR__ . '/../../vendor/autoload.php';  para corrigir erro no update para a versão: 6.2.5.

[root@fileserver config]# occ libresign:configure:check An unhandled exception has been thrown:
Error: Class "Jeidison\JSignPDF\JSignPDF" not found in /usr/share/nextcloud/apps/libresign/lib/Handler/JSignPdfHandler.php:33 Stack trace:
#0 /usr/share/nextcloud/apps/libresign/lib/Service/ConfigureCheckService.php(116): OCA\Libresign\Handler\JSignPdfHandler->getJSignPdf()
#1 /usr/share/nextcloud/apps/libresign/lib/Service/ConfigureCheckService.php(48): OCA\Libresign\Service\ConfigureCheckService->checkJSignPdf()
#2 /usr/share/nextcloud/apps/libresign/lib/Service/ConfigureCheckService.php(34): OCA\Libresign\Service\ConfigureCheckService->checkSign()
#3 /usr/share/nextcloud/apps/libresign/lib/Command/Configure/Check.php(54): OCA\Libresign\Service\ConfigureCheckService->checkAll()
#4 /usr/share/nextcloud/3rdparty/symfony/console/Command/Command.php(255): OCA\Libresign\Command\Configure\Check->execute()
#5 /usr/share/nextcloud/core/Command/Base.php(177): Symfony\Component\Console\Command\Command->run()
#6 /usr/share/nextcloud/3rdparty/symfony/console/Application.php(1009): OC\Core\Command\Base->run()
#7 /usr/share/nextcloud/3rdparty/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#8 /usr/share/nextcloud/3rdparty/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun()
#9 /usr/share/nextcloud/lib/private/Console/Application.php(213): Symfony\Component\Console\Application->run()
#10 /usr/share/nextcloud/console.php(100): OC\Console\Application->run()
#11 /usr/share/nextcloud/occ(11): require_once('...')