### PR TITLE
Disable execution of composer update every when install a new package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
       "composer dump-autoload"
     ],
     "post-update-cmd": [
-      "@composer bin all update --ansi",
       "composer dump-autoload"
     ]
   },


### PR DESCRIPTION
This is very bad because every time when we need only to install a package, the update script was executed updating packages that I don't want to update. I removed this.