### PR TITLE
Log CLI exceptions

### DIFF
--- a/lib/Command/Base.php
+++ b/lib/Command/Base.php
@@ -6,16 +6,22 @@ namespace OCA\Libresign\Command;
 
 use OC\Core\Command\Base as CommandBase;
 use OCA\Libresign\Service\InstallService;
+use Psr\Log\LoggerInterface;
 
 class Base extends CommandBase {
 	/** @var InstallService */
 	public $installService;
 
+	/** @var LoggerInterface */
+	protected $logger;
+
 	public function __construct(
-		InstallService $installService
+		InstallService $installService,
+		LoggerInterface $logger
 	) {
 		parent::__construct();
 		$this->installService = $installService;
+		$this->logger = $logger;
 	}
 
 	protected function installJava(): void {

--- a/lib/Command/Configure/Cfssl.php
+++ b/lib/Command/Configure/Cfssl.php
@@ -8,16 +8,19 @@ use InvalidArgumentException;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Command\Base;
 use OCA\Libresign\Service\InstallService;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Cfssl extends Base {
 	public function __construct(
-		InstallService $installService
+		InstallService $installService,
+		LoggerInterface $logger
 	) {
 		parent::__construct(
-			$installService
+			$installService,
+			$logger
 		);
 	}
 

--- a/tests/Unit/Service/InstallServiceTest.php
+++ b/tests/Unit/Service/InstallServiceTest.php
@@ -31,6 +31,7 @@ use OCP\Http\Client\IClientService;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use org\bovigo\vfs\vfsStream;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class InstallServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
@@ -46,6 +47,7 @@ final class InstallServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private $config;
 	/** @var IRootFolder|MockObject */
 	private $rootFolder;
+	/** @var LoggerInterface */
 
 	public function setUp(): void {
 		parent::setUp();
@@ -58,13 +60,15 @@ final class InstallServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->cfsslHandler = $this->createMock(CfsslHandler::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		return new InstallService(
 			$this->cacheFactory,
 			$this->clientService,
 			$this->cfsslServerHandler,
 			$this->cfsslHandler,
 			$this->config,
-			$this->rootFolder
+			$this->rootFolder,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
Unlike the web application, Nextcloud Symfony console application does not log exceptions to the `nextcloud.log`. This is a change to help debugging some install errors from asynchronous CLI calls while we don't implement install logs in the admin page.