### PR TITLE
chore: reset modal when load and close

### DIFF
--- a/src/views/ReadCertificate.vue
+++ b/src/views/ReadCertificate.vue
@@ -1,6 +1,7 @@
 <template>
 	<NcDialog v-if="signMethodsStore.modal.readCertificate"
 		:name="t('libresign', 'Certificate data')"
+		:size="size"
 		@closing="onClose">
 		<NcNoteCard v-if="error" type="error">
 			<p>{{ error }}</p>
@@ -116,9 +117,19 @@ export default {
 			password: '',
 			certificateData: [],
 			error: '',
+			size: 'small',
 		}
 	},
+	mounted() {
+		this.reset()
+	},
 	methods: {
+		reset() {
+			this.password = ''
+			this.certificateData = []
+			this.error = ''
+			this.size = 'small'
+		},
 		getLabelFromId(id) {
 			const item = selectCustonOption(id).unwrap()
 			return item.label
@@ -130,6 +141,7 @@ export default {
 			})
 				.then(({ data }) => {
 					this.certificateData = data
+					this.size = 'large'
 					this.error = ''
 				})
 				.catch(({ response }) => {
@@ -142,8 +154,8 @@ export default {
 			this.hasLoading = false
 		},
 		onClose() {
-			this.certificateData = []
 			this.signMethodsStore.closeModal('readCertificate')
+			this.reset()
 		},
 	},
 }
@@ -183,7 +195,6 @@ form{
 }
 
 table {
-	display: block;
 	width: 100%;
 	white-space: unset;
 }


### PR DESCRIPTION
The certificate data, password, error message need to be empty when modal is open. I also put this to close function to prevent to have these data when is no more necessary.

I also converted the modal to large when display the certificate data because in some cases, the certificate data have very large rows and a lot of rows.