### PR TITLE
fix: fetch signature methods

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -125,10 +125,23 @@ namespace OCA\Libresign;
  *     label: string,
  *     name: string,
  * }
+ * @psalm-type LibresignSignatureMethodEmailToken = array{
+ *     label: string,
+ *     identifyMethod: "email"|"account",
+ *     needCode: bool,
+ *     hasConfirmCode: bool,
+ *     blurredEmail: string,
+ *     hashOfEmail: string,
+ * }
+ * @psalm-type LibresignSignatureMethodPassword = array{
+ *     label: string,
+ *     name: string,
+ *     hasSignatureFile: bool,
+ * }
  * @psalm-type LibresignSignatureMethods = array{
  *     clickToSign?: LibresignSignatureMethod,
- *     emailToken?: LibresignSignatureMethod,
- *     password?: LibresignSignatureMethod,
+ *     emailToken?: LibresignSignatureMethodEmailToken,
+ *     password?: LibresignSignatureMethodPassword,
  * }
  * @psalm-type LibresignSigner = array{
  *     description: ?string,
@@ -143,7 +156,7 @@ namespace OCA\Libresign;
  *     signRequestId: non-negative-int,
  *     identifyMethods?: LibresignIdentifyMethod[],
  *     visibleElements?: LibresignVisibleElement[],
- *     signatureMethods?: LibresignSignatureMethods[],
+ *     signatureMethods?: LibresignSignatureMethods,
  * }
  * @psalm-type LibresignValidateFile = array{
  *     uuid: string,

--- a/lib/Service/IdentifyMethodService.php
+++ b/lib/Service/IdentifyMethodService.php
@@ -178,9 +178,6 @@ class IdentifyMethodService {
 		$return = [];
 		foreach ($matrix as $identifyMethods) {
 			foreach ($identifyMethods as $identifyMethod) {
-				if (empty($identifyMethod->getEntity()->getIdentifiedAtDate())) {
-					continue;
-				}
 				$signatureMethods = $identifyMethod->getSignatureMethods();
 				foreach ($signatureMethods as $signatureMethod) {
 					if (!$signatureMethod->isEnabled()) {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -612,6 +612,60 @@
                     }
                 }
             },
+            "SignatureMethodEmailToken": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "identifyMethod",
+                    "needCode",
+                    "hasConfirmCode",
+                    "blurredEmail",
+                    "hashOfEmail"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "identifyMethod": {
+                        "type": "string",
+                        "enum": [
+                            "email",
+                            "account"
+                        ]
+                    },
+                    "needCode": {
+                        "type": "boolean"
+                    },
+                    "hasConfirmCode": {
+                        "type": "boolean"
+                    },
+                    "blurredEmail": {
+                        "type": "string"
+                    },
+                    "hashOfEmail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SignatureMethodPassword": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "name",
+                    "hasSignatureFile"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "hasSignatureFile": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "SignatureMethods": {
                 "type": "object",
                 "properties": {
@@ -619,10 +673,10 @@
                         "$ref": "#/components/schemas/SignatureMethod"
                     },
                     "emailToken": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodEmailToken"
                     },
                     "password": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodPassword"
                     }
                 }
             },
@@ -685,10 +739,7 @@
                         }
                     },
                     "signatureMethods": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SignatureMethods"
-                        }
+                        "$ref": "#/components/schemas/SignatureMethods"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -516,6 +516,60 @@
                     }
                 }
             },
