### PR TITLE
fix: notify by email when is not authenticated

### DIFF
--- a/lib/Listener/MailNotifyListener.php
+++ b/lib/Listener/MailNotifyListener.php
@@ -17,7 +17,6 @@ use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
 use OCA\Libresign\Service\MailService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -50,10 +49,6 @@ class MailNotifyListener implements IEventListener {
 		FileEntity $libreSignFile,
 		IIdentifyMethod $identifyMethod,
 	): void {
-		$actor = $this->userSession->getUser();
-		if (!$actor instanceof IUser) {
-			return;
-		}
 		try {
 			if ($identifyMethod->getEntity()->isDeletedAccount()) {
 				return;


### PR DESCRIPTION
When the user is not authenticated, is necessary to send notification by email after renew the duration of sign request

Steps to reproduce:
- At Administration Settings > LibreSign
  - Enable email as identification method
  - set renewal interval to 5 seconds
- Send a sign request to an email that haven't any account associated
- Access the link received by email after 5 seconds
- Click at the button to renew the sign link

Expected behavior:
- You need to receive an email

Behavior before fix:
- The email wasn't sent