### PR TITLE
fix: prevent warning when check if array has key

### DIFF
--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -393,7 +393,7 @@ class AccountService {
 	}
 
 	private function saveFileOfVisibleElementUsingSession(array $data, string $sessionId): File {
-		if ($data['nodeId']) {
+		if (!empty($data['nodeId'])) {
 			return $this->updateFileOfVisibleElementUsingSession($data, $sessionId);
 		}
 		return $this->createFileOfVisibleElementUsingSession($data, $sessionId);


### PR DESCRIPTION
Ref: #3660