### PR TITLE
If we do a return, dont will check other proccess

### DIFF
--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -272,7 +272,7 @@ class InstallService {
 			exec('ps -p ' . $progressData['pid'], $output, $exitCode);
 			if (count($output) <= 1) {
 				$this->removeDownloadProgress();
-				return false;
+				continue;
 			}
 			return true;
 		}


### PR DESCRIPTION
We only need to do a return if the process isn't running
