### PR TITLE
fix: await api response

### DIFF
--- a/src/views/Account/partials/Signature.vue
+++ b/src/views/Account/partials/Signature.vue
@@ -90,7 +90,7 @@ export default {
 			this.isEditing = true
 		},
 		async removeSignature() {
-			this.signatureElementsStore.delete(this.type)
+			await this.signatureElementsStore.delete(this.type)
 			if (this.signatureElementsStore.success.length) {
 				showSuccess(this.signatureElementsStore.success)
 			} else if (this.signatureElementsStore.error.length) {


### PR DESCRIPTION
Is necessary to await the API response before display the answer of API. The request to API is made asynchronous,