### PR TITLE
Downgrade the PHP version to be compatible with Nextcloud server

### DIFF
--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -29,10 +29,10 @@ jobs:
           ref: ${{ matrix.branch }}
           submodules: true
 
-      - name: Set up php8.2
+      - name: Set up php8.0
         uses: shivammathur/setup-php@81cd5ae0920b34eef300e1775313071038a53429 # v2
         with:
-          php-version: 8.2
+          php-version: 8.0
           extensions: ctype,curl,dom,fileinfo,gd,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:


### PR DESCRIPTION
The minimum version of PHP at Nextcloud server is 8.0 and if we run the command composer update in an environment with PHP 8.2 will update a lot of packages to versions that isn't compatible with PHP 8.0