### PR TITLE
Fix check if requested_by exists

### DIFF
--- a/src/Components/Request/RequestSignature.vue
+++ b/src/Components/Request/RequestSignature.vue
@@ -96,7 +96,10 @@ export default {
 	computed: {
 		canSave() {
 			return this.canRequestSign
-				&& this.filesStore.getFile().requested_by.uid === getCurrentUser().uid
+				&& (
+					!Object.hasOwn(this.filesStore.getFile(), 'requested_by')
+					|| this.filesStore.getFile().requested_by.uid === getCurrentUser().uid
+				)
 				&& !this.filesStore.isSigned()
 				&& this.filesStore.getFile()?.signers?.length > 0
 		},


### PR DESCRIPTION
When we request to sign a file, this property does not exists. This property only exists after request to sign