### PR TITLE
Prevent warning

### DIFF
--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -46,7 +46,7 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 	/**
 	 * @var string[]
 	 */
-	public array $availableSignatureMethods;
+	public array $availableSignatureMethods = [];
 	/**
 	 * @var AbstractSignatureMethod[]
 	 */


### PR DESCRIPTION
Error: `Typed property OCA\\Libresign\\Service\\IdentifyMethod\\AbstractIdentifyMethod::$availableSignatureMethods must not be accessed before initialization"`