### PR TITLE
[stable28] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,6 +2436,18 @@
       "integrity": "sha512-da8hT/ZUrFifAjxblVYzloiIhf8e8uUtfbh0qB5cxtNjDx4KDyUoDMj9TSAqvvjx1YKwhhfay0yDt38a19BHHQ==",
       "license": "OFL-1.1"
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.24.4.tgz",
+      "integrity": "sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^1.24.2",
+        "@shikijs/types": "^1.24.2",
+        "@shikijs/vscode-textmate": "^9.3.1"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2554,7 +2566,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2878,9 +2889,9 @@
       }
     },
     "node_modules/@nextcloud/dialogs": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-5.3.7.tgz",
-      "integrity": "sha512-//pRF2GJNhW3VbVzSoE97J+DR9nZ/+IkzOzgKKDdMr65JYYMAdOs9Iew4nMf+OruDgZanGyXrfubSMVNI+1svQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-5.3.8.tgz",
+      "integrity": "sha512-FtVwWXYLgTg9XKYNawYGi4Vt8T9QTuOi0qRgOzmnj8NK4CzRikIXbkXkqQKRkRn8LufLpW9c8aE6y5CtVljnZQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
@@ -2896,6 +2907,7 @@
         "@types/toastify-js": "^1.12.3",
         "@vueuse/core": "^10.11.1",
         "cancelable-promise": "^4.3.1",
+        "p-queue": "^8.0.1",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
         "webdav": "^5.7.1"
@@ -2997,9 +3009,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.1.tgz",
-      "integrity": "sha512-eureE0Hi13QhC7detUUlp5B7NjLLu1JnVLDF0yuNv/My5ETbe3SuWjulAXQ2KH3lvqVjhjgbNoEjH5wHemIG+g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.1.tgz",
+      "integrity": "sha512-hYUK28ZEU4GTbMXd0/YXTUUKedWnzdr4Eva+6sTxiuJMnACJ4/pZvSzFL9i82fBXvR/0MI5DA6+1gryMyNv1ww==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -3011,7 +3023,7 @@
         "@nextcloud/sharing": "^0.2.3",
         "cancelable-promise": "^4.3.1",
         "is-svg": "^5.1.0",
-        "typedoc-plugin-missing-exports": "^3.0.0",
+        "typedoc-plugin-missing-exports": "^3.1.0",
         "typescript-event-target": "^1.1.1",
         "webdav": "^5.7.1"
       },
@@ -3063,9 +3075,9 @@
       }
     },
     "node_modules/@nextcloud/moment": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.1.tgz",
-      "integrity": "sha512-+1CtYlc4Lu4soa1RKXvUsTJdsHS0kHUCzNBtb02BADMY5PMGUTCiCQx5xf1Ez15h2ehuwg0vESr8VyKem9sGAQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.2.tgz",
+      "integrity": "sha512-VfSPnllfciZe1eU4zaHS0fE/4pPWKRUjLFxZSNQec9gkUfbskMsKH2xyPqkYLlYP9FF1uQh2+wZbzkFd6QLc4A==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^2.2.0",
@@ -3074,7 +3086,7 @@
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n": {
@@ -3109,12 +3121,14 @@
       }
     },
     "node_modules/@nextcloud/password-confirmation": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-5.1.1.tgz",
-      "integrity": "sha512-UlQcjVe/fr/JaJ6TWaRM+yBLIEZRU6RWMy0JoExcA6UVJs2HJrRIyVMuiCLuIYlH23ReJH+z7zFI3+V7vdeJ1Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-5.3.1.tgz",
+      "integrity": "sha512-4+gcUBslO9QHI7UktsEB5qZv9FXojL+yMfIu9Rr2Z7V4ksTMxyqf2MaE4Utcs9BzcoS1oTRT5UxwdmfNkktraw==",
       "license": "MIT",
       "dependencies": {
+        "@nextcloud/auth": "^2.4.0",
         "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/dialogs": "^6.0.1",
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/router": "^3.0.1"
       },
