### PR TITLE
Organize initial states

### DIFF
--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -73,7 +73,15 @@ class FileController extends Controller {
 	#[PublicPage]
 	public function validate(?string $type = null, $identifier = null): JSONResponse {
 		try {
-			if (!empty($type) && !empty($identifier)) {
+			if ($type === 'Uuid' && !empty($identifier)) {
+				try {
+					$this->fileService
+						->setFileByType('Uuid', $identifier);
+				} catch (LibresignException $e) {
+					$this->fileService
+						->setFileByType('SignerUuid', $identifier);
+				}
+			} elseif (!empty($type) && !empty($identifier)) {
 				$this->fileService
 					->setFileByType($type, $identifier);
 			} elseif ($this->request->getParam('path')) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -303,7 +303,7 @@ class PageController extends AEnvironmentPageAwareController {
 	#[RequireSignRequestUuid]
 	public function resetPassword(): TemplateResponse {
 		$this->initialState->provideInitialState('config',
-			$this->accountService->getConfig($this->userSession->getUser()),
+			$this->accountService->getConfig($this->userSession->getUser())
 		);
 
 		Util::addScript(Application::APP_ID, 'libresign-main');

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -144,6 +144,7 @@ class PageController extends AEnvironmentPageAwareController {
 			->showVisibleElements()
 			->showSigners()
 			->formatFile();
+		$this->initialState->provideInitialState('status', $file['status']);
 		$this->initialState->provideInitialState('visibleElements', $file['visibleElements']);
 		$this->initialState->provideInitialState('signers', $file['signers']);
 		$this->initialState->provideInitialState('description', $this->getSignRequestEntity()->getDescription() ?? '');

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -139,6 +139,13 @@ class PageController extends AEnvironmentPageAwareController {
 			$this->signFileService->getAvailableIdentifyMethods($this->getSignRequestEntity())
 		);
 		$this->initialState->provideInitialState('filename', $this->getFileEntity()->getName());
+		$file = $this->fileService
+			->setFile($this->getFileEntity())
+			->showVisibleElements()
+			->showSigners()
+			->formatFile();
+		$this->initialState->provideInitialState('visibleElements', $file['visibleElements']);
+		$this->initialState->provideInitialState('signers', $file['signers']);
 		$this->initialState->provideInitialState('description', $this->getSignRequestEntity()->getDescription() ?? '');
 		$this->initialState->provideInitialState('pdf',
 			$this->signFileService->getFileUrl('url', $this->getFileEntity(), $this->getNextcloudFile(), $uuid)

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -138,11 +138,11 @@ class PageController extends AEnvironmentPageAwareController {
 		$this->initialState->provideInitialState('identifyMethods',
 			$this->signFileService->getAvailableIdentifyMethods($this->getSignRequestEntity())
 		);
-		$this->initialState->provideInitialState('sign', [
-			'filename' => $this->getFileEntity()->getName(),
-			'description' => $this->getSignRequestEntity()->getDescription(),
-			'pdf' => $this->signFileService->getFileUrl('url', $this->getFileEntity(), $this->getNextcloudFile(), $uuid),
-		]);
+		$this->initialState->provideInitialState('filename', $this->getFileEntity()->getName());
+		$this->initialState->provideInitialState('description', $this->getSignRequestEntity()->getDescription() ?? '');
+		$this->initialState->provideInitialState('pdf',
+			$this->signFileService->getFileUrl('url', $this->getFileEntity(), $this->getNextcloudFile(), $uuid)
+		);
 
 		Util::addScript(Application::APP_ID, 'libresign-external');
 		$response = new TemplateResponse(Application::APP_ID, 'external', [], TemplateResponse::RENDER_AS_BASE);
@@ -254,9 +254,9 @@ class PageController extends AEnvironmentPageAwareController {
 			);
 			$this->initialState->provideInitialState('file', [
 				'uuid' => $this->getFileEntity()?->getUuid(),
-				'filename' => $this->getFileEntity()?->getName(),
 				'description' => $this->getSignRequestEntity()?->getDescription(),
 			]);
+			$this->initialState->provideInitialState('filename', $this->getFileEntity()?->getName());
 			$this->initialState->provideInitialState('pdf',
 				$this->signFileService->getFileUrl('url', $this->getFileEntity(), $this->getNextcloudFile(), $this->request->getParam('uuid'))
 			);

--- a/lib/Controller/SignFileController.php
+++ b/lib/Controller/SignFileController.php
@@ -94,6 +94,7 @@ class SignFileController extends AEnvironmentAwareController {
 					'user-agent' => $this->request->getHeader('User-Agent'),
 					'remote-address' => $this->request->getRemoteAddress(),
 				])
+				->setCurrentUser($user)
 				->setVisibleElements($elements)
 				->setSignWithoutPassword(!empty($code))
 				->setPassword($password)

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -72,7 +72,7 @@ class FileMapper extends QBMapper {
 	}
 
 	/**
-	 * Return LibreSign file by UUID
+	 * Return LibreSign file by file UUID
 	 */
 	public function getByUuid(?string $uuid = null): File {
 		if (is_null($uuid) && !empty($this->file)) {
@@ -89,6 +89,27 @@ class FileMapper extends QBMapper {
 			->from($this->getTableName())
 			->where(
 				$qb->expr()->eq('uuid', $qb->createNamedParameter($uuid))
+			);
+
+		$file = $this->findEntity($qb);
+		$this->file[] = $file;
+		return $file;
+	}
+
+	/**
+	 * Return LibreSign file by signer UUID
+	 */
+	public function getBySignerUuid(?string $uuid = null): File {
+		if (is_null($uuid) && !empty($this->file)) {
+			return current($this->file);
+		}
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('f.*')
+			->from($this->getTableName(), 'f')
+			->join('f', 'libresign_sign_request', 'sr', $qb->expr()->eq('f.id', 'sr.file_id'))
+			->where(
+				$qb->expr()->eq('sr.uuid', $qb->createNamedParameter($uuid))
 			);
 
 		$file = $this->findEntity($qb);

--- a/lib/Db/SignRequestMapper.php
+++ b/lib/Db/SignRequestMapper.php
@@ -165,7 +165,7 @@ class SignRequestMapper extends QBMapper {
 	 */
 	public function getById(int $signRequestId): SignRequest {
 		foreach ($this->signers as $signRequest) {
-			if ($signRequest->getFileId() === $signRequestId) {
+			if ($signRequest->getId() === $signRequestId) {
 				return $signRequest;
 			}
 		}

--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -291,14 +291,14 @@ class ValidateHelper {
 
 	private function validateUserHasNecessaryElements(SignRequest $signRequest, IUser $user, array $list = []): void {
 		$fileElements = $this->fileElementMapper->getByFileIdAndSignRequestId($signRequest->getFileId(), $signRequest->getId());
-		$total = array_filter($fileElements, function (FileElement $fileElement) use ($list, $signRequest): bool {
+		$total = array_filter($fileElements, function (FileElement $fileElement) use ($list, $user, $signRequest): bool {
 			$found = array_filter($list, function ($item) use ($fileElement): bool {
 				return $item['documentElementId'] === $fileElement->getId();
 			});
 			if (!$found) {
 				try {
 					$this->userElementMapper->findMany([
-						'user_id' => $signRequest->getUserId(),
+						'user_id' => $user->getUID(),
 						'type' => $fileElement->getType(),
 					]);
 					return true;

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -251,11 +251,11 @@ class AccountService {
 	 * @return array[]
 	 */
 	public function getConfig(?IUser $user): array {
-		$info['settings']['identificationDocumentsFlow'] = $this->config->getAppValue(Application::APP_ID, 'identification_documents') ? true : false;
-		$info['settings']['certificateOk'] = $this->certificateEngineHandler->getEngine()->isSetupOk() && $this->pkcs12Handler->isHandlerOk();
-		$info['settings']['hasSignatureFile'] = $this->hasSignatureFile($user);
-		$info['settings']['phoneNumber'] = $this->getPhoneNumber($user);
-		$info['settings']['isApprover'] = $this->validateHelper->userCanApproveValidationDocuments($user, false);
+		$info['identificationDocumentsFlow'] = $this->config->getAppValue(Application::APP_ID, 'identification_documents') ? true : false;
+		$info['certificateOk'] = $this->certificateEngineHandler->getEngine()->isSetupOk() && $this->pkcs12Handler->isHandlerOk();
+		$info['hasSignatureFile'] = $this->hasSignatureFile($user);
+		$info['phoneNumber'] = $this->getPhoneNumber($user);
+		$info['isApprover'] = $this->validateHelper->userCanApproveValidationDocuments($user, false);
 		return $info;
 	}
 

--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -135,6 +135,11 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		$this->sessionService->resetDurationOfSignPage();
 	}
 
+	protected function updateIdentifiedAt(): void {
+		$this->getEntity()->setIdentifiedAtDate($this->timeFactory->getDateTime());
+		$this->save();
+	}
+
 	protected function throwIfRenewalIntervalExpired(): void {
 		$renewalInterval = (int) $this->config->getAppValue(Application::APP_ID, 'renewal_interval', (string) SessionService::NO_RENEWAL_INTERVAL);
 		if ($renewalInterval <= 0) {

--- a/lib/Service/IdentifyMethod/Account.php
+++ b/lib/Service/IdentifyMethod/Account.php
@@ -127,6 +127,7 @@ class Account extends AbstractIdentifyMethod {
 			$this->validateWithEmail($user);
 		}
 		$this->renewSession();
+		$this->updateIdentifiedAt();
 	}
 
 	private function validateWithAccount(IUser $user): void {

--- a/lib/Service/IdentifyMethod/Email.php
+++ b/lib/Service/IdentifyMethod/Email.php
@@ -98,6 +98,7 @@ class Email extends AbstractIdentifyMethod {
 		$this->throwIfFileNotFound();
 		$this->throwIfAlreadySigned();
 		$this->renewSession();
+		$this->updateIdentifiedAt();
 	}
 
 	private function throwIfAccountAlreadyExists(?IUser $user): ?IUser {

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -435,9 +435,7 @@ class SignFileService {
 			$this->validateHelper->userCanApproveValidationDocuments($user);
 			$signRequest = new SignRequestEntity();
 			$signRequest->setFileId($libresignFile->getId());
-			$signRequest->setEmail($user->getEMailAddress());
 			$signRequest->setDisplayName($user->getDisplayName());
-			$signRequest->setUserId($user->getUID());
 			$signRequest->setUuid(UUIDUtil::getUUID());
 			$signRequest->setCreatedAt(time());
 		}

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -78,6 +78,7 @@ class SignFileService {
 	private ?Node $fileToSign = null;
 	private string $userUniqueIdentifier = '';
 	private string $friendlyName = '';
+	private IUser $user;
 
 	public function __construct(
 		protected IL10N $l10n,
@@ -208,6 +209,11 @@ class SignFileService {
 		return $this;
 	}
 
+	public function setCurrentUser(IUser $user): self {
+		$this->user = $user;
+		return $this;
+	}
+
 	/**
 	 * @return static
 	 */
@@ -222,7 +228,7 @@ class SignFileService {
 				$userElement = $this->userElementMapper->findOne(['id' => $c['profileElementId']]);
 			} else {
 				$userElement = $this->userElementMapper->findOne([
-					'user_id' => $this->signRequest->getUserId(),
+					'user_id' => $this->user->getUID(),
 					'type' => $fileElement->getType(),
 				]);
 			}

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -537,31 +537,17 @@ class SignFileService {
 		$this->validateHelper->validateRenewSigner($uuid, $user);
 	}
 
-	public function getFileData(FileEntity $fileData, ?IUser $user, ?SignRequestEntity $signRequest = null): array {
-		$return['action'] = JSActions::ACTION_SIGN;
-		$return['sign'] = [
-			'uuid' => $fileData->getUuid(),
-			'filename' => $fileData->getName()
-		];
+	public function getSignerData(?IUser $user, ?SignRequestEntity $signRequest = null): array {
 		if ($signRequest) {
 			$return['user']['name'] = $signRequest->getDisplayName();
-			$return['sign']['description'] = $signRequest->getDescription();
-			$return['settings']['identifyMethods'] = array_map(function (IdentifyMethod $identifyMethod): array {
-				return [
-					'mandatory' => $identifyMethod->getMandatory(),
-					'identifiedAtDate' => $identifyMethod->getIdentifiedAtDate(),
-					'method' => $identifyMethod->getMethod(),
-				];
-			}, $this->identifyMethodMapper->getIdentifyMethodsFromSignRequestId($signRequest->getId()));
-		} else {
+		} elseif ($user) {
 			$return['user']['name'] = $user->getDisplayName();
 		}
 		return $return;
 	}
 
-	public function getSignerData(?SignRequestEntity $signRequest = null): array {
-		$return['user']['name'] = $signRequest->getDisplayName();
-		$return['settings']['identifyMethods'] = array_map(function (IdentifyMethod $identifyMethod): array {
+	public function getAvailableIdentifyMethods(?SignRequestEntity $signRequest = null): array {
+		$return = array_map(function (IdentifyMethod $identifyMethod): array {
 			return [
 				'mandatory' => $identifyMethod->getMandatory(),
 				'identifiedAtDate' => $identifyMethod->getIdentifiedAtDate(),

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -551,7 +551,7 @@ class SignFileService {
 		return $return;
 	}
 
-	public function getAvailableIdentifyMethods(?SignRequestEntity $signRequest = null): array {
+	public function getAvailableIdentifyMethods(SignRequestEntity $signRequest = null): array {
 		$return = array_map(function (IdentifyMethod $identifyMethod): array {
 			return [
 				'mandatory' => $identifyMethod->getMandatory(),

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -538,6 +538,7 @@ class SignFileService {
 	}
 
 	public function getSignerData(?IUser $user, ?SignRequestEntity $signRequest = null): array {
+		$return = ['user' => ['name' => null]];
 		if ($signRequest) {
 			$return['user']['name'] = $signRequest->getDisplayName();
 		} elseif ($user) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,7 @@
 					:title="t('libresign', 'Back to sign')"
 					exact
 					@click="goToSign" />
-				<NcAppNavigationItem v-if="settings.certificateOk"
+				<NcAppNavigationItem v-if="config.certificateOk"
 					:to="{name: 'requestFiles'}"
 					:title="t('libresign', 'Request')"
 					icon="icon-rename"
@@ -44,7 +44,7 @@
 					:title="t('libresign', 'Validate')"
 					icon="icon-file" />
 
-				<NcAppNavigationItem v-if="settings.identificationDocumentsFlow && settings.isApprover"
+				<NcAppNavigationItem v-if="config.identificationDocumentsFlow && config.isApprover"
 					:to="{name: 'DocsAccountValidation'}"
 					:title="t('libresign', 'Documents Validation')"
 					icon="icon-user" />
@@ -81,9 +81,6 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import Icon from './assets/images/signed-icon.svg'
 import CroppedLayoutSettings from './Components/Settings/CroppedLayoutSettings.vue'
 import { loadState } from '@nextcloud/initial-state'
-import { defaults } from 'lodash-es'
-
-const libresignState = loadState('libresign', 'config', {})
 
 export default {
 	name: 'App',
@@ -98,7 +95,7 @@ export default {
 	},
 	data() {
 		return {
-			settings: defaults({}, libresignState?.settings || {}, {
+			config: loadState('libresign', 'config', {
 				hasSignatureFile: false,
 				identificationDocumentsFlow: false,
 				certificateOk: false,

--- a/src/Components/Request/VisibleElements.vue
+++ b/src/Components/Request/VisibleElements.vue
@@ -307,8 +307,8 @@ export default {
 
 			try {
 				this.editingElement
-					? await axios.patch(generateOcsUrl(`/apps/libresign/api/v1/file-element/${this.file.uuid}/${element.elementId}`), payload)
-					: await axios.post(generateOcsUrl(`/apps/libresign/api/v1/file-element/${this.file.uuid}`), payload)
+					? await axios.patch(generateOcsUrl(`/apps/libresign/api/v1/file-element/${this.document.uuid}/${element.elementId}`), payload)
+					: await axios.post(generateOcsUrl(`/apps/libresign/api/v1/file-element/${this.document.uuid}`), payload)
 				showSuccess(t('libresign', 'Element created'))
 
 				this.loadDocument()

--- a/src/helpers/SelectAction.js
+++ b/src/helpers/SelectAction.js
@@ -23,9 +23,7 @@
 
 import { loadState } from '@nextcloud/initial-state'
 
-const libresignVar = loadState('libresign', 'config', {})
-
-const redirectURL = libresignVar.redirect ? libresignVar.redirect : 'Home'
+const redirectURL = loadState('libresign', 'redirect', null) ?? 'Home'
 
 export const selectAction = (action) => {
 	switch (action) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -26,10 +26,9 @@ import Router from 'vue-router'
 import routes from './router.js'
 import store from '../store/index.js'
 import { generateUrl } from '@nextcloud/router'
+import { loadState } from '@nextcloud/initial-state'
 
 Vue.use(Router)
-
-const libresignVar = store.state.settings
 
 const base = generateUrl('/apps/libresign')
 
@@ -45,13 +44,9 @@ router.beforeEach((to, from, next) => {
 		next({ name: 'CreatePassword' })
 	}
 
-	if (libresignVar) {
-		if (libresignVar.sign) {
-			store.commit('setPdfData', libresignVar.sign)
-		}
-		if (libresignVar.errors) {
-			store.commit('setError', libresignVar.errors)
-		}
+	const errors = loadState('libresign', 'errors', [])
+	if (errors) {
+		store.commit('setError', errors)
 	}
 	next()
 })

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -24,8 +24,7 @@ import { translate as t } from '@nextcloud/l10n'
 import { selectAction } from '../helpers/SelectAction.js'
 import { loadState } from '@nextcloud/initial-state'
 
-const libresignVar = loadState('libresign', 'config', {})
-const isCompleteAdminConfig = libresignVar?.settings?.certificateOk
+const isCompleteAdminConfig = loadState('libresign', 'config', {})?.certificateOk ?? false
 const initUrl = isCompleteAdminConfig ? 'requestFiles' : 'incomplete'
 
 const routes = [
@@ -44,7 +43,7 @@ const routes = [
 	},
 	{
 		path: '/p/sign/:uuid',
-		redirect: { name: selectAction(libresignVar.action) },
+		redirect: { name: selectAction(loadState('libresign', 'action', '')) },
 	},
 	{
 		path: '/p/sign/:uuid/pdf',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,11 +30,8 @@ import validate from './modules/validate.js'
 import error from './modules/errors.js'
 import settings from './modules/settings.js'
 import user from './modules/user.js'
-import { loadState } from '@nextcloud/initial-state'
 
 Vue.use(Vuex)
-
-const libresignVar = loadState('libresign', 'config', {})
 
 export default new Store({
 
@@ -77,9 +74,6 @@ export default new Store({
 	getters: {
 		getErrors: state => {
 			return state.errors
-		},
-		getError(state) {
-			return libresignVar.errors
 		},
 		getHasPfx(state) {
 			return state.settings.hasSignatureFile

--- a/src/views/DefaultPageSuccess.vue
+++ b/src/views/DefaultPageSuccess.vue
@@ -49,15 +49,11 @@ export default {
 	},
 	computed: {
 		myUuid() {
-			const config = loadState('libresign', 'config', {})
 			const getUuid = this.$store.getters.getUuidToValidate
 			if (getUuid) {
 				return getUuid
 			}
-			if (config.sign) {
-				return config.sign.uuid
-			}
-			return config.uuid
+			return loadState('libresign', 'uuid')
 		},
 	},
 	methods: {

--- a/src/views/Timeline/Timeline.vue
+++ b/src/views/Timeline/Timeline.vue
@@ -74,7 +74,6 @@ export default {
 			pendingFilter: 'files/pendingFilter',
 			signedFilter: 'files/signedFilter',
 			orderFiles: 'files/orderFiles',
-			getError: 'error/getError',
 		}),
 		filterFile: {
 			get() {

--- a/tests/integration/features/account/create_to_sign.feature
+++ b/tests/integration/features/account/create_to_sign.feature
@@ -21,32 +21,15 @@ Feature: account/create_to_sign
       """
       250
       """
-    And the response should contain the initial state "libresign-sign" with the following values:
+    And the response should contain the initial state "libresign-pdf" with the following values:
       """
       {
-        "pdf": {
-          "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
-        },
-        "description": null,
-        "filename": "document"
+        "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
       }
       """
-    And the response should contain the initial state "libresign-config" with the following values:
+    And the response should contain the initial state "libresign-filename" with the following values:
       """
-      {
-        "user": {
-          "name": ""
-        },
-        "settings": {
-          "identifyMethods": [
-            {
-              "mandatory": 1,
-              "identifiedAtDate": null,
-              "method": "email"
-            }
-          ]
-        }
-      }
+      document
       """
     Then sending "post" to ocs "/apps/libresign/api/v1/account/create/<SIGN_UUID>"
       | uuid     | <SIGN_UUID>         |
@@ -70,32 +53,15 @@ Feature: account/create_to_sign
       """
       250
       """
-    And the response should contain the initial state "libresign-sign" with the following values:
+    And the response should contain the initial state "libresign-pdf" with the following values:
       """
       {
-        "pdf": {
-          "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
-        },
-        "description": null,
-        "filename": "document"
+        "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
       }
       """
-    And the response should contain the initial state "libresign-config" with the following values:
+    And the response should contain the initial state "libresign-filename" with the following values:
       """
-      {
-        "user": {
-          "name": ""
-        },
-        "settings": {
-          "identifyMethods": [
-            {
-              "mandatory": 1,
-              "identifiedAtDate": null,
-              "method": "email"
-            }
-          ]
-        }
-      }
+      document
       """
     Then sending "post" to ocs "/apps/libresign/api/v1/account/create/<SIGN_UUID>"
       | uuid | <SIGN_UUID> |

--- a/tests/integration/features/page/sign_identify_account.feature
+++ b/tests/integration/features/page/sign_identify_account.feature
@@ -93,30 +93,13 @@ Feature: page/sign_identify_account
       """
       250
       """
-    And the response should contain the initial state "libresign-sign" with the following values:
+    And the response should contain the initial state "libresign-pdf" with the following values:
       """
       {
-        "pdf": {
-          "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
-        },
-        "description": null,
-        "filename": "document"
+        "url": "/index.php/apps/libresign/pdf/user/<SIGN_UUID>"
       }
       """
-    Then the response should contain the initial state "libresign-config" with the following values:
+    And the response should contain the initial state "libresign-filename" with the following values:
       """
-      {
-        "user": {
-          "name": ""
-        },
-        "settings": {
-          "identifyMethods": [
-            {
-              "mandatory": 1,
-              "identifiedAtDate": null,
-              "method": "account"
-            }
-          ]
-        }
-      }
+      document
       """

--- a/tests/integration/features/page/validate.feature
+++ b/tests/integration/features/page/validate.feature
@@ -5,10 +5,7 @@ Feature: page/validate
     And sending "delete" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/make_validation_url_private"
     And as user ""
     When sending "get" to "/apps/libresign/p/validation"
-    And the response should contain the initial state "libresign-config" with the following values:
-      """
-      []
-      """
+    And the response should have a status code 200
 
   Scenario: Unauthenticated user can not see sign page
     Given as user "admin"


### PR DESCRIPTION
I separated the content of complex methods in specific initial state values.

Making this I identified code executions that wasn't necessary. As example, the endpoint to display page to reset password.