### PR TITLE
Prevent override instance

### DIFF
--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -53,9 +53,13 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		private IRootFolder $root,
 		private IUserMountCache $userMountCache,
 	) {
-		$this->entity = new IdentifyMethod();
 		$className = (new \ReflectionClass($this))->getShortName();
 		$this->name = lcfirst($className);
+		$this->cleanEntity();
+	}
+
+	public function cleanEntity(): void {
+		$this->entity = new IdentifyMethod();
 		$this->entity->setIdentifierKey($this->name);
 	}
 

--- a/lib/Service/IdentifyMethod/IIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/IIdentifyMethod.php
@@ -28,6 +28,7 @@ use OCA\Libresign\Db\IdentifyMethod;
 use OCP\IUser;
 
 interface IIdentifyMethod {
+	public function cleanEntity(): void;
 	public function setEntity(IdentifyMethod $entity): void;
 	public function getEntity(): IdentifyMethod;
 	public function willNotifyUser(bool $willNotify): void;

--- a/lib/Service/IdentifyMethodService.php
+++ b/lib/Service/IdentifyMethodService.php
@@ -71,8 +71,7 @@ class IdentifyMethodService {
 				}
 			}
 		}
-		$className = 'OCA\Libresign\Service\IdentifyMethod\\' . ucfirst($name);
-		$identifyMethod = \OC::$server->get($className);
+		$identifyMethod = $this->getNewInstanceOfMethod($name);
 
 		$entity = $identifyMethod->getEntity();
 		$entity->setIdentifierKey($name);
@@ -84,6 +83,13 @@ class IdentifyMethodService {
 		}
 
 		$this->identifyMethods[$name][] = $identifyMethod;
+		return $identifyMethod;
+	}
+
+	private function getNewInstanceOfMethod(string $name): IIdentifyMethod {
+		$className = 'OCA\Libresign\Service\IdentifyMethod\\' . ucfirst($name);
+		$identifyMethod = clone \OC::$server->get($className);
+		$identifyMethod->cleanEntity();
 		return $identifyMethod;
 	}
 


### PR DESCRIPTION
When we use OC::$server->get() will return the same instance all time and is necessary to return a new instance to don't override the previous instance.