+            "SignatureMethodEmailToken": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "identifyMethod",
+                    "needCode",
+                    "hasConfirmCode",
+                    "blurredEmail",
+                    "hashOfEmail"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "identifyMethod": {
+                        "type": "string",
+                        "enum": [
+                            "email",
+                            "account"
+                        ]
+                    },
+                    "needCode": {
+                        "type": "boolean"
+                    },
+                    "hasConfirmCode": {
+                        "type": "boolean"
+                    },
+                    "blurredEmail": {
+                        "type": "string"
+                    },
+                    "hashOfEmail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SignatureMethodPassword": {
+                "type": "object",
+                "required": [
+                    "label",
+                    "name",
+                    "hasSignatureFile"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "hasSignatureFile": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "SignatureMethods": {
                 "type": "object",
                 "properties": {
@@ -523,10 +577,10 @@
                         "$ref": "#/components/schemas/SignatureMethod"
                     },
                     "emailToken": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodEmailToken"
                     },
                     "password": {
-                        "$ref": "#/components/schemas/SignatureMethod"
+                        "$ref": "#/components/schemas/SignatureMethodPassword"
                     }
                 }
             },
@@ -589,10 +643,7 @@
                         }
                     },
                     "signatureMethods": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SignatureMethods"
-                        }
+                        "$ref": "#/components/schemas/SignatureMethods"
                     }
                 }
             },

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1210,10 +1210,24 @@ export type components = {
             label: string;
             name: string;
         };
+        SignatureMethodEmailToken: {
+            label: string;
+            /** @enum {string} */
+            identifyMethod: "email" | "account";
+            needCode: boolean;
+            hasConfirmCode: boolean;
+            blurredEmail: string;
+            hashOfEmail: string;
+        };
+        SignatureMethodPassword: {
+            label: string;
+            name: string;
+            hasSignatureFile: boolean;
+        };
         SignatureMethods: {
             clickToSign?: components["schemas"]["SignatureMethod"];
-            emailToken?: components["schemas"]["SignatureMethod"];
-            password?: components["schemas"]["SignatureMethod"];
+            emailToken?: components["schemas"]["SignatureMethodEmailToken"];
+            password?: components["schemas"]["SignatureMethodPassword"];
         };
         Signer: {
             description: string | null;
@@ -1229,7 +1243,7 @@ export type components = {
             signRequestId: number;
             identifyMethods?: components["schemas"]["IdentifyMethod"][];
             visibleElements?: components["schemas"]["VisibleElement"][];
-            signatureMethods?: components["schemas"]["SignatureMethods"][];
+            signatureMethods?: components["schemas"]["SignatureMethods"];
         };
         UserElement: {
             /** Format: int64 */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1064,10 +1064,24 @@ export type components = {
             label: string;
             name: string;
         };
+        SignatureMethodEmailToken: {
+            label: string;
+            /** @enum {string} */
+            identifyMethod: "email" | "account";
+            needCode: boolean;
+            hasConfirmCode: boolean;
+            blurredEmail: string;
+            hashOfEmail: string;
+        };
+        SignatureMethodPassword: {
+            label: string;
+            name: string;
+            hasSignatureFile: boolean;
+        };
         SignatureMethods: {
             clickToSign?: components["schemas"]["SignatureMethod"];
-            emailToken?: components["schemas"]["SignatureMethod"];
-            password?: components["schemas"]["SignatureMethod"];
+            emailToken?: components["schemas"]["SignatureMethodEmailToken"];
+            password?: components["schemas"]["SignatureMethodPassword"];
         };
         Signer: {
             description: string | null;
@@ -1083,7 +1097,7 @@ export type components = {
             signRequestId: number;
             identifyMethods?: components["schemas"]["IdentifyMethod"][];
             visibleElements?: components["schemas"]["VisibleElement"][];
-            signatureMethods?: components["schemas"]["SignatureMethods"][];
+            signatureMethods?: components["schemas"]["SignatureMethods"];
         };
         UserElement: {
             /** Format: int64 */


### PR DESCRIPTION
When we make a patch at a signature request, the signature method need to be always returned and this continue was removing the signature methods from return object.

Side effects of previous code: When I make a patch of herself sign request, I can't sign the document if the file list wasn't updated because the signature methods is returned to each element when we are listing the files. With this change is possible to return the signature methods after I'm added to be a signer and go ahead to sign the document.