### PR TITLE
feat: allow to change signature hash algorithm

### DIFF
--- a/lib/Handler/JSignPdfHandler.php
+++ b/lib/Handler/JSignPdfHandler.php
@@ -73,7 +73,11 @@ class JSignPdfHandler extends SignEngineHandler {
 		 * Need to respect the follow code:
 		 * https://github.com/intoolswetrust/jsignpdf/blob/JSignPdf_2_2_2/jsignpdf/src/main/java/net/sf/jsignpdf/types/HashAlgorithm.java#L46-L47
 		 */
-		preg_match('/^%PDF-(?<version>\d+(\.\d+)?)/', $this->getInputFile()->getContent(), $match);
+		$content = $this->getInputFile()->getContent();
+		if (!$content) {
+			return 'SHA1';
+		}
+		preg_match('/^%PDF-(?<version>\d+(\.\d+)?)/', $content, $match);
 		if (isset($match['version'])) {
 			$version = (float)$match['version'];
 			if ($version < 1.6) {

--- a/lib/Handler/JSignPdfHandler.php
+++ b/lib/Handler/JSignPdfHandler.php
@@ -54,10 +54,6 @@ class JSignPdfHandler extends SignEngineHandler {
 				->setjSignPdfJarPath(
 					$this->appConfig->getAppValue('jsignpdf_jar_path', '/opt/jsignpdf-' . self::VERSION . '/JSignPdf.jar')
 				);
-			$parameters = $this->jSignParam->getJSignParameters();
-			$parameters .= ' --hash-algorithm ' . $this->getHashAlgorithm();
-			$parameters = trim($parameters);
-			$this->jSignParam->setJSignParameters($parameters);
 			if (!empty($javaPath)) {
 				if (!file_exists($javaPath)) {
 					throw new \Exception('Invalid Java binary. Run occ libresign:install --java');
@@ -143,6 +139,13 @@ class JSignPdfHandler extends SignEngineHandler {
 
 	private function signWrapper(JSignPDF $jSignPDF): string {
 		try {
+			$param = $this->getJSignParam();
+			$param
+				->setJSignParameters(
+					$this->jSignParam->getJSignParameters() .
+					' --hash-algorithm ' . $this->getHashAlgorithm()
+				);
+			$jSignPDF->setParam($param);
 			return $jSignPDF->sign();
 		} catch (\Throwable $th) {
 			$rows = str_getcsv($th->getMessage());

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -125,10 +125,23 @@ namespace OCA\Libresign;
  *     label: string,
  *     name: string,
  * }
+ * @psalm-type LibresignSignatureMethodEmailToken = array{
+ *     label: string,
+ *     identifyMethod: "email"|"account",
+ *     needCode: bool,
+ *     hasConfirmCode: bool,
+ *     blurredEmail: string,
+ *     hashOfEmail: string,
+ * }
+ * @psalm-type LibresignSignatureMethodPassword = array{
+ *     label: string,
+ *     name: string,
+ *     hasSignatureFile: bool,
+ * }
  * @psalm-type LibresignSignatureMethods = array{
  *     clickToSign?: LibresignSignatureMethod,
- *     emailToken?: LibresignSignatureMethod,
- *     password?: LibresignSignatureMethod,
+ *     emailToken?: LibresignSignatureMethodEmailToken,
+ *     password?: LibresignSignatureMethodPassword,
  * }
  * @psalm-type LibresignSigner = array{
  *     description: ?string,
@@ -143,7 +156,7 @@ namespace OCA\Libresign;
  *     signRequestId: non-negative-int,
  *     identifyMethods?: LibresignIdentifyMethod[],
  *     visibleElements?: LibresignVisibleElement[],
- *     signatureMethods?: LibresignSignatureMethods[],
+ *     signatureMethods?: LibresignSignatureMethods,
  * }
  * @psalm-type LibresignValidateFile = array{
  *     uuid: string,

--- a/lib/Service/IdentifyMethodService.php
+++ b/lib/Service/IdentifyMethodService.php
@@ -178,9 +178,6 @@ class IdentifyMethodService {
 		$return = [];
 		foreach ($matrix as $identifyMethods) {
 			foreach ($identifyMethods as $identifyMethod) {
-				if (empty($identifyMethod->getEntity()->getIdentifiedAtDate())) {
-					continue;
-				}
 				$signatureMethods = $identifyMethod->getSignatureMethods();
 				foreach ($signatureMethods as $signatureMethod) {
 					if (!$signatureMethod->isEnabled()) {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -612,6 +612,60 @@
                     }
                 }
             },
+            "SignatureMethodEmailToken": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "identifyMethod",
+                    "needCode",
+                    "hasConfirmCode",
+                    "blurredEmail",
+                    "hashOfEmail"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "identifyMethod": {
+                        "type": "string",
+                        "enum": [
+                            "email",
+                            "account"
+                        ]
+                    },
+                    "needCode": {
+                        "type": "boolean"
+                    },
+                    "hasConfirmCode": {
+                        "type": "boolean"
+                    },
+                    "blurredEmail": {
+                        "type": "string"
+                    },
+                    "hashOfEmail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SignatureMethodPassword": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "name",
+                    "hasSignatureFile"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "hasSignatureFile": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "SignatureMethods": {
                 "type": "object",
                 "properties": {
@@ -619,10 +673,10 @@
                         "$ref": "#/components/schemas/SignatureMethod"
                     },
                     "emailToken": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodEmailToken"
                     },
                     "password": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodPassword"
                     }
                 }
             },
@@ -685,10 +739,7 @@
                         }
                     },
                     "signatureMethods": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SignatureMethods"
-                        }
+                        "$ref": "#/components/schemas/SignatureMethods"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -516,6 +516,60 @@
                     }
                 }
             },
+            "SignatureMethodEmailToken": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "identifyMethod",
+                    "needCode",
+                    "hasConfirmCode",
+                    "blurredEmail",
+                    "hashOfEmail"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "identifyMethod": {
+                        "type": "string",
+                        "enum": [
+                            "email",
+                            "account"
+                        ]
+                    },
+                    "needCode": {
+                        "type": "boolean"
+                    },
+                    "hasConfirmCode": {
+                        "type": "boolean"
+                    },
+                    "blurredEmail": {
+                        "type": "string"
+                    },
+                    "hashOfEmail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SignatureMethodPassword": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "name",
+                    "hasSignatureFile"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "hasSignatureFile": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "SignatureMethods": {
                 "type": "object",
                 "properties": {
@@ -523,10 +577,10 @@
                         "$ref": "#/components/schemas/SignatureMethod"
                     },
                     "emailToken": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodEmailToken"
                     },
                     "password": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodPassword"
                     }
                 }
             },
