### PR TITLE
fix: prevent error when collect metadata

### DIFF
--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -303,8 +303,8 @@ class SignFileService {
 			return $this;
 		}
 		$this->signRequest->setMetadata(array_merge(
+			$this->signRequest->getMetadata() ?? [],
 			$metadata,
-			$this->signRequest->getMetadata(),
 		));
 		$this->signRequestMapper->update($this->signRequest);
 		return $this;


### PR DESCRIPTION
If the metadata field of a sign request is null, the array_merge function will throws an error because wait for an array as argument.

I also identified after implement the tests that when exists a previous value and this value is changed, the order of array_merge was prioritizing the previous value and the new value never was saved. I flipped the arguments of array_merge to prevent this.