### PR TITLE
[stable25] Fix Node engine version constraint in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "engines": {
-    "node": ">=16.0.0",
+    "node": "^16.0.0",
     "npm": "^8"
   },
   "devDependencies": {


### PR DESCRIPTION
Backport of #1439 