### PR TITLE
Add more tests when save identify method

### DIFF
--- a/lib/Service/IdentifyMethod/Account.php
+++ b/lib/Service/IdentifyMethod/Account.php
@@ -58,7 +58,10 @@ class Account extends AbstractIdentifyMethod {
 		private IRootFolder $rootFolder,
 		private MailService $mail
 	) {
-		parent::__construct($identifyMethodMapper);
+		parent::__construct(
+			$identifyMethodMapper,
+			$config
+		);
 		$this->canCreateAccount = (bool) $this->config->getAppValue(Application::APP_ID, 'can_create_accountApplication', true);
 	}
 
@@ -218,12 +221,15 @@ class Account extends AbstractIdentifyMethod {
 	}
 
 	public function getSettings(): array {
-		$settings = parent::getSettings();
-		$settings['signature_method'] = 'password';
-		$settings['can_create_account'] = $this->canCreateAccount;
-		$settings['allowed_signature_methods'] = [
-			'password',
-		];
+		$settings = $this->getSettingsFromDatabase(
+			default: [
+				'signature_method' => 'password',
+				'can_create_account' => $this->canCreateAccount,
+				'allowed_signature_methods' => [
+					'password',
+				],
+			]
+		);
 		return $settings;
 	}
 }

--- a/lib/Service/IdentifyMethod/Email.php
+++ b/lib/Service/IdentifyMethod/Email.php
@@ -29,12 +29,14 @@ use OCA\Libresign\Db\FileUserMapper;
 use OCA\Libresign\Db\IdentifyMethodMapper;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\MailService;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 
 class Email extends AbstractIdentifyMethod {
 	public function __construct(
+		private IConfig $config,
 		private IL10N $l10n,
 		private MailService $mail,
 		private FileUserMapper $fileUserMapper,
@@ -42,7 +44,10 @@ class Email extends AbstractIdentifyMethod {
 		private IUserManager $userManager,
 		private IURLGenerator $urlGenerator
 	) {
-		parent::__construct($identifyMethodMapper);
+		parent::__construct(
+			$identifyMethodMapper,
+			$config
+		);
 	}
 
 	public function notify(bool $isNew): void {
@@ -71,8 +76,11 @@ class Email extends AbstractIdentifyMethod {
 	}
 
 	public function getSettings(): array {
-		$settings = parent::getSettings();
-		$settings['test_url'] = $this->urlGenerator->linkToRoute('settings.MailSettings.sendTestMail');
+		$settings = parent::getSettingsFromDatabase(
+			immutable: [
+				'test_url' => $this->urlGenerator->linkToRoute('settings.MailSettings.sendTestMail'),
+			]
+		);
 		return $settings;
 	}
 }

--- a/lib/Service/IdentifyMethodService.php
+++ b/lib/Service/IdentifyMethodService.php
@@ -182,27 +182,10 @@ class IdentifyMethodService {
 		if ($this->identifyMethodsSettings) {
 			return $this->identifyMethodsSettings;
 		}
-		$config = $this->config->getAppValue(Application::APP_ID, 'identify_methods', '[]');
-		$config = json_decode($config, true);
 		$this->identifyMethodsSettings = [
-			array_merge(
-				$this->account->getSettings(),
-				$this->getMethodFromConfig('account', $config)
-			),
-			array_merge(
-				$this->email->getSettings(),
-				$this->getMethodFromConfig('email', $config)
-			),
+			$this->account->getSettings(),
+			$this->email->getSettings(),
 		];
 		return $this->identifyMethodsSettings;
-	}
-
-	private function getMethodFromConfig(string $name, array $config): array {
-		foreach ($config as $current) {
-			if ($current['name'] === $name) {
-				return $current;
-			}
-		}
-		return [];
 	}
 }

--- a/tests/integration/features/admin/initial_state.feature
+++ b/tests/integration/features/admin/initial_state.feature
@@ -11,6 +11,62 @@ Feature: admin/initial_state
       ]
       """
 
+  Scenario: Update identify methods with string
+    Given as user "admin"
+    And sending "delete" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+    When sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | "invalid" |
+    Then sending "get" to "/settings/admin/libresign"
+    And the response should contain the initial state "libresign-identify_methods" with the following values:
+      """
+      [
+        {"name":"account","enabled":true,"mandatory":true,"can_create_account":true,"signature_method":"password","allowed_signature_methods":["password"],"can_be_used":true},
+        {"name":"email","enabled":true,"mandatory":true,"can_be_used":true,"test_url":"/index.php/settings/admin/mailtest"}
+      ]
+      """
+
+  Scenario: Update identify methods with invalid keys
+    Given as user "admin"
+    And sending "delete" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+    When sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | (string)[{"name":"account","fake":null}] |
+    Then sending "get" to "/settings/admin/libresign"
+    And the response should contain the initial state "libresign-identify_methods" with the following values:
+      """
+      [
+        {"name":"account","enabled":true,"mandatory":true,"can_create_account":true,"signature_method":"password","allowed_signature_methods":["password"],"can_be_used":true},
+        {"name":"email","enabled":true,"mandatory":true,"can_be_used":true,"test_url":"/index.php/settings/admin/mailtest"}
+      ]
+      """
+
+  Scenario: Update identify methods with inalid type as value
+    Given as user "admin"
+    And sending "delete" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+    When sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | (string)[{"name":"account","enabled":"string"}] |
+    Then sending "get" to "/settings/admin/libresign"
+    And the response should contain the initial state "libresign-identify_methods" with the following values:
+      """
+      [
+        {"name":"account","enabled":true,"mandatory":true,"can_create_account":true,"signature_method":"password","allowed_signature_methods":["password"],"can_be_used":true},
+        {"name":"email","enabled":true,"mandatory":true,"can_be_used":true,"test_url":"/index.php/settings/admin/mailtest"}
+      ]
+      """
+
+  Scenario: Update identify methods with property that can't be changed
+    Given as user "admin"
+    And sending "delete" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+    When sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | (string)[{"name":"email","test_url":"immutable"}] |
+    Then sending "get" to "/settings/admin/libresign"
+    And the response should contain the initial state "libresign-identify_methods" with the following values:
+      """
+      [
+        {"name":"account","enabled":true,"mandatory":true,"can_create_account":true,"signature_method":"password","allowed_signature_methods":["password"],"can_be_used":true},
+        {"name":"email","enabled":true,"mandatory":true,"can_be_used":true,"test_url":"/index.php/settings/admin/mailtest"}
+      ]
+      """
+
   Scenario: Update identify methods and retrieve with success as initial state
     Given as user "admin"
     When sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"


### PR DESCRIPTION
Motivation: the appsetting `identify_methods` isn't manipulated by LibreSign when is defined, because this is necessary to verify the values when retrieve from database, sanitize and populate with the default values.

Added more tests and made necessary refactors to cover the scenarios.