### PR TITLE
Cover afterException hook with tests

### DIFF
--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -144,10 +144,8 @@ class InjectionMiddleware extends Middleware {
 					];
 				}
 				return new JSONResponse(
-					$body,
-					$exception->getCode() === 0
-						? AppFrameworkHttp::STATUS_UNPROCESSABLE_ENTITY
-						: $exception->getCode()
+					data: $body,
+					statusCode: $this->getStatusCodeFromException($exception)
 				);
 			case $exception instanceof PageException:
 				if ($this->isJson($exception->getMessage())) {
@@ -158,13 +156,10 @@ class InjectionMiddleware extends Middleware {
 
 				Util::addScript(Application::APP_ID, 'libresign-external');
 				$response = new TemplateResponse(
-					Application::APP_ID,
-					'external',
-					[],
-					TemplateResponse::RENDER_AS_BASE,
-					$exception->getCode() === 0
-						? AppFrameworkHttp::STATUS_UNPROCESSABLE_ENTITY
-						: $exception->getCode()
+					appName: Application::APP_ID,
+					templateName: 'external',
+					renderAs: TemplateResponse::RENDER_AS_BASE,
+					status: $this->getStatusCodeFromException($exception)
 				);
 
 				$policy = new ContentSecurityPolicy();
@@ -174,6 +169,13 @@ class InjectionMiddleware extends Middleware {
 		}
 
 		throw $exception;
+	}
+
+	private function getStatusCodeFromException(\Exception $exception): int {
+		if ($exception->getCode() === 0) {
+			return AppFrameworkHttp::STATUS_UNPROCESSABLE_ENTITY;
+		}
+		return $exception->getCode();
 	}
 
 	protected function isJson(string $string): bool {

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -150,10 +150,22 @@ class InjectionMiddleware extends Middleware {
 						: $exception->getCode()
 				);
 			case $exception instanceof PageException:
-				$this->initialState->provideInitialState('config', json_decode($exception->getMessage(), true));
+				if ($this->isJson($exception->getMessage())) {
+					$this->initialState->provideInitialState('config', json_decode($exception->getMessage(), true));
+				} else {
+					$this->initialState->provideInitialState('error', ['message' => $exception->getMessage()]);
+				}
 
 				Util::addScript(Application::APP_ID, 'libresign-external');
-				$response = new TemplateResponse(Application::APP_ID, 'external', [], TemplateResponse::RENDER_AS_BASE);
+				$response = new TemplateResponse(
+					Application::APP_ID,
+					'external',
+					[],
+					TemplateResponse::RENDER_AS_BASE,
+					$exception->getCode() === 0
+						? AppFrameworkHttp::STATUS_UNPROCESSABLE_ENTITY
+						: $exception->getCode()
+				);
 
 				$policy = new ContentSecurityPolicy();
 				$policy->addAllowedFrameDomain('\'self\'');

--- a/tests/Unit/Middleware/InjectionMiddlewareTest.php
+++ b/tests/Unit/Middleware/InjectionMiddlewareTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use OC\AppFramework\Bootstrap\Coordinator;
+use OC\AppFramework\Services\InitialState;
+use OC\InitialStateService;
+use OCA\Libresign\Db\FileMapper;
+use OCA\Libresign\Db\SignRequestMapper;
+use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Exception\PageException;
+use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Middleware\InjectionMiddleware;
+use OCA\Libresign\Service\SignFileService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IServerContainer;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @copyright Copyright (c) 2023 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
+	private IRequest|MockObject $request;
+	private IUserSession|MockObject $userSession;
+	private ValidateHelper|MockObject $validateHelper;
+	private SignRequestMapper|MockObject $signRequestMapper;
+	private FileMapper|MockObject $fileMapper;
+	private IInitialState|MockObject $initialState;
+	private SignFileService|MockObject $signFileService;
+	private IL10N|MockObject $l10n;
+	private ?string $userId;
+
+	private InitialStateService $initialStateService;
+
+	public function setUp(): void {
+		$this->request = $this->createMock(IRequest::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
+		$this->fileMapper = $this->createMock(FileMapper::class);
+
+		$this->initialStateService = new InitialStateService(
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(Coordinator::class),
+			$this->createMock(IServerContainer::class)
+		);
+		$this->initialState = new InitialState($this->initialStateService, 'libresign');
+		$this->signFileService = $this->createMock(SignFileService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->userId = null;
+	}
+
+	public function getInjectionMiddleware(): InjectionMiddleware {
+		return new InjectionMiddleware(
+			$this->request,
+			$this->userSession,
+			$this->validateHelper,
+			$this->signRequestMapper,
+			$this->fileMapper,
+			$this->initialState,
+			$this->signFileService,
+			$this->l10n,
+			$this->userId,
+		);
+	}
+
+	/**
+	 * @dataProvider providerAfterException
+	 */
+	public function testAfterException(string $message, int $code, string $exception, callable $expected): void {
+		$controller = $this->createMock(Controller::class);
+		$methodName = 'fake';
+		try {
+			throw new $exception($message, $code);
+		} catch (\Throwable $exception) {
+		}
+		$injectionMiddleware = $this->getInjectionMiddleware();
+		$actual = $injectionMiddleware->afterException($controller, $methodName, $exception);
+		$expected($this, $message, $code, $actual);
+	}
+
+	public static function providerAfterException(): array {
+		return [
+			[
+				json_encode(['action' => 100]), 1, LibresignException::class,
+				function (self $self, $message, int $code, $actual) {
+					/** @var JSONResponse $actual */
+					$self->assertInstanceOf(
+						JSONResponse::class,
+						$actual,
+						'The response need to be JSONResponse'
+					);
+					$self->assertJsonStringEqualsJsonString(
+						$message,
+						json_encode($actual->getData()),
+						'Invalid response json content'
+					);
+					$self->assertEquals(
+						$code,
+						$actual->getStatus(),
+						'Invalid response status code'
+					);
+				},
+			],
+			[
+				'a text here', 1, LibresignException::class,
+				function (self $self, $message, int $code, $actual) {
+					/** @var JSONResponse $actual */
+					$self->assertInstanceOf(
+						JSONResponse::class,
+						$actual,
+						'The response need to be JSONResponse'
+					);
+					$self->assertJsonStringEqualsJsonString(
+						json_encode(['message' => $message]),
+						json_encode($actual->getData()),
+						'Invalid response json content'
+					);
+					$self->assertEquals(
+						$code,
+						$actual->getStatus(),
+						'Invalid response status code'
+					);
+				},
+			],
+			[
+				'a text here', 1, PageException::class,
+				function (self $self, $message, int $code, $actual) {
+					/** @var TemplateResponse $actual */
+					$self->assertInstanceOf(
+						TemplateResponse::class,
+						$actual,
+						'The response need to be TemplateResponse'
+					);
+					$states = $self->initialStateService->getInitialStates();
+					$self->assertArrayHasKey('libresign-error', $states);
+					$self->assertJsonStringEqualsJsonString(
+						json_encode(['message' => $message]),
+						$states['libresign-error'],
+						'Invalid response params content'
+					);
+					$self->assertEquals(
+						$code,
+						$actual->getStatus(),
+						'Invalid response status code'
+					);
+				},
+			],
+		];
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -72,6 +72,11 @@
       <code>LoadSidebar</code>
     </UndefinedClass>
   </file>
+  <file src="lib/Middleware/InjectionMiddleware.php">
+    <InvalidTemplateParam occurrences="1">
+      <code>$response-&gt;setContentSecurityPolicy($policy)</code>
+    </InvalidTemplateParam>
+  </file>
   <file src="lib/Migration/Version2040Date20211027183759.php">
     <MissingDependency occurrences="3">
       <code>$this-&gt;root</code>


### PR DESCRIPTION
This change is to implement a middleware to handle errors and return the erros to client.

The client could be a request from API or a request made from user.

When the request have the header `Accept: 'application/json'` is made to API and will return as json

When the request haven't the header `Accept: 'application/json'` is made from user and will return as HTML with all properties of JSON as initial state

Suggestion of response from backend:

```yaml
openapi: "3.0.2"
info:
  title: Response from routes
  version: "1.0"
paths:
  /test:
    get:
      responses:
        200:
          description: OK
          content:
            application/json:
              schema:
                type: object
                allOf:
                  - type: object
                    properties:
                      action:
                        enum:
                          # ACTION_REDIRECT
                          - 100
                          # ACTION_CREATE_USER
                          - 150
                          # ACTION_DO_NOTHING
                          - 200
                          # ACTION_SIGN
                          - 250
                          # ACTION_SHOW_ERROR
                          - 300
                          # ACTION_SIGNED
                          - 350
                          # ACTION_CREATE_SIGNATURE_PASSWORD
                          - 400
                oneOf:
                  - type: object
                    description: Success
                    properties:
                      message:
                        type: string
                        description: Success message
                        example: Success
                  - type: object
                    description: Error
                    properties:
                      errors:
                        type: array
                        items:
                          type: string
                        example:
                          - User 0 needs an email address
            text/html:
              example: |
                initial-state:
                  config: // Config is deprecated
                  action: 200
                  error:
                    - error1
                    - error2
```