@@ -3125,6 +3139,127 @@
       "peerDependencies": {
         "@nextcloud/vue": "^8.0.0",
         "vue": "^2.7.16"
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@nextcloud/dialogs": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.0.1.tgz",
+      "integrity": "sha512-TlzNUy0eFPIjnop2Wfom45xJdUjLOoUwd/E8V/6ehh+PifrgIWGy6jqBYMRoQfUASc/LKtSYUrCN3yDgVrK8Tw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@mdi/js": "^7.4.47",
+        "@nextcloud/auth": "^2.4.0",
+        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/event-bus": "^3.3.1",
+        "@nextcloud/files": "^3.9.0",
+        "@nextcloud/initial-state": "^2.2.0",
+        "@nextcloud/l10n": "^3.1.0",
+        "@nextcloud/router": "^3.0.1",
+        "@nextcloud/sharing": "^0.2.3",
+        "@nextcloud/typings": "^1.9.1",
+        "@types/toastify-js": "^1.12.3",
+        "@vueuse/core": "^11.2.0",
+        "cancelable-promise": "^4.3.1",
+        "p-queue": "^8.0.1",
+        "toastify-js": "^1.12.0",
+        "vue-frag": "^1.4.3",
+        "webdav": "^5.7.1"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@nextcloud/vue": "^8.16.0",
+        "vue": "^2.7.16"
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@vueuse/core": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
+      "integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "11.3.0",
+        "@vueuse/shared": "11.3.0",
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@vueuse/metadata": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
+      "integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@vueuse/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/password-confirmation/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nextcloud/paths": {
@@ -3206,9 +3341,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.19.0.tgz",
-      "integrity": "sha512-mEawbIueee5fSGZreJV+/8h80SRriRTuib1UO9UWWEgqWvZQp0i99xXnIQj+UMw9AugxznJWd5R0ZOmZkN7p5w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.21.0.tgz",
+      "integrity": "sha512-at06uh2JJkn8dV3Yzyoag2z1g6omad8MZ8yKWE+9ZAGP+kaysbnI5q3lB7KXu8SVRtX3Rex8/oal0jgsbb6Spg==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -3228,7 +3363,7 @@
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
         "clone": "^2.1.2",
-        "debounce": "2.1.1",
+        "debounce": "^2.2.0",
         "dompurify": "^3.0.5",
         "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
@@ -3237,6 +3372,7 @@
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "rehype-external-links": "^3.0.0",
+        "rehype-highlight": "^7.0.1",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
@@ -3272,6 +3408,24 @@
         "vue": "2.x"
       }
     },
+    "node_modules/@nextcloud/vue/node_modules/@vue/compiler-sfc": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "@vue/compiler-core": "3.5.13",
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.11",
+        "postcss": "^8.4.48",
+        "source-map-js": "^1.2.0"
+      }
+    },
     "node_modules/@nextcloud/vue/node_modules/@vueuse/core": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.1.0.tgz",
@@ -3285,6 +3439,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/core/node_modules/@vue/server-renderer": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13"
+      },
+      "peerDependencies": {
+        "vue": "3.5.13"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/core/node_modules/vue": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-sfc": "3.5.13",
+        "@vue/runtime-dom": "3.5.13",
+        "@vue/server-renderer": "3.5.13",
+        "@vue/shared": "3.5.13"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nextcloud/vue/node_modules/@vueuse/core/node_modules/vue-demi": {
@@ -3819,59 +4009,32 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@shikijs/core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.2.tgz",
-      "integrity": "sha512-bvIQcd8BEeR1yFvOYv6HDiyta2FFVePbzeowf5pPS1avczrPK+cjmaxxh0nx5QzbON7+Sv0sQfQVciO7bN72sg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/engine-javascript": "1.22.2",
-        "@shikijs/engine-oniguruma": "1.22.2",
-        "@shikijs/types": "1.22.2",
-        "@shikijs/vscode-textmate": "^9.3.0",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.3"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.2.tgz",
-      "integrity": "sha512-iOvql09ql6m+3d1vtvP8fLCVCK7BQD1pJFmHIECsujB0V32BJ0Ab6hxk1ewVSMFA58FI0pR2Had9BKZdyQrxTw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "1.22.2",
-        "@shikijs/vscode-textmate": "^9.3.0",
-        "oniguruma-to-js": "0.4.3"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.2.tgz",
-      "integrity": "sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
+      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@shikijs/types": "1.22.2",
-        "@shikijs/vscode-textmate": "^9.3.0"
+        "@shikijs/types": "1.24.4",
+        "@shikijs/vscode-textmate": "^9.3.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.2.tgz",
-      "integrity": "sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.4.tgz",
+      "integrity": "sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@shikijs/vscode-textmate": "^9.3.0",
+        "@shikijs/vscode-textmate": "^9.3.1",
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
-      "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
       "license": "MIT",
       "peer": true
     },
@@ -4465,6 +4628,31 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "license": "ISC"
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "@vue/shared": "3.5.13",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.5.13",
+        "@vue/shared": "3.5.13"
+      }
+    },
     "node_modules/@vue/compiler-sfc": {
       "version": "2.7.16",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
@@ -4485,6 +4673,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -4597,6 +4796,47 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.13",
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.13",
+        "@vue/runtime-core": "3.5.13",
+        "@vue/shared": "3.5.13",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@vue/tsconfig": {
       "version": "0.5.1",
@@ -6237,28 +6477,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -6785,9 +7003,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7020,9 +7238,9 @@
       "license": "MIT"
     },
     "node_modules/debounce": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.1.1.tgz",
-      "integrity": "sha512-+xRWxgel9LgTC4PwKlm7TJUK6B6qsEK77NaiNvXmeQ7Y3e6OVVsBC4a9BSptS/mAYceyAz37Oa8JTTuPRft7uQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8666,6 +8884,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8731,9 +8956,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8757,7 +8982,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8772,6 +8997,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -9757,38 +9986,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-      "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html/node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/hast": "^3.0.0"
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9813,6 +10020,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.0.tgz",
+      "integrity": "sha512-6ErL7JlGu2CNFHyRQEuDogOyGPNiqcuWdt4iSSFUPyferNTGlNTPFqeV36Y/XwA4V/TJ8l0sxp6FTnxud/mf8g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -9920,17 +10136,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -11319,6 +11524,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11335,6 +11555,16 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -12568,9 +12798,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -12959,19 +13189,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/oniguruma-to-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-      "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "regex": "^4.3.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/open": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -13087,6 +13304,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/p-retry": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
@@ -13101,6 +13340,18 @@
       },
       "engines": {
         "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
+      "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13240,9 +13491,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -13526,9 +13777,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -13546,7 +13797,7 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -14074,13 +14325,6 @@
         "@babel/runtime": "^7.8.4"
       }
     },
-    "node_modules/regex": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.3.tgz",
-      "integrity": "sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
@@ -14152,6 +14396,23 @@
         "is-absolute-url": "^4.0.0",
         "space-separated-tokens": "^2.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.1.tgz",
