### PR TITLE
Make the text more clear

### DIFF
--- a/lib/Service/ConfigureCheckService.php
+++ b/lib/Service/ConfigureCheckService.php
@@ -323,7 +323,7 @@ class ConfigureCheckService {
 				->setResource('cfssl-configure')];
 		}
 		return [(new ConfigureCheckHelper())
-			->setErrorMessage('CFSSL not configured.')
+			->setErrorMessage('CFSSL (root certificate) not configured.')
 			->setResource('cfssl-configure')
 			->setTip('Run occ libresign:configure:cfssl --help')];
 	}


### PR DESCRIPTION
The message about cfssl is related to root certificate and I put the reference in the text to be more easy to identify because we have the cfssl integration