### PR TITLE
fix: submit on click

### DIFF
--- a/src/Components/Request/RequestPicker.vue
+++ b/src/Components/Request/RequestPicker.vue
@@ -58,7 +58,8 @@
 			<template #actions>
 				<NcButton :disabled="!canUploadFronUrl"
 					type="primary"
-					native-type="submit">
+					native-type="submit"
+					@click="uploadUrl()">
 					{{ t('libresign', 'Send') }}
 					<template #icon>
 						<NcLoadingIcon v-if="loading" :size="20" />

--- a/src/views/CreatePassword.vue
+++ b/src/views/CreatePassword.vue
@@ -16,6 +16,7 @@
 		<template #actions>
 			<NcButton :disabled="hasLoading"
 				native-type="submit"
+				@click="send()"
 				type="primary">
 				<template #icon>
 					<NcLoadingIcon v-if="hasLoading" :size="20" />

--- a/src/views/ReadCertificate.vue
+++ b/src/views/ReadCertificate.vue
@@ -85,6 +85,7 @@
 		<template v-if="Object.keys(certificateData).length === 0" #actions>
 			<NcButton :disabled="hasLoading"
 				native-type="submit"
+				@click="send()"
 				type="primary">
 				<template #icon>
 					<NcLoadingIcon v-if="hasLoading" :size="20" />

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -22,6 +22,7 @@
 			<NcButton :disabled="!canSave"
 				:class="hasLoading ? 'btn-load loading primary btn-confirm' : 'primary btn-confirm'"
 				native-type="submit"
+				@click="send()"
 				type="primary">
 				<template #icon>
 					<NcLoadingIcon v-if="hasLoading" :size="20" />

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -79,7 +79,8 @@
 			<template #actions>
 				<NcButton type="primary"
 					:disabled="signPassword.length < 3 || loading"
-					native-type="submit">
+					native-type="submit"
+					@click="signWithPassword()">
 					<template #icon>
 						<NcLoadingIcon v-if="loading" :size="20" />
 					</template>


### PR DESCRIPTION
At previous change was added the native type equals to submit to all buttons, but at some buttons the click action stopped to work. The click action was added again.