### PR TITLE
Hide unauthorized actions and add validation action

### DIFF
--- a/src/Components/Request/RequestSignature.vue
+++ b/src/Components/Request/RequestSignature.vue
@@ -28,6 +28,10 @@
 			@click="save()">
 			{{ t('libresign', 'Next') }}
 		</NcButton>
+		<NcButton v-if="signed"
+			@click="validationFile()">
+			{{ t('libresign', 'Validate') }}
+		</NcButton>
 		<VisibleElements :file="file" />
 	</div>
 	<div v-else>
@@ -102,6 +106,9 @@ export default {
 		subscribe('libresign:edit-signer', this.editSigner)
 	},
 	methods: {
+		validationFile() {
+			this.$router.push({ name: 'validationFile', params: { uuid: this.file.uuid } })
+		},
 		addIdentifier(signers) {
 			signers.map(signer => {
 				// generate unique code to new signer to be possible delete or edit

--- a/src/Components/Request/RequestSignature.vue
+++ b/src/Components/Request/RequestSignature.vue
@@ -83,11 +83,12 @@ export default {
 			listSigners: true,
 			signerToEdit: {},
 			dataSigners: this.signers,
+			signed: this.signers.filter(signer => signer.sign_date.length > 0).length > 0
 		}
 	},
 	computed: {
 		canSave() {
-			return this.dataSigners.length > 0
+			return this.canRequestSign && !this.signed && this.dataSigners.length > 0
 		},
 	},
 	watch: {

--- a/src/Components/Request/RequestSignature.vue
+++ b/src/Components/Request/RequestSignature.vue
@@ -16,7 +16,7 @@
 					</template>
 					{{ t('libresign', 'Delete') }}
 				</NcActionButton>
-				<NcActionButton v-if="!signer.signed && signer.signRequestId"
+				<NcActionButton v-if="canRequestSign && !signer.sign_date && signer.signRequestId"
 					icon="icon-comment"
 					:close-after-click="true"
 					@click="sendNotify(signer)">


### PR DESCRIPTION
## Don't send reminder when can't request sign and when the file is signed

* The file is signed when sign_date is filled. In this case, don't make sense to send a reminder to sign
* When the user can't reques to sign, is disallow to send reminder

|Before|After|
|---|---|
| ![image](https://github.com/LibreSign/libresign/assets/1079143/ce2d375b-6829-4824-84c6-da2d6dcf5346) | ![image](https://github.com/LibreSign/libresign/assets/1079143/f8bd0877-165c-4f13-b60f-51c162bffff5) |

## Hide next button when haven't permission to request to sign

|Before|After|
|---|---|
| ![image](https://github.com/LibreSign/libresign/assets/1079143/a34f7403-2ff7-441c-b86c-f5a6fa10148f) | ![Screenshot_20240106_142148](https://github.com/LibreSign/libresign/assets/1079143/7446515d-1a47-4411-a2fa-fed229842f71) |

## When the file is signed, show the validation button

|Before|After|
|---|---|
| ![Screenshot_20240106_142148](https://github.com/LibreSign/libresign/assets/1079143/7446515d-1a47-4411-a2fa-fed229842f71) | ![Screenshot_20240106_143425](https://github.com/LibreSign/libresign/assets/1079143/fba739e6-0953-4469-90bf-eefee1110deb) |