### PR TITLE
Wrong identifier on new distribution check (Successfully tested on Nextcloud-AIO)

### DIFF
--- a/lib/Service/Install/InstallService.php
+++ b/lib/Service/Install/InstallService.php
@@ -363,7 +363,7 @@ class InstallService {
 	private function getLinuxDistributionToDownloadJava(): string {
 		$distribution = shell_exec('cat /etc/*-release');
 		preg_match('/^ID=(?<version>.*)$/m', $distribution, $matches);
-		if (isset($matches['ID']) && strtolower($matches['ID']) === 'alpine') {
+		if (isset($matches['version']) && strtolower($matches['version']) === 'alpine') {
 			return 'alpine-linux';
 		}
 		return 'linux';


### PR DESCRIPTION
Fixing the check on regular expression matches. The named group is <version> not <ID> therefore the field have to be $matches['version'] to make a correct check


### Related Issue
https://github.com/LibreSign/libresign/pull/3049

### Pull Request Type
- Bugfix


### Pull request checklist
Now testing the modifications on InstallService.php with the two commits and with the change of this pull request the branch of fix/check-if-is-alpine will work well with Nextcloud-AIO / Alpine based Nextcloud - If the distribution is not containing "alpine" the fix does not interfere with any other installations.
