### PR TITLE
fix: display error at same route

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,8 @@
 	<NcContent app-name="libresign" :class="{'sign-external-page': isSignExternalPage}">
 		<LeftSidebar />
 		<NcAppContent :class="{'icon-loading' : loading }">
-			<router-view v-if="!loading" :key="$route.name " :loading.sync="loading" />
+			<DefaultPageError v-if="isDoNothingError" />
+			<router-view v-else-if="!loading" :key="$route.name " :loading.sync="loading" />
 			<NcEmptyContent v-if="isRoot" :description="t('libresign', 'LibreSign, digital signature app for Nextcloud.')">
 				<template #icon>
 					<img :src="LogoLibreSign">
@@ -25,6 +26,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 
 import LeftSidebar from './Components/LeftSidebar/LeftSidebar.vue'
 import RightSidebar from './Components/RightSidebar/RightSidebar.vue'
+import DefaultPageError from './views/DefaultPageError.vue'
 
 import LogoLibreSign from './../img/logo-gray.svg'
 
@@ -36,6 +38,7 @@ export default {
 		NcEmptyContent,
 		LeftSidebar,
 		RightSidebar,
+		DefaultPageError,
 	},
 	data() {
 		return {
@@ -49,6 +52,9 @@ export default {
 		},
 		isSignExternalPage() {
 			return this.$route.path.startsWith('/p/')
+		},
+		isDoNothingError() {
+			return this.$route.params?.action === 2000
 		},
 	},
 }

--- a/src/helpers/SelectAction.js
+++ b/src/helpers/SelectAction.js
@@ -19,7 +19,7 @@ export const selectAction = (action, to, from) => {
 	case 1500: // ACTION_CREATE_ACCOUNT
 		return 'CreateAccount' + external
 	case 2000: // ACTION_DO_NOTHING
-		return 'DefaultPageError' + external
+		return to.name
 	case 2500: // ACTION_SIGN
 		return 'SignPDF' + external
 	case 2625: // ACTION_SIGN_INTERNAL

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -63,7 +63,7 @@ const router = new Router({
 			props: true,
 		},
 		{
-			path: '/p/sign/:uuid/error',
+			path: '/p/error',
 			name: 'DefaultPageErrorExternal',
 			component: () => import('../views/DefaultPageError.vue'),
 			props: true,
@@ -76,6 +76,12 @@ const router = new Router({
 		{
 			path: '/p/validation/:uuid',
 			name: 'ValidationFileExternal',
+			component: () => import('../views/Validation.vue'),
+			props: true,
+		},
+		{
+			path: '/validation/:uuid',
+			name: 'ValidationFileShortUrl',
 			component: () => import('../views/Validation.vue'),
 			props: true,
 		},
@@ -191,7 +197,8 @@ router.beforeEach((to, from, next) => {
 	const actionElement = document.querySelector('#initial-state-libresign-action')
 	let action
 	if (actionElement) {
-		action = selectAction(loadState('libresign', 'action', ''), to, from)
+		to.params.action = loadState('libresign', 'action', '')
+		action = selectAction(to.params.action, to, from)
 		document.querySelector('#initial-state-libresign-action')?.remove()
 	}
 	if (Object.hasOwn(to, 'name') && typeof to.name === 'string' && !to.name.endsWith('External') && isExternal(to, from)) {


### PR DESCRIPTION
To display an error is necessary to be displayed at the same route. The previous behavior was changing the path and generating strange side effects.