### PR TITLE
fix: prevent js error

### DIFF
--- a/src/Components/RightSidebar/SignTab.vue
+++ b/src/Components/RightSidebar/SignTab.vue
@@ -52,7 +52,7 @@ export default {
 		},
 		onSigned(data) {
 			this.$router.push({
-				name: 'ValidationFile',
+				name: this.$route.path.startsWith('/p/') ? 'ValidationFileExternal' : 'ValidationFile',
 				params: {
 					uuid: data.file.uuid,
 					isAfterSigned: true,


### PR DESCRIPTION
After sign with unauthenticated signer, the validation page need to be the external.