### PR TITLE
Disable notification when click on next

### DIFF
--- a/src/Components/Request/RequestSignature.vue
+++ b/src/Components/Request/RequestSignature.vue
@@ -179,6 +179,7 @@ export default {
 					identify: {},
 				}
 				signer.identifyMethods.forEach(method => {
+					user.notify = false
 					if (method.method === 'account') {
 						user.identify.account = method?.value?.id ?? method?.value ?? signer.uid
 					} else if (method.method === 'email') {


### PR DESCRIPTION
This is about the notification that is send to all signers by email or by Nextcloud notification

Now, the notification is send when click on request

![Screenshot_20240229_174804](https://github.com/LibreSign/libresign/assets/1079143/ba4a06e7-d5f0-4d50-aee3-994b2b028ab5)
