### PR TITLE
Prevent to don't close modal when API return an error

### DIFF
--- a/src/Components/Request/VisibleElements.vue
+++ b/src/Components/Request/VisibleElements.vue
@@ -265,6 +265,7 @@ export default {
 				showSuccess(t('libresign', response.data.message))
 				this.closeModal()
 			} catch (err) {
+				this.loading = false
 				this.onError(err)
 				return false
 			}


### PR DESCRIPTION
The loading need to be defined to false after all API request

