### PR TITLE
Make possible to approvers can sign identification documents

### DIFF
--- a/lib/Controller/SignFileController.php
+++ b/lib/Controller/SignFileController.php
@@ -184,6 +184,7 @@ class SignFileController extends ApiController {
 		try {
 			$user = $this->userSession->getUser();
 			$this->validateHelper->canSignWithIdentificationDocumentStatus(
+				$user,
 				$this->fileService->getIdentificationDocumentsStatus($user->getUID())
 			);
 			$libreSignFile = $this->signFileService->getLibresignFile($fileId, $fileUserUuid);

--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -534,8 +534,8 @@ class ValidateHelper {
 
 	public function canSignWithIdentificationDocumentStatus(IUser $user, int $status): void {
 		// User that can approve validation documents don't need to have a valid
-		// document attached to our profile because if this is mandatory, nobody
-		// will can sign any document
+		// document attached to their profile. If this were required, nobody
+		// would be able to sign any document
 		if ($this->userCanApproveValidationDocuments($user, false)) {
 			return;
 		}

--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -532,7 +532,13 @@ class ValidateHelper {
 		return $signMethod !== 'password';
 	}
 
-	public function canSignWithIdentificationDocumentStatus(int $status): void {
+	public function canSignWithIdentificationDocumentStatus(IUser $user, int $status): void {
+		// User that can approve validation documents don't need to have a valid
+		// document attached to our profile because if this is mandatory, nobody
+		// will can sign any document
+		if ($this->userCanApproveValidationDocuments($user, false)) {
+			return;
+		}
 		$allowedStatus = [
 			FileService::IDENTIFICATION_DOCUMENTS_DISABLED,
 			FileService::IDENTIFICATION_DOCUMENTS_APPROVED,


### PR DESCRIPTION
If the flow of identification documents is enabled, the approvers need to have permission to sign an identification document if he haven't an identification document signed on our profile.

How to reproduce:
* Login with user A as admin
* Go to LibeSign admin settings
* Enable the __Identification documents__ flow
* Login with user B as common user
* As user B, go to LibreSign > settings > account and add an identification document
* As user A, go to LibreSign > Documents Validation and click to validate (sign) the identification document
* Then, the user A need to sign the identification document