### PR TITLE
Fix Node engine version constraint in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "engines": {
-    "node": ">=16.0.0",
+    "node": "^16.0.0",
     "npm": "^7.0.0 || ^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The previous constraint was allowing CI to run with a higher Node version (18). The fix is inspired by official Nextcloud apps. See https://github.com/nextcloud/deck/blob/33912454ae2b17dc3107e2e7b6145b42682fd078/package.json#L72