### PR TITLE
fix: layut signature validation in dark mode

### DIFF
--- a/src/assets/styles/validation.scss
+++ b/src/assets/styles/validation.scss
@@ -5,7 +5,6 @@ $title-font-mobile: 1.3rem;
 $date-signed-font: .7rem;
 
 .jumbotron{
-	background-color: $background;
 	padding: 0;
 }
 
@@ -49,7 +48,7 @@ $date-signed-font: .7rem;
 }
 
 form{
-	background-color: #FFF;
+	background-color: $background;
 	color: $text-color;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
close #1459 

fix validation page in dark mode:

![image](https://user-images.githubusercontent.com/7907068/235253690-02ed943d-2521-4d09-a63f-32a85c0eac56.png)
