### PR TITLE
fix: prevent error when output of pdfsig is empty

### DIFF
--- a/lib/Handler/Pkcs12Handler.php
+++ b/lib/Handler/Pkcs12Handler.php
@@ -202,6 +202,9 @@ class Pkcs12Handler extends SignEngineHandler {
 		file_put_contents($tempFile, $content);
 
 		$content = shell_exec('pdfsig ' . $tempFile);
+		if (empty($content)) {
+			return [];
+		}
 		$lines = explode("\n", $content);
 
 		$lastSignature = 0;


### PR DESCRIPTION
ref: https://github.com/LibreSign/libresign/issues/4770#issuecomment-2790224178