### PR TITLE
Fix load font

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,12 +23,7 @@ module.exports = merge(nextcloudWebpackConfig, {
 		rules: [
 			{
 				test: /\.(ttf|otf|eot|woff|woff2)$/,
-				use: {
-					loader: 'file-loader',
-					options: {
-					name: 'fonts/[name].[ext]',
-					},
-				},
+				type: 'asset/inline',
 			},
 			// Load raw SVGs to be able to inject them via v-html
 			{


### PR DESCRIPTION
When we create a signature by typing a text, use a font that need to be loaded by webpack