### PR TITLE
Make possible save a file content into a file of different authenticated user

### DIFF
--- a/tests/Unit/Service/SignFileServiceTest.php
+++ b/tests/Unit/Service/SignFileServiceTest.php
@@ -23,6 +23,7 @@ use OCP\IL10N;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -43,6 +44,7 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IConfig $config;
 	private ValidateHelper|MockObject $validateHelper;
 	private IRootFolder|MockObject $root;
+	private IUserSession|MockObject $userSession;
 	private IUserMountCache|MockObject $userMountCache;
 	private FileElementMapper|MockObject $fileElementMapper;
 	private UserElementMapper|MockObject $userElementMapper;
@@ -72,6 +74,7 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->validateHelper = $this->createMock(\OCA\Libresign\Helper\ValidateHelper::class);
 		$this->root = $this->createMock(\OCP\Files\IRootFolder::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userMountCache = $this->createMock(IUserMountCache::class);
 		$this->fileElementMapper = $this->createMock(FileElementMapper::class);
 		$this->userElementMapper = $this->createMock(UserElementMapper::class);
@@ -99,6 +102,7 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->config,
 			$this->validateHelper,
 			$this->root,
+			$this->userSession,
 			$this->userMountCache,
 			$this->fileElementMapper,
 			$this->userElementMapper,


### PR DESCRIPTION
Problem: Nextcloud server disalowed to write a content into a file that isn't of authenticated user.

Workaround: to prevent error when try to save a file in a folder of different authenticated user

At the follow code:
https://github.com/nextcloud/server/blob/4173dfe05bd0155eb217dd428ac82091a508567a/apps/files_versions/lib/Listener/FileEventsListener.php#L350-L366 Nextcloud server force to use the user folder to get the file of authenticated user. This piece of code is to bypass the logic to use the authenticated user.

We need to identify a way to be possible save the file content