### PR TITLE
add signer details to visible elements

### DIFF
--- a/lib/Controller/SignFileController.php
+++ b/lib/Controller/SignFileController.php
@@ -105,6 +105,7 @@ class SignFileController extends AEnvironmentAwareController implements ISignatu
 				$user,
 				$this->fileService->getIdentificationDocumentsStatus($user?->getUID())
 			);
+			$GLOBALS["currentSigner"] = $user;
 			$libreSignFile = $this->signFileService->getLibresignFile($fileId, $signRequestUuid);
 			$signRequest = $this->signFileService->getSignRequestToSign($libreSignFile, $signRequestUuid, $user);
 			$this->validateHelper->validateVisibleElementsRelation($elements, $signRequest, $user);


### PR DESCRIPTION
### Pull Request Description

Trying to add visible signature details like date, time, signer name, signer email.

As a proper `--l2-text` placement is almost impossible together with the signature as background image, I'm directly modifying the background image to add the signature details.

Things that need to be improved before merging:

- More elegant way to pass signer details (or session) down to `JSignPdfHandler.php`
- Use timezone of signer instead of static or system timezone
- Customizable text/details (?)
- Multilanguage support
- Custom font file to remove system font dependency

### Related Issue

Issue Number: https://github.com/LibreSign/libresign/issues/1766

### Pull Request Type

- Feature

### Pull request checklist

- [ ] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution
