### PR TITLE
refactor: moved version of JSignPdf to InstallService

### DIFF
--- a/lib/Handler/JSignPdfHandler.php
+++ b/lib/Handler/JSignPdfHandler.php
@@ -12,6 +12,7 @@ use Jeidison\JSignPDF\JSignPDF;
 use Jeidison\JSignPDF\Sign\JSignParam;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\Install\InstallService;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
@@ -20,7 +21,6 @@ class JSignPdfHandler extends SignEngineHandler {
 	private $jSignPdf;
 	/** @var JSignParam */
 	private $jSignParam;
-	public const VERSION = '2.3.0';
 
 	public function __construct(
 		private IAppConfig $appConfig,
@@ -53,7 +53,7 @@ class JSignPdfHandler extends SignEngineHandler {
 				)
 				->setIsUseJavaInstalled(empty($javaPath))
 				->setjSignPdfJarPath(
-					$this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path', '/opt/jsignpdf-' . self::VERSION . '/JSignPdf.jar')
+					$this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path', '/opt/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar')
 				);
 			if (!empty($javaPath)) {
 				if (!file_exists($javaPath)) {

--- a/lib/Service/Install/ConfigureCheckService.php
+++ b/lib/Service/Install/ConfigureCheckService.php
@@ -171,20 +171,20 @@ class ConfigureCheckService {
 				$jsignPdf = $this->jSignPdfHandler->getJSignPdf();
 				$jsignPdf->setParam($this->jSignPdfHandler->getJSignParam());
 				$currentVersion = $jsignPdf->getVersion();
-				if ($currentVersion < JSignPdfHandler::VERSION) {
+				if ($currentVersion < InstallService::JSIGNPDF_VERSION) {
 					if (!$currentVersion) {
-						$message = 'Necessary install the version ' . JSignPdfHandler::VERSION;
+						$message = 'Necessary install the version ' . InstallService::JSIGNPDF_VERSION;
 					} else {
-						$message = 'Necessary bump JSignPdf versin from ' . $currentVersion . ' to ' . JSignPdfHandler::VERSION;
+						$message = 'Necessary bump JSignPdf versin from ' . $currentVersion . ' to ' . InstallService::JSIGNPDF_VERSION;
 					}
 					$return[] = (new ConfigureCheckHelper())
 						->setErrorMessage($message)
 						->setResource('jsignpdf')
 						->setTip('Run occ libresign:install --jsignpdf');
 				}
-				if ($currentVersion > JSignPdfHandler::VERSION) {
+				if ($currentVersion > InstallService::JSIGNPDF_VERSION) {
 					$return[] = (new ConfigureCheckHelper())
-						->setErrorMessage('Necessary downgrade JSignPdf versin from ' . $currentVersion . ' to ' . JSignPdfHandler::VERSION)
+						->setErrorMessage('Necessary downgrade JSignPdf versin from ' . $currentVersion . ' to ' . InstallService::JSIGNPDF_VERSION)
 						->setResource('jsignpdf')
 						->setTip('Run occ libresign:install --jsignpdf');
 				}

--- a/lib/Service/Install/InstallService.php
+++ b/lib/Service/Install/InstallService.php
@@ -20,7 +20,6 @@ use OCA\Libresign\Handler\CertificateEngine\AEngineHandler;
 use OCA\Libresign\Handler\CertificateEngine\CfsslHandler;
 use OCA\Libresign\Handler\CertificateEngine\Handler as CertificateEngineHandler;
 use OCA\Libresign\Handler\CertificateEngine\IEngineHandler;
-use OCA\Libresign\Handler\JSignPdfHandler;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
@@ -43,6 +42,7 @@ class InstallService {
 	public const JAVA_VERSION = 'openjdk version "21.0.6" 2025-01-21 LTS';
 	private const JAVA_URL_PATH_NAME = '21.0.6+7';
 	public const PDFTK_VERSION = '3.3.3';
+	public const JSIGNPDF_VERSION = '2.3.0';
 	/**
 	 * When update, verify the hash of all architectures
 	 */
@@ -471,19 +471,19 @@ class InstallService {
 			if (!$this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path')) {
 				$folder = $this->getFolder($this->resource);
 				$extractDir = $this->getInternalPathOfFolder($folder);
-				$fullPath = $extractDir . '/jsignpdf-' . JSignPdfHandler::VERSION . '/JSignPdf.jar';
+				$fullPath = $extractDir . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar';
 				$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_jar_path', $fullPath);
 			}
 		} else {
 			$folder = $this->getFolder($this->resource);
-			$compressedFileName = 'jsignpdf-' . JSignPdfHandler::VERSION . '.zip';
+			$compressedFileName = 'jsignpdf-' . InstallService::JSIGNPDF_VERSION . '.zip';
 			try {
 				$compressedFile = $folder->getFile($compressedFileName);
 			} catch (\Throwable $th) {
 				$compressedFile = $folder->newFile($compressedFileName);
 			}
 			$comporessedInternalFileName = $this->getInternalPathOfFile($compressedFile);
-			$url = 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_' . str_replace('.', '_', JSignPdfHandler::VERSION) . '/jsignpdf-' . JSignPdfHandler::VERSION . '.zip';
+			$url = 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_' . str_replace('.', '_', InstallService::JSIGNPDF_VERSION) . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '.zip';
 			/** WHEN UPDATE version: generate this hash handmade and update here */
 			$hash = 'd239658ea50a39eb35169d8392feaffb';
 
@@ -493,7 +493,7 @@ class InstallService {
 			$zip = new ZIP($extractDir . '/' . $compressedFileName);
 			$zip->extract($extractDir);
 			unlink($extractDir . '/' . $compressedFileName);
-			$fullPath = $extractDir . '/jsignpdf-' . JSignPdfHandler::VERSION . '/JSignPdf.jar';
+			$fullPath = $extractDir . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar';
 			$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_jar_path', $fullPath);
 			$this->writeAppSignature();
 		}


### PR DESCRIPTION
All versions of dependencies stays at InstallService, because this the version of JSignPdf also was moved to this class.