### PR TITLE
Fix makefile appstore target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,10 @@ test: composer
 appstore: clean
 	mkdir -p $(appstore_sign_dir)/$(app_name)
 	composer install --no-dev
-	npm install
+	npm ci
 	npm run build
 	cp -r \
 		appinfo \
-		cfssl \
 		img \
 		js \
 		l10n \


### PR DESCRIPTION
Remove cfssl directory from the published package, it was deleted back in #1132.

Additionally, use `npm ci` instead of `npm install`.