### PR TITLE
Hide generate passowrd when cert handler isn't ok

### DIFF
--- a/lib/Handler/Pkcs12Handler.php
+++ b/lib/Handler/Pkcs12Handler.php
@@ -306,6 +306,15 @@ class Pkcs12Handler extends SignEngineHandler {
 		return $this->cfsslHandler;
 	}
 
+	public function isHandlerOk(): bool {
+		try {
+			$this->getCertificateHandler()->getClient();
+			return true;
+		} catch (\Throwable $th) {
+		}
+		return false;
+	}
+
 	/**
 	 * Generate certificate
 	 *

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -274,7 +274,7 @@ class AccountService {
 			$info = json_decode($e->getMessage(), true);
 		}
 		$info['settings']['identificationDocumentsFlow'] = $this->config->getAppValue(Application::APP_ID, 'identification_documents') ? true : false;
-		$info['settings']['certificateOk'] = $this->signatureService->hasRootCert();
+		$info['settings']['certificateOk'] = $this->signatureService->hasRootCert() && $this->pkcs12Handler->isHandlerOk();
 		$info['settings']['hasSignatureFile'] = $this->hasSignatureFile($user);
 		$info['settings']['phoneNumber'] = $this->getPhoneNumber($user);
 		$info['settings']['signMethod'] = $this->config->getAppValue(Application::APP_ID, 'sign_method', 'password');


### PR DESCRIPTION
If have any problem at cert handler, don't make sense to display the button to generate password