### PR TITLE
fix: migration column

### DIFF
--- a/lib/Migration/Version11000Date20250114182030.php
+++ b/lib/Migration/Version11000Date20250114182030.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\ITempManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version11000Date20250114182030 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $connection,
+		private ITempManager $tempManager,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		// // reset table
+		// $delete1 = $this->connection->getQueryBuilder();
+		// $delete1
+		// 	->delete('libresign_identify_method');
+		// $delete1->executeStatement();
+		// $identifyMethods = [];
+		// if (($handle = fopen('backup.csv', 'r')) !== FALSE) {
+		// 	$keys = fgetcsv($handle);
+		// 	while (($values = fgetcsv($handle)) !== FALSE) {
+		// 		$identifyMethods[] = array_combine($keys, $values);
+		// 	}
+		// 	fclose($handle);
+		// }
+		// $insert1 = $this->connection->getQueryBuilder();
+		// $exists = [];
+		// foreach ($identifyMethods as $key => $row) {
+		// 	if (in_array($row['id'], $exists)) {
+		// 		continue;
+		// 	}
+		// 	$exists[] = $row['id'];
+		// 	$insert1
+		// 		->insert('libresign_identify_method')
+		// 		->values([
+		// 			'id' => $insert1->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT),
+		// 			'mandatory' => $insert1->createNamedParameter($row['mandatory'], IQueryBuilder::PARAM_INT),
+		// 			'code' => $insert1->createNamedParameter(!empty($row['code']) ? $row['code'] : null),
+		// 			'identifier_key' => $insert1->createNamedParameter($row['identifier_key']),
+		// 			'identifier_value' => $insert1->createNamedParameter($row['identifier_value']),
+		// 			'attempts' => $insert1->createNamedParameter($row['attempts'], IQueryBuilder::PARAM_INT),
+		// 			'identified_at_date' => $insert1->createNamedParameter(!empty($row['identified_at_date']) ? $row['identified_at_date'] : null),
+		// 			'last_attempt_date' => $insert1->createNamedParameter(!empty($row['last_attempt_date']) ? $row['last_attempt_date'] : null),
+		// 			'sign_request_id' => $insert1->createNamedParameter($row['sign_request_id'], IQueryBuilder::PARAM_INT),
+		// 			'metadata' => $insert1->createNamedParameter(!empty($row['metadata']) ? $row['metadata'] : null, IQueryBuilder::PARAM_JSON),
+		// 		])
+		// 		->executeStatement();
+		// }
+		// $backup = 'backup.csv';
+		// $maxId = 130;
+
+		// BACKUP BEGIN
+		$qb1 = $this->connection->getQueryBuilder();
+		$qb1
+			->select('lim.*')
+			->addSelect('lsr.id as fixed_id')
+			->from('libresign_identify_method', 'lim')
+			->leftJoin('lim', 'libresign_sign_request', 'lsr',
+				$qb1->expr()->andX(
+					$qb1->expr()->eq('lsr.file_id', 'lim.sign_request_id'),
+					$qb1->expr()->eq('lim.identified_at_date', 'lim.last_attempt_date'),
+					$qb1->expr()->neq('lim.sign_request_id', 'lsr.id'),
+					$qb1->expr()->eq($qb1->createFunction($this->convertToEpoch('lim.last_attempt_date')), 'lsr.signed')
+				)
+			)
+			->orderBy('lim.id');
+		$result = $qb1->executeQuery();
+		$identifyMethods = [];
+		$backup = $this->tempManager->getTemporaryFile('.csv');
+		$maxId = 0;
+		$fp = fopen($backup, 'w');
+		$row = $result->fetch();
+		$identifyMethods[] = $row;
+		fputcsv($fp, array_keys($row));
+		fputcsv($fp, $row);
+		while ($row = $result->fetch()) {
+			$identifyMethods[] = $row;
+			fputcsv($fp, $row);
+			if ($row['fixed_id']) {
+				if ($row['id'] > $maxId) {
+					$maxId = $row['id'];
+				}
+			}
+		}
+		fclose($fp);
+		$result->closeCursor();
+		// BACKUP END
+
+		// Delete bad rows
+		$delete1 = $this->connection->getQueryBuilder();
+		$delete1
+			->delete('libresign_identify_method')
+			->where($delete1->expr()->lte('id', $delete1->createNamedParameter($maxId, IQueryBuilder::PARAM_INT)));
+		$delete1->executeStatement();
+
+		// Insert fixed rows
+		$insert1 = $this->connection->getQueryBuilder();
+		$fixedConstraints = [];
+		$fixedIds = [];
+		foreach ($identifyMethods as $key => $row) {
+			if (!$row['fixed_id'] || $row['id'] > $maxId || in_array($row['id'], $fixedIds)) {
+				continue;
+			}
+			$fixedIds[] = $row['id'];
+			$constraint = $row['fixed_id'] . ',' . $row['identifier_key'] . ',' . $row['identifier_value'];
+			$fixedConstraints[] = $constraint;
+			$insert1
+				->insert('libresign_identify_method')
+				->values([
+					'id' => $insert1->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT),
+					'mandatory' => $insert1->createNamedParameter($row['mandatory'], IQueryBuilder::PARAM_INT),
+					'code' => $insert1->createNamedParameter(!empty($row['code']) ? $row['code'] : null),
+					'identifier_key' => $insert1->createNamedParameter($row['identifier_key']),
+					'identifier_value' => $insert1->createNamedParameter($row['identifier_value']),
+					'attempts' => $insert1->createNamedParameter($row['attempts'], IQueryBuilder::PARAM_INT),
+					'identified_at_date' => $insert1->createNamedParameter(!empty($row['identified_at_date']) ? $row['identified_at_date'] : null),
+					'last_attempt_date' => $insert1->createNamedParameter(!empty($row['last_attempt_date']) ? $row['last_attempt_date'] : null),
+					'sign_request_id' => $insert1->createNamedParameter($row['fixed_id'], IQueryBuilder::PARAM_INT),
+					'metadata' => $insert1->createNamedParameter(!empty($row['metadata']) ? $row['metadata'] : null, IQueryBuilder::PARAM_JSON),
+				])
+				->executeStatement();
+			unset($identifyMethods[$key]);
+		}
+
+		// Insert non fixed rows
+		$insertedNonFixed = [];
+		foreach ($identifyMethods as $key => $row) {
+			if ($row['fixed_id'] || $row['id'] > $maxId || in_array($row['id'], $fixedIds)) {
+				continue;
+			}
+			$constraint = $row['sign_request_id'] . ',' . $row['identifier_key'] . ',' . $row['identifier_value'];
+			if (in_array($constraint, $fixedConstraints)) {
+				continue;
+			}
+			$insertedNonFixed[] = $constraint;
+			$insert1
+				->insert('libresign_identify_method')
+				->values([
+					'id' => $insert1->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT),
+					'mandatory' => $insert1->createNamedParameter($row['mandatory'], IQueryBuilder::PARAM_INT),
+					'code' => $insert1->createNamedParameter(!empty($row['code']) ? $row['code'] : null),
+					'identifier_key' => $insert1->createNamedParameter($row['identifier_key']),
+					'identifier_value' => $insert1->createNamedParameter($row['identifier_value']),
+					'attempts' => $insert1->createNamedParameter($row['attempts'], IQueryBuilder::PARAM_INT),
+					'identified_at_date' => $insert1->createNamedParameter(!empty($row['identified_at_date']) ? $row['identified_at_date'] : null),
+					'last_attempt_date' => $insert1->createNamedParameter(!empty($row['last_attempt_date']) ? $row['last_attempt_date'] : null),
+					'sign_request_id' => $insert1->createNamedParameter($row['sign_request_id'], IQueryBuilder::PARAM_INT),
+					'metadata' => $insert1->createNamedParameter(!empty($row['metadata']) ? $row['metadata'] : null, IQueryBuilder::PARAM_JSON),
+				])
+				->executeStatement();
+			unset($identifyMethods[$key]);
+		}
+	}
+
+	private function convertToEpoch(string $datetime): string {
+		return match ($this->connection->getDatabaseProvider()) {
+			IDBConnection::PLATFORM_MYSQL => "UNIX_TIMESTAMP($datetime)",
+			IDBConnection::PLATFORM_POSTGRES => "EXTRACT(EPOCH FROM $datetime)",
+			IDBConnection::PLATFORM_ORACLE => "(CAST((TO_DATE($datetime, 'YYYY-MM-DD HH24:MI:SS') - TO_DATE('1970-01-01', 'YYYY-MM-DD')) * 86400 AS NUMBER))",
+			IDBConnection::PLATFORM_SQLITE => "STRFTIME('%s', $datetime)",
+			default => $datetime,
+		};
+	}
+}

