### PR TITLE
Add feedback when got error server side

### DIFF
--- a/lib/Service/TFile.php
+++ b/lib/Service/TFile.php
@@ -100,7 +100,11 @@ trait TFile {
 			if (!filter_var($data['file']['url'], FILTER_VALIDATE_URL)) {
 				throw new \Exception($this->l10n->t('Invalid URL file'));
 			}
-			$response = $this->client->newClient()->get($data['file']['url']);
+			try {
+				$response = $this->client->newClient()->get($data['file']['url']);
+			} catch (\Throwable $th) {
+				throw new \Exception($this->l10n->t('Invalid URL file'));
+			}
 			$mimetypeFromHeader = $response->getHeader('Content-Type');
 			$content = (string) $response->getBody();
 			if (!$content) {

--- a/src/views/Request.vue
+++ b/src/views/Request.vue
@@ -35,6 +35,10 @@
 			@close="closeModalUploadFromUrl">
 			<div class="modal__content">
 				<h2>{{ t('libresign', 'URL of a PDF file') }}</h2>
+				<NcNoteCard v-if="error.length > 0"
+					type="error">
+					{{ error }}
+				</NcNoteCard>
 				<div class="form-group">
 					<NcTextField :label="t('libresign', 'URL of a PDF file')"
 						:value.sync="pdfUrl">
@@ -64,6 +68,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import LinkIcon from 'vue-material-design-icons/Link.vue'
 import CloudUploadIcon from 'vue-material-design-icons/CloudUpload.vue'
 import UploadIcon from 'vue-material-design-icons/Upload.vue'
@@ -90,6 +95,7 @@ export default {
 		NcModal,
 		NcTextField,
 		NcButton,
+		NcNoteCard,
 		LinkIcon,
 		UploadIcon,
 		CloudUploadIcon,
@@ -105,6 +111,7 @@ export default {
 			loading: false,
 			file: {},
 			signers: [],
+			error: '',
 		}
 	},
 	computed: {
@@ -162,13 +169,18 @@ export default {
 			this.modalUploadFromUrl = false
 		},
 		async uploadUrl() {
-			const response = await axios.post(generateOcsUrl('/apps/libresign/api/v1/file'), {
-				file: {
-					url: this.pdfUrl,
-				},
-			})
-			this.file.nodeId = response.data.id
-			this.file.name = response.data.name
+			try {
+				const response = await axios.post(generateOcsUrl('/apps/libresign/api/v1/file'), {
+					file: {
+						url: this.pdfUrl,
+					},
+				})
+				this.file.nodeId = response.data.id
+				this.file.name = response.data.name
+			} catch (err) {
+				this.error = err.response.data.message
+				return
+			}
 			this.showSidebar = true
 			this.closeModalUploadFromUrl()
 		},


### PR DESCRIPTION
When the URL is invalid or we got an error sever side, this error now is displayed to user

![Screenshot_20240106_153148](https://github.com/LibreSign/libresign/assets/1079143/96860dd8-58f2-4f32-89aa-84763e583f0b)

Only to do a best explain about this screenshot:
- I got the error because I'm running PHP as FPM and haven't localhost domain. The http server at my environment stay running at a separated machine