@@ -589,10 +643,7 @@
                         }
                     },
                     "signatureMethods": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SignatureMethods"
-                        }
+                        "$ref": "#/components/schemas/SignatureMethods"
                     }
                 }
             },

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1210,10 +1210,24 @@ export type components = {
             label: string;
             name: string;
         };
+        SignatureMethodEmailToken: {
+            label: string;
+            /** @enum {string} */
+            identifyMethod: "email" | "account";
+            needCode: boolean;
+            hasConfirmCode: boolean;
+            blurredEmail: string;
+            hashOfEmail: string;
+        };
+        SignatureMethodPassword: {
+            label: string;
+            name: string;
+            hasSignatureFile: boolean;
+        };
         SignatureMethods: {
             clickToSign?: components["schemas"]["SignatureMethod"];
-            emailToken?: components["schemas"]["SignatureMethod"];
-            password?: components["schemas"]["SignatureMethod"];
+            emailToken?: components["schemas"]["SignatureMethodEmailToken"];
+            password?: components["schemas"]["SignatureMethodPassword"];
         };
         Signer: {
             description: string | null;
@@ -1229,7 +1243,7 @@ export type components = {
             signRequestId: number;
             identifyMethods?: components["schemas"]["IdentifyMethod"][];
             visibleElements?: components["schemas"]["VisibleElement"][];
-            signatureMethods?: components["schemas"]["SignatureMethods"][];
+            signatureMethods?: components["schemas"]["SignatureMethods"];
         };
         UserElement: {
             /** Format: int64 */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1064,10 +1064,24 @@ export type components = {
             label: string;
             name: string;
         };
+        SignatureMethodEmailToken: {
+            label: string;
+            /** @enum {string} */
+            identifyMethod: "email" | "account";
+            needCode: boolean;
+            hasConfirmCode: boolean;
+            blurredEmail: string;
+            hashOfEmail: string;
+        };
+        SignatureMethodPassword: {
+            label: string;
+            name: string;
+            hasSignatureFile: boolean;
+        };
         SignatureMethods: {
             clickToSign?: components["schemas"]["SignatureMethod"];
-            emailToken?: components["schemas"]["SignatureMethod"];
-            password?: components["schemas"]["SignatureMethod"];
+            emailToken?: components["schemas"]["SignatureMethodEmailToken"];
+            password?: components["schemas"]["SignatureMethodPassword"];
         };
         Signer: {
             description: string | null;
@@ -1083,7 +1097,7 @@ export type components = {
             signRequestId: number;
             identifyMethods?: components["schemas"]["IdentifyMethod"][];
             visibleElements?: components["schemas"]["VisibleElement"][];
-            signatureMethods?: components["schemas"]["SignatureMethods"][];
+            signatureMethods?: components["schemas"]["SignatureMethods"];
         };
         UserElement: {
             /** Format: int64 */

--- a/src/views/Settings/Settings.vue
+++ b/src/views/Settings/Settings.vue
@@ -18,6 +18,7 @@
 		<IdentificationDocuments />
 		<CollectMetadata />
 		<DefaultUserFolder />
+		<SignatureHashAlgorithm />
 	</NcSettingsSection>
 </template>
 
@@ -36,6 +37,7 @@ import IdentificationFactors from './IdentificationFactors.vue'
 import LegalInformation from './LegalInformation.vue'
 import RootCertificateCfssl from './RootCertificateCfssl.vue'
 import RootCertificateOpenSsl from './RootCertificateOpenSsl.vue'
+import SignatureHashAlgorithm from './SignatureHashAlgorithm.vue'
 import Validation from './Validation.vue'
 
 export default {
@@ -55,6 +57,7 @@ export default {
 		IdentificationDocuments,
 		CollectMetadata,
 		DefaultUserFolder,
+		SignatureHashAlgorithm,
 	},
 	data() {
 		return {

--- a/src/views/Settings/SignatureHashAlgorithm.vue
+++ b/src/views/Settings/SignatureHashAlgorithm.vue
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 LibreCode coop and LibreCode contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcSettingsSection :name="name" :description="description">
+		<NcSelect :key="idKey"
+			v-model="selected"
+			label="displayname"
+			:no-wrap="false"
+			:aria-label-combobox="description"
+			:close-on-select="false"
+			:disabled="loading"
+			:loading="loading"
+			required
+			:options="hashes"
+			:show-no-options="false"
+			@update:modelValue="saveSignatureHash" />
+	</NcSettingsSection>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { translate as t } from '@nextcloud/l10n'
+import { confirmPassword } from '@nextcloud/password-confirmation'
+import { generateOcsUrl } from '@nextcloud/router'
+
+import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
+import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection.js'
+
+import '@nextcloud/password-confirmation/dist/style.css'
+
+export default {
+	name: 'SignatureHashAlgorithm',
+	components: {
+		NcSettingsSection,
+		NcSelect,
+	},
+
+	data: () => ({
+		name: t('libresign', 'Signature hash algorithm'),
+		description: t('libresign', 'Hash algorithm used for signature.'),
+		selected: [],
+		hashes: ['SHA1', 'SHA256', 'SHA384', 'SHA512', 'RIPEMD160'],
+		loading: false,
+		idKey: 0,
+	}),
+
+	mounted() {
+		this.getData()
+	},
+
+	methods: {
+		async getData() {
+			this.loading = true
+			const response = await axios.get(
+				generateOcsUrl('/apps/provisioning_api/api/v1/config/apps/libresign/signature_hash_algorithm'),
+			)
+			this.selected = this.hashes.includes(response.data.ocs.data.data)
+				? response.data.ocs.data.data
+				: 'SHA256'
+			this.loading = false
+		},
+
+		async saveSignatureHash() {
+			await confirmPassword()
+
+			const selected = this.hashes.includes(this.selected) ? this.selected : 'SHA256'
+			OCP.AppConfig.setValue('libresign', 'signature_hash_algorithm', selected)
+			this.idKey += 1
+		},
+	},
+
+}
+</script>

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -283,9 +283,12 @@ export default {
 					}
 				})
 				.catch((err) => {
-					err.response.data.ocs.data.errors.forEach(err => {
-						showError(err)
-					})
+					const errors = err.response?.data?.ocs?.data?.errors;
+					if (errors) {
+						errors.forEach(error => {
+							showError(error);
+						});
+					}
 				})
 			this.loading = false
 		},

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -283,11 +283,11 @@ export default {
 					}
 				})
 				.catch((err) => {
-					const errors = err.response?.data?.ocs?.data?.errors;
+					const errors = err.response?.data?.ocs?.data?.errors
 					if (errors) {
 						errors.forEach(error => {
-							showError(error);
-						});
+							showError(error)
+						})
 					}
 				})
 			this.loading = false


