### PR TITLE
Prevent warning when do not have visible elements

### DIFF
--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -380,10 +380,7 @@ class FileService {
 			$return['signers'] = $this->getSigners();
 		}
 		if ($this->showVisibleElements) {
-			$visibleElements = $this->getVisibleElements();
-			if ($visibleElements) {
-				$return['visibleElements'] = $visibleElements;
-			}
+			$return['visibleElements'] = $this->getVisibleElements();
 		}
 		ksort($return);
 		return $return;


### PR DESCRIPTION
The method always return an array, don't need to check if exists. The return need to always return the array of visible elements.