### PR TITLE
fix: make compatible with FPDF

### DIFF
--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -73,7 +73,8 @@ class PdfParserService {
 		foreach ($pages as $page) {
 			$details = $page->getDetails();
 			if (!isset($details['MediaBox'])) {
-				$details = reset($pdf->getObjectsByType('Pages'))->getHeader()->getDetails();
+				$pages = $pdf->getObjectsByType('Pages');
+				$details = reset($pages)->getHeader()->getDetails();
 			}
 			$output['d'][] = [
 				'w' => $details['MediaBox'][2],

--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -72,6 +72,9 @@ class PdfParserService {
 		];
 		foreach ($pages as $page) {
 			$details = $page->getDetails();
+			if (!isset($details['MediaBox'])) {
+				$details = reset($pdf->getObjectsByType('Pages'))->getHeader()->getDetails();
+			}
 			$output['d'][] = [
 				'w' => $details['MediaBox'][2],
 				'h' => $details['MediaBox'][3]


### PR DESCRIPTION
I identified an edge case parsing a PDF generated with FPDF. The MediaBox don't exists at page scope and was necessary to get from document scope.