### PR DESCRIPTION
The default hash algorithm of JSignPdf is SHA1 and with this change was defined SHA256 as default hash algorithm and make possible choose between the allowed algorithms: SHA1, SHA256, SHA384, SHA512, RIPEMD160.

Follow the compatibility analysis with different algorithms of documents signed by LibreSign. The follow analysis was made at https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/validation

|SHA1 :red_circle:  |SHA256 :green_circle: |RIPEMD160 :red_circle: |
|---|---|---|
|![Screenshot_20241223_205949](https://github.com/user-attachments/assets/3607d27a-9cb0-4042-8183-eae99631bd1c)|![Screenshot_20241223_205936](https://github.com/user-attachments/assets/2f44d5f8-46f4-4506-9082-3dc48bb023da)|![Screenshot_20241224_001655](https://github.com/user-attachments/assets/4fe5ac2d-d471-49ab-894f-c3e0e9557e44)|

Was made performance tests making 30 signatures in sequence by CLI and was got a very similar output that can't be considered as impact between usage of SHA1 and SHA256.

To don't throw the follow message, was implemented a logic to identify the right algorithm to sign the document depending of PDF version but the implemented algorithm usign the prefix of PDF file, isn't effective. The most effective way to identify the pdf version is using the command pdfinfo of poppler-utils.

![Screenshot_20241223_210412](https://github.com/user-attachments/assets/e38024c7-291d-4f5e-aa1d-27373fa666ba)

For now, JSignPDF haven't support to `PDF-2.0`

The way to add the footer with qr-code as stamp over a PDF file, is generated using mPDF that only generate `PDF-1.4`.

The current way to add a stamp to PDF with footer using PDFtk, sometimes could reduce the version to `PDF-1.0` when put the footer.