### PR TITLE
fix: assure that all signers will have an unique id

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -152,6 +152,7 @@ export const useFilesStore = function(...args) {
 				})
 			},
 			async hydrateFile(nodeId) {
+				this.addUniqueIdentifierToAllSigners(this.files[nodeId].signers)
 				if (Object.hasOwn(this.files[nodeId], 'uuid')) {
 					return
 				}
@@ -173,6 +174,9 @@ export const useFilesStore = function(...args) {
 				signers.map(signer => this.addIdentifierToSigner(signer))
 			},
 			addIdentifierToSigner(signer) {
+				if (signer.identify) {
+					return
+				}
 				// generate unique code to new signer to be possible delete or edit
 				if ((signer.identify === undefined || signer.identify === '') && signer.signRequestId === undefined) {
 					signer.identify = btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(signer))))


### PR DESCRIPTION
Without an unique ID, when do a delete will delete all that haven't an unique ID. By this way we assure that all will have an unique id