--- a/lib/Migration/Version8000Date20230420125331.php
+++ b/lib/Migration/Version8000Date20230420125331.php
@@ -102,7 +102,7 @@ class Version8000Date20230420125331 extends SimpleMigrationStep {
 		while ($row = $result->fetch()) {
 			$insert
 				->values([
-					'file_user_id' => $insert->createNamedParameter($row['file_id'], IQueryBuilder::PARAM_INT),
+					'file_user_id' => $insert->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT),
 					'mandatory' => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
 					'identifier_key' => $insert->createNamedParameter('account'),
 					'identifier_value' => $insert->createNamedParameter($row['user_id']),
@@ -125,7 +125,7 @@ class Version8000Date20230420125331 extends SimpleMigrationStep {
 		while ($row = $result->fetch()) {
 			$insert
 				->values([
-					'file_user_id' => $insert->createNamedParameter($row['file_id'], IQueryBuilder::PARAM_INT),
+					'file_user_id' => $insert->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT),
 					'mandatory' => $insert->createNamedParameter(1, IQueryBuilder::PARAM_INT),
 					'identifier_key' => $insert->createNamedParameter('email'),
 					'identifier_value' => $insert->createNamedParameter($row['email']),


### PR DESCRIPTION
When was published the biggest release 8 of LibreSign, was made a mistake and the column name was changed causing inconsistent data at old registers.

Because haven't backup of old data, I made a workaround to restore the possible data considering that at migration Version8000Date20230420125331.php the field `signed` was used to fill identified_at_date and last_attempt_date.

This fix only will affect the problematic rows.