### PR TITLE
fix: remove extension from filename

### DIFF
--- a/src/Components/Request/RequestPicker.vue
+++ b/src/Components/Request/RequestPicker.vue
@@ -187,7 +187,7 @@ export default {
 		async upload(file) {
 			const data = await loadFileToBase64(file)
 			await this.filesStore.upload({
-				name: file.name,
+				name: file.name.replace(/\.pdf$/i, ''),
 				file: data,
 			})
 				.then((response) => {


### PR DESCRIPTION
When upload a file, the extension is removed to don't have a document called `file.pdf.pdf`

Maybe will be necessary do the same at backend side.