### PR TITLE
fix: prevent error when add new signer

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -199,6 +199,9 @@ export const useFilesStore = function(...args) {
 			},
 			signerUpdate(signer) {
 				this.addIdentifierToSigner(signer)
+				if (!this.getFile().signers?.length) {
+					this.getFile().signers = []
+				}
 				// Remove if already exists
 				for (let i = this.getFile().signers.length - 1; i >= 0; i--) {
 					if (this.getFile().signers[i].identify === signer.identify) {


### PR DESCRIPTION
At listing of sign request immediately after then is uploaded a file to request a new signature, the frontend iterate at signers array but signers wasn't initialized at this moment.

Was added a check preventing access to undefined property.