### PR TITLE
fix: prevent error when synchonize with windows

### DIFF
--- a/lib/Service/FolderService.php
+++ b/lib/Service/FolderService.php
@@ -142,7 +142,7 @@ class FolderService {
 			$data['settings']['separator'] = '_';
 			$data['settings']['folderPatterns'][] = [
 				'name' => 'date',
-				'setting' => 'Y-m-d\TH:i:s'
+				'setting' => 'Y-m-d\TH-i-s'
 			];
 			$data['settings']['folderPatterns'][] = [
 				'name' => 'name'


### PR DESCRIPTION
When we do a sync of a folder created with two points using Nextcloud desktop client, Windows don't recognize this and will do an error.