### PR TITLE
Lock friendsofphp/php-cs-fixer version

### DIFF
--- a/lib/Service/TFile.php
+++ b/lib/Service/TFile.php
@@ -2,7 +2,6 @@
 
 namespace OCA\Libresign\Service;
 
-use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Http\Client\IClientService;

--- a/vendor-bin/coding-standard/composer.json
+++ b/vendor-bin/coding-standard/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
-        "nextcloud/coding-standard": "^1.0"
+        "nextcloud/coding-standard": "^1.0",
+        "friendsofphp/php-cs-fixer": "3.15.1"
     }
 }

--- a/vendor-bin/coding-standard/composer.lock
+++ b/vendor-bin/coding-standard/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a5693b526d9f7daff44677575380c21",
+    "content-hash": "4185a00142b8966b4b8bb4416d72c304",
     "packages": [],
     "packages-dev": [
         {
@@ -424,16 +424,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.16.0",
+            "version": "v3.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc"
+                "reference": "d48755372a113bddb99f749e34805d83f3acfe04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
-                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d48755372a113bddb99f749e34805d83f3acfe04",
+                "reference": "d48755372a113bddb99f749e34805d83f3acfe04",
                 "shasum": ""
             },
             "require": {
@@ -508,7 +508,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.16.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.15.1"
             },
             "funding": [
                 {
@@ -516,7 +516,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-02T19:30:06+00:00"
+            "time": "2023-03-13T23:26:30+00:00"
         },
         {
             "name": "nextcloud/coding-standard",


### PR DESCRIPTION
The newest version of this package broked the CI because implemented a new pattern.