### PR TITLE
fix: prevent kill webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = merge(nextcloudWebpackConfig, {
 	},
 	optimization: {
 		splitChunks: {
+			chunks: 'all',
 			cacheGroups: {
 				defaultVendors: {
 					reuseExistingChunk: true,


### PR DESCRIPTION
This will split in smaller bundles