### PR TITLE
fix: consider filter status to toggle components

### DIFF
--- a/src/views/FilesList/FilesList.vue
+++ b/src/views/FilesList/FilesList.vue
@@ -41,7 +41,7 @@
 			class="files-list__loading-icon"
 			:size="38"
 			:name="t('libresign', 'Loading …')" />
-		<NcEmptyContent v-else-if="!loading && isEmptyDir"
+		<NcEmptyContent v-else-if="!loading && isEmptyDir && filtersStore.activeChips.length === 0"
 			:name="t('libresign', 'There are no documents')"
 			:description="t('libresign', 'Choose the file to request signatures.')">
 			<template #action>
@@ -79,6 +79,7 @@ import FilesListVirtual from './FilesListVirtual.vue'
 import RequestPicker from '../../Components/Request/RequestPicker.vue'
 
 import { useFilesStore } from '../../store/files.js'
+import { useFiltersStore } from '../../store/filters.js'
 import { useUserConfigStore } from '../../store/userconfig.js'
 
 export default {
@@ -99,9 +100,11 @@ export default {
 	},
 	setup() {
 		const filesStore = useFilesStore()
+		const filtersStore = useFiltersStore()
 		const userConfigStore = useUserConfigStore()
 		return {
 			filesStore,
+			filtersStore,
 			userConfigStore,
 		}
 	},

--- a/src/views/FilesList/FilesListTableFooter.vue
+++ b/src/views/FilesList/FilesListTableFooter.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<tr v-show="haveFiles">
+	<tr v-show="haveFiles || filtersStore.activeChips.length > 0">
 		<th class="files-list__row-checkbox">
 			<!-- TRANSLATORS Label for a table footer which summarizes the columns of the table -->
 			<span class="hidden-visually">{{ t('libresign', 'Total rows summary') }}</span>
@@ -25,13 +25,16 @@
 
 <script>
 import { useFilesStore } from '../../store/files.js'
+import { useFiltersStore } from '../../store/filters.js'
 
 export default {
 	name: 'FilesListTableFooter',
 	setup() {
 		const filesStore = useFilesStore()
+		const filtersStore = useFiltersStore()
 		return {
 			filesStore,
+			filtersStore,
 		}
 	},
 	computed: {

--- a/src/views/FilesList/FilesListTableHeader.vue
+++ b/src/views/FilesList/FilesListTableHeader.vue
@@ -3,7 +3,8 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<tr class="files-list__row-head">
+	<tr v-if="filesStore.ordered.length > 0"
+		class="files-list__row-head">
 		<th class="files-list__column files-list__row-checkbox"
 			@keyup.esc.exact="resetSelection">
 			<NcCheckboxRadioSwitch v-bind="selectAllBind" @update:checked="onToggleAll" />
@@ -101,6 +102,7 @@ export default {
 		},
 		isAllSelected() {
 			return this.selectedNodes.length === this.filesStore.ordered.length
+				&& this.filesStore.ordered.length > 0
 		},
 		isNoneSelected() {
 			return this.selectedNodes.length === 0


### PR DESCRIPTION
If we have files and apply a filter that will return an empty list of files, is necessary to show the footer with "0 files".