### PR TITLE
fix: change error class

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -15,6 +15,7 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Events\SendSignNotificationEvent;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
@@ -103,7 +104,7 @@ class Listener implements IEventListener {
 				],
 			]);
 			$this->activityManager->publish($event);
-		} catch (\InvalidArgumentException $e) {
+		} catch (UnknownActivityException $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return;
 		}

--- a/lib/Activity/Provider/SignRequest.php
+++ b/lib/Activity/Provider/SignRequest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Libresign\Activity\Provider;
 
 use OCA\Libresign\AppInfo\Application;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\Activity\IProvider;
@@ -29,7 +30,7 @@ class SignRequest implements IProvider {
 
 	public function parse($language, IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		if ($event->getApp() !== Application::APP_ID) {
-			throw new \InvalidArgumentException('Wrong app');
+			throw new UnknownActivityException('Wrong app');
 		}
 
 		$this->definitions->definitions['sign-request'] = [

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -11,6 +11,7 @@ namespace OCA\Libresign\Notification;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Db\SignRequestMapper;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
@@ -39,7 +40,7 @@ class Notifier implements INotifier {
 
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		$this->definitions->definitions['sign-request'] = [
@@ -69,7 +70,7 @@ class Notifier implements INotifier {
 			case 'update_sign_request':
 				return $this->parseSignRequest($notification, $l, true);
 			default:
-				throw new \InvalidArgumentException();
+				throw new UnknownActivityException();
 		}
 	}
 


### PR DESCRIPTION
since 30.0.0:

Providers should throw `UnknownActivityException` instead of `\InvalidArgumentException` when they did not handle the event. Throwing `\InvalidArgumentException` directly is deprecated and will be logged as an error in Nextcloud 39.
