### PR TITLE
feat: add OWASP dependency check

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024 LibreCode coop and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: "OWASP Dependency-Check"
+
+on: pull_request
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run OWASP Dependency-Check
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          format: 'ALL'
+          project: 'LibreSign'
+          path: './'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+            --enableExperimental
+
+      - name: Upload Dependency-Check report
+        uses: actions/upload-artifact@master
+        with:
+          name: dependency-check-report
+          path: dependency-check-report.html


### PR DESCRIPTION
## to-do
- [x] fix package-lock.json?pdfjs-dist: GHSA-wgrm-67xf-hhpq(10.0), CVE-2024-4367(8.800000190734863)

Will be necessary check if is possible:
- [x] bump dependencies of https://github.com/LibreSign/vue-pdf-editor
  - https://github.com/LibreSign/libresign/pull/3832

Sounds that this action do the same as dependabot but dependabot have a best result. Maybe we don't need to merge this PR.