+      "integrity": "sha512-dB/vVGFsbm7xPglqnYbg0ABg6rAuIWKycTvuXaOO27SgLoOFNoTlniTBtAxp3n5ZyMioW1a3KwiNqgjkb6Skjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15081,21 +15342,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/shiki": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.2.tgz",
-      "integrity": "sha512-3IZau0NdGKXhH2bBlUk4w1IHNxPh6A5B2sUpyY+8utLu2j/h1QpFkAaUA1bAMxOWWGtTWcAh531vnS4NJKS/lA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/core": "1.22.2",
-        "@shikijs/engine-javascript": "1.22.2",
-        "@shikijs/engine-oniguruma": "1.22.2",
-        "@shikijs/types": "1.22.2",
-        "@shikijs/vscode-textmate": "^9.3.0",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -15552,21 +15798,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -16502,17 +16733,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.10.tgz",
-      "integrity": "sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.5.tgz",
+      "integrity": "sha512-x+fhKJtTg4ozXwKayh/ek4wxZQI/+2hmZUdO2i2NGDBRUflDble70z+ewHod3d4gRpXSO6fnlnjbDTnJk7HlkQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
+        "@gerrit0/mini-shiki": "^1.24.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "shiki": "^1.16.2",
-        "yaml": "^2.5.1"
+        "yaml": "^2.6.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -16521,16 +16752,16 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.0.0.tgz",
-      "integrity": "sha512-R7D8fYrK34mBFZSlF1EqJxfqiUSlQSmyrCiQgTQD52nNm6+kUtqwiaqaNkuJ2rA2wBgWFecUA8JzHT7x2r7ePg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.1.0.tgz",
+      "integrity": "sha512-Sogbaj+qDa21NjB3SlIw4JXSwmcl/WOjwiPNaVEcPhpNG/MiRTtpwV81cT7h1cbu9StpONFPbddYWR0KV/fTWA==",
       "license": "MIT",
       "peerDependencies": {
-        "typedoc": "0.26.x"
+        "typedoc": "0.26.x || 0.27.x"
       }
     },
     "node_modules/typescript": {
@@ -16683,6 +16914,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -18009,9 +18254,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "license": "ISC",
       "peer": true,
       "bin": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 16 of the total 25 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/password-confirmation](#user-content-\@nextcloud\/password-confirmation)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [cross-spawn](#user-content-cross-spawn)
* [express](#user-content-express)
* [nanoid](#user-content-nanoid)
* [path-to-regexp](#user-content-path-to-regexp)
* [postcss](#user-content-postcss)
* [vue-advanced-cropper](#user-content-vue-advanced-cropper)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vuex](#user-content-vuex)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/password-confirmation <a href="#user-content-\@nextcloud\/password-confirmation" id="\@nextcloud\/password-confirmation">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
* Affected versions: >=3.0.0
* Package usage:
  * `node_modules/@nextcloud/password-confirmation`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### cross-spawn <a href="#user-content-cross-spawn" id="cross-spawn">#</a>
* Regular Expression Denial of Service (ReDoS) in cross-spawn
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275)
* Affected versions: 7.0.0 - 7.0.4
* Package usage:
  * `node_modules/cross-spawn`

### express <a href="#user-content-express" id="express">#</a>
* Caused by vulnerable dependency:
  * [path-to-regexp](#user-content-path-to-regexp)
* Affected versions: 4.0.0-rc1 - 4.21.1 || 5.0.0-alpha.1 - 5.0.0-beta.3
* Package usage:
  * `node_modules/express`

### nanoid <a href="#user-content-nanoid" id="nanoid">#</a>
* Predictable results in nanoid generation when given non-integer values
* Severity: **moderate** (CVSS 4.3)
* Reference: [https://github.com/advisories/GHSA-mwcw-c2x4-8c55](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)
* Affected versions: <3.3.8
* Package usage:
  * `node_modules/nanoid`

### path-to-regexp <a href="#user-content-path-to-regexp" id="path-to-regexp">#</a>
* Unpatched `path-to-regexp` ReDoS in 0.1.x
* Severity: **moderate**
* Reference: [https://github.com/advisories/GHSA-rhx6-c78j-4q9w](https://github.com/advisories/GHSA-rhx6-c78j-4q9w)
* Affected versions: <0.1.12
* Package usage:
  * `node_modules/path-to-regexp`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-advanced-cropper <a href="#user-content-vue-advanced-cropper" id="vue-advanced-cropper">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.11.7
* Package usage:
  * `node_modules/vue-advanced-cropper`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vuex <a href="#user-content-vuex" id="vuex">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 3.1.3 - 3.6.2
* Package usage:
  * `node_modules/vuex`