### PR TITLE
Prevent hide validate setup errors

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -159,6 +159,9 @@ class AdminController extends Controller {
 					$seconds = 0;
 				}
 			}
+			if ($errors = $this->installService->getErrorMessages()) {
+				$this->eventSource->send('errors', json_encode($errors));
+			}
 		} catch (\Exception $exception) {
 			$this->eventSource->send('errors', json_encode([
 				$this->l10n->t('Could not download binaries.'),

--- a/lib/Service/InstallService.php
+++ b/lib/Service/InstallService.php
@@ -289,7 +289,6 @@ class InstallService {
 			}
 			$pid = isset($progressData['pid']) ? $progressData['pid'] : 0;
 			if ($this->getInstallPid($pid) === 0) {
-				$this->removeDownloadProgress();
 				continue;
 			}
 			return true;


### PR DESCRIPTION
When the download progress is removed, all errors is removed together, we need to check first if exist errors on return of process, if yes we can't remove the download progress because the method to get errors will clean all.