### PR TITLE
fix: block access to route when isn't allowed by admin

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -260,6 +260,7 @@ class PageController extends AEnvironmentPageAwareController {
 	#[RequireSignRequestUuid]
 	#[FrontpageRoute(verb: 'GET', url: '/p/sign/{uuid}')]
 	public function sign(string $uuid): TemplateResponse {
+		$this->throwIfValidationPageNotAccessible();
 		$this->initialState->provideInitialState('action', JSActions::ACTION_SIGN);
 		$this->initialState->provideInitialState('config',
 			$this->accountService->getConfig($this->userSession->getUser())

--- a/src/helpers/SelectAction.js
+++ b/src/helpers/SelectAction.js
@@ -37,6 +37,9 @@ export const selectAction = (action, to, from) => {
 	case 5000: // ACTION_INCOMPLETE_SETUP
 		return 'Incomplete' + external
 	default:
+		if (loadState('libresign', 'error', false)) {
+			return 'DefaultPageError' + external
+		}
 		break
 	}
 }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -188,22 +188,24 @@ const router = new Router({
 })
 
 router.beforeEach((to, from, next) => {
+	const actionElement = document.querySelector('#initial-state-libresign-action')
+	let action
+	if (actionElement) {
+		action = selectAction(loadState('libresign', 'action', ''), to, from)
+		document.querySelector('#initial-state-libresign-action')?.remove()
+	}
 	if (Object.hasOwn(to, 'name') && typeof to.name === 'string' && !to.name.endsWith('External') && isExternal(to, from)) {
 		next({
 			name: to.name + 'External',
 			params: to.params,
 		})
+	} else if (action !== undefined) {
+		next({
+			name: action,
+			params: to.params,
+		})
 	} else {
-		const action = selectAction(loadState('libresign', 'action', ''), to, from)
-		if (action !== undefined) {
-			document.querySelector('#initial-state-libresign-action').remove()
-			next({
-				name: action,
-				params: to.params,
-			})
-		} else {
-			next()
-		}
+		next()
 	}
 })
 

--- a/src/views/DefaultPageError.vue
+++ b/src/views/DefaultPageError.vue
@@ -7,15 +7,13 @@
 	<div class="container">
 		<div id="img" />
 		<div class="content">
-			<h1>{{ code || '404' }}</h1>
+			<h1>404</h1>
 			<h2>
-				{{ message || t('libresign', 'Page not found') }}
+				{{ t('libresign', 'Page not found') }}
 			</h2>
-			<p>{{ paragth }}</p>
-			<NcNoteCard v-if="errors.length > 0" type="error" heading="Error">
-				<p v-for="error in errors" :key="error">
-					{{ error }}
-				</p>
+			<p>{{ paragrath }}</p>
+			<NcNoteCard v-if="error" type="error" heading="Error">
+				{{ error }}
 			</NcNoteCard>
 		</div>
 	</div>
@@ -35,8 +33,8 @@ export default {
 
 	data() {
 		return {
-			paragth: t('libresign', 'Sorry but the page you are looking for does not exist, has been removed, moved or is temporarily unavailable.'),
-			errors: loadState('libresign', 'errors', []),
+			paragrath: t('libresign', 'Sorry but the page you are looking for does not exist, has been removed, moved or is temporarily unavailable.'),
+			error: loadState('libresign', 'error', {})?.message,
 		}
 	},
 


### PR DESCRIPTION
Now we already don't send data to validation page when the public access to this route is blocked but we follow loading the frontend without data. With this change will redirect to an error page