### PR TITLE
fix: merge metadata

### DIFF
--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -310,7 +310,10 @@ class SignFileService {
 		if (!$collectMetadata || !$metadata) {
 			return $this;
 		}
-		$this->signRequest->setMetadata($metadata);
+		$this->signRequest->setMetadata(array_merge(
+			$metadata,
+			$this->signRequest->getMetadata(),
+		));
 		$this->signRequestMapper->update($this->signRequest);
 		return $this;
 	}


### PR DESCRIPTION
When we collect the user metadata to save on the time that the document is signed, is necessary to merge with previous metadata.