### PR TITLE
feat: manage certificate policy

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -564,7 +564,7 @@ class AdminController extends AEnvironmentAwareController {
 			);
 		}
 		try {
-			$url = $this->certificatePolicyService->updateFile($pdf['tmp_name']);
+			$cps = $this->certificatePolicyService->updateFile($pdf['tmp_name']);
 		} catch (\Exception $e) {
 			return new DataResponse(
 				[
@@ -576,7 +576,7 @@ class AdminController extends AEnvironmentAwareController {
 		}
 		return new DataResponse(
 			[
-				'url' => $url,
+				'CPS' => $cps,
 				'status' => 'success',
 			]
 		);

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -32,6 +32,7 @@ use OCP\IEventSourceFactory;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
+use UnexpectedValueException;
 
 /**
  * @psalm-import-type LibresignEngineHandler from ResponseDefinitions
@@ -565,7 +566,7 @@ class AdminController extends AEnvironmentAwareController {
 		}
 		try {
 			$cps = $this->certificatePolicyService->updateFile($pdf['tmp_name']);
-		} catch (\Exception $e) {
+		} catch (UnexpectedValueException $e) {
 			return new DataResponse(
 				[
 					'message' => $e->getMessage(),

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -531,7 +531,7 @@ class AdminController extends AEnvironmentAwareController {
 	/**
 	 * Update certificate policy of this instance
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{status: 'success', url: string}, array{}>|DataResponse<Http::STATUS_UNPROCESSABLE_ENTITY, array{status: 'failure', message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{status: 'success', CPS: string}, array{}>|DataResponse<Http::STATUS_UNPROCESSABLE_ENTITY, array{status: 'failure', message: string}, array{}>
 	 *
 	 * 200: OK
 	 * 422: Not found

--- a/lib/Controller/CertificatePolicyController.php
+++ b/lib/Controller/CertificatePolicyController.php
@@ -14,75 +14,18 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
-use OCP\IL10N;
 use OCP\IRequest;
 
 class CertificatePolicyController extends Controller {
 	public function __construct(
 		IRequest $request,
 		private CertificatePolicyService $certificatePolicyService,
-		private IL10N $l10n,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-	}
-
-	/**
-	 * Update certificate policy of this instance
-	 *
-	 * @return DataResponse<Http::STATUS_OK, array{status: 'success'}, array{}>|DataResponse<Http::STATUS_UNPROCESSABLE_ENTITY, array{status: 'failure', message: string}, array{}>
-	 *
-	 * 200: OK
-	 * 404: Not found
-	 */
-	#[PublicPage]
-	#[AnonRateLimit(limit: 10, period: 60)]
-	#[FrontpageRoute(verb: 'POST', url: '/certificate-policy.pdf')]
-	public function saveCertificatePolicy(): DataResponse {
-		$pdf = $this->request->getUploadedFile('pdf');
-		$phpFileUploadErrors = [
-			UPLOAD_ERR_OK => $this->l10n->t('The file was uploaded'),
-			UPLOAD_ERR_INI_SIZE => $this->l10n->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
-			UPLOAD_ERR_FORM_SIZE => $this->l10n->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
-			UPLOAD_ERR_PARTIAL => $this->l10n->t('The file was only partially uploaded'),
-			UPLOAD_ERR_NO_FILE => $this->l10n->t('No file was uploaded'),
-			UPLOAD_ERR_NO_TMP_DIR => $this->l10n->t('Missing a temporary folder'),
-			UPLOAD_ERR_CANT_WRITE => $this->l10n->t('Could not write file to disk'),
-			UPLOAD_ERR_EXTENSION => $this->l10n->t('A PHP extension stopped the file upload'),
-		];
-		if (empty($pdf)) {
-			$error = $this->l10n->t('No file uploaded');
-		} elseif (!empty($pdf) && array_key_exists('error', $pdf) && $pdf['error'] !== UPLOAD_ERR_OK) {
-			$error = $phpFileUploadErrors[$pdf['error']];
-		}
-		if ($error !== null) {
-			return new DataResponse(
-				[
-					'message' => $error,
-					'status' => 'failure',
-				],
-				Http::STATUS_UNPROCESSABLE_ENTITY
-			);
-		}
-		try {
-			$this->certificatePolicyService->updateFile($pdf['tmp_name']);
-		} catch (\Exception $e) {
-			return new DataResponse(
-				[
-					'message' => $e->getMessage(),
-					'status' => 'failure',
-				],
-				Http::STATUS_UNPROCESSABLE_ENTITY
-			);
-		}
-
-		return new DataResponse(
-			[
-				'status' => 'success',
-			]
-		);
 	}
 
 	/**
@@ -94,6 +37,7 @@ class CertificatePolicyController extends Controller {
 	 * 404: Not found
 	 */
 	#[PublicPage]
+	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 10, period: 60)]
 	#[FrontpageRoute(verb: 'GET', url: '/certificate-policy.pdf')]
 	public function getCertificatePolicy(): FileDisplayResponse {

--- a/lib/Controller/CertificatePolicyController.php
+++ b/lib/Controller/CertificatePolicyController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2020-2024 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Controller;
+
+use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Service\CertificatePolicyService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+
+class CertificatePolicyController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private CertificatePolicyService $certificatePolicyService,
+		private IL10N $l10n,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	/**
+	 * Update certificate policy of this instance
+	 *
+	 * @return DataResponse<Http::STATUS_OK, array{status: 'success'}, array{}>|DataResponse<Http::STATUS_UNPROCESSABLE_ENTITY, array{status: 'failure', message: string}, array{}>
+	 *
+	 * 200: OK
+	 * 404: Not found
+	 */
+	#[PublicPage]
+	#[AnonRateLimit(limit: 10, period: 60)]
+	#[FrontpageRoute(verb: 'POST', url: '/certificate-policy.pdf')]
+	public function saveCertificatePolicy(): DataResponse {
+		$pdf = $this->request->getUploadedFile('pdf');
+		$phpFileUploadErrors = [
+			UPLOAD_ERR_OK => $this->l10n->t('The file was uploaded'),
+			UPLOAD_ERR_INI_SIZE => $this->l10n->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
+			UPLOAD_ERR_FORM_SIZE => $this->l10n->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
+			UPLOAD_ERR_PARTIAL => $this->l10n->t('The file was only partially uploaded'),
+			UPLOAD_ERR_NO_FILE => $this->l10n->t('No file was uploaded'),
+			UPLOAD_ERR_NO_TMP_DIR => $this->l10n->t('Missing a temporary folder'),
+			UPLOAD_ERR_CANT_WRITE => $this->l10n->t('Could not write file to disk'),
+			UPLOAD_ERR_EXTENSION => $this->l10n->t('A PHP extension stopped the file upload'),
+		];
+		if (empty($pdf)) {
+			$error = $this->l10n->t('No file uploaded');
+		} elseif (!empty($pdf) && array_key_exists('error', $pdf) && $pdf['error'] !== UPLOAD_ERR_OK) {
+			$error = $phpFileUploadErrors[$pdf['error']];
+		}
+		if ($error !== null) {
+			return new DataResponse(
+				[
+					'message' => $error,
+					'status' => 'failure',
+				],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
+		try {
+			$this->certificatePolicyService->updateFile($pdf['tmp_name']);
+		} catch (\Exception $e) {
+			return new DataResponse(
+				[
+					'message' => $e->getMessage(),
+					'status' => 'failure',
+				],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
+
+		return new DataResponse(
+			[
+				'status' => 'success',
+			]
+		);
+	}
+
+	/**
+	 * Certificate policy of this instance
+	 *
+	 * @return FileDisplayResponse<Http::STATUS_OK, array{Content-Disposition: 'inline; filename="certificate-policy.pdf"', Content-Type: 'application/pdf'}>|DataResponse<Http::STATUS_NOT_FOUND, array<empty>, array{}>
+	 *
+	 * 200: OK
+	 * 404: Not found
+	 */
+	#[PublicPage]
+	#[AnonRateLimit(limit: 10, period: 60)]
+	#[FrontpageRoute(verb: 'GET', url: '/certificate-policy.pdf')]
+	public function getCertificatePolicy(): FileDisplayResponse {
+		$file = $this->certificatePolicyService->getFile();
+		return new FileDisplayResponse($file, Http::STATUS_OK, [
+			'Content-Disposition' => 'inline; filename="certificate-policy.pdf"',
+			'Content-Type' => 'application/pdf',
+		]);
+	}
+}

--- a/lib/Controller/CertificatePolicyController.php
+++ b/lib/Controller/CertificatePolicyController.php
@@ -18,6 +18,7 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\Files\NotFoundException;
 use OCP\IRequest;
 
 class CertificatePolicyController extends Controller {
@@ -40,11 +41,15 @@ class CertificatePolicyController extends Controller {
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 10, period: 60)]
 	#[FrontpageRoute(verb: 'GET', url: '/certificate-policy.pdf')]
-	public function getCertificatePolicy(): FileDisplayResponse {
-		$file = $this->certificatePolicyService->getFile();
-		return new FileDisplayResponse($file, Http::STATUS_OK, [
-			'Content-Disposition' => 'inline; filename="certificate-policy.pdf"',
-			'Content-Type' => 'application/pdf',
-		]);
+	public function getCertificatePolicy(): FileDisplayResponse|DataResponse {
+		try {
+			$file = $this->certificatePolicyService->getFile();
+			return new FileDisplayResponse($file, Http::STATUS_OK, [
+				'Content-Disposition' => 'inline; filename="certificate-policy.pdf"',
+				'Content-Type' => 'application/pdf',
+			]);
+		} catch (NotFoundException $e) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
 	}
 }

--- a/lib/Handler/CertificateEngine/AEngineHandler.php
+++ b/lib/Handler/CertificateEngine/AEngineHandler.php
@@ -350,11 +350,11 @@ abstract class AEngineHandler implements IEngineHandler {
 	}
 
 	private function getCertificatePolicy(): array {
-		$return = ['policy_section' => []];
+		$return = ['policySection' => []];
 		$oid = $this->certificatePolicyService->getOid();
 		$cps = $this->certificatePolicyService->getCps();
 		if ($oid && $cps) {
-			$return['policy_section'][] = [
+			$return['policySection'][] = [
 				'OID' => $oid,
 				'CPS' => $cps,
 			];

--- a/lib/Handler/CertificateEngine/AEngineHandler.php
+++ b/lib/Handler/CertificateEngine/AEngineHandler.php
@@ -291,10 +291,12 @@ abstract class AEngineHandler implements IEngineHandler {
 		if (!$configPath) {
 			$this->appConfig->deleteKey(Application::APP_ID, 'config_path');
 		} else {
-			mkdir(
-				directory: $configPath,
-				recursive: true,
-			);
+			if (!is_dir($configPath)) {
+				mkdir(
+					directory: $configPath,
+					recursive: true,
+				);
+			}
 			$this->appConfig->setValueString(Application::APP_ID, 'config_path', $configPath);
 		}
 		$this->configPath = $configPath;

--- a/lib/Handler/CertificateEngine/AEngineHandler.php
+++ b/lib/Handler/CertificateEngine/AEngineHandler.php
@@ -291,6 +291,10 @@ abstract class AEngineHandler implements IEngineHandler {
 		if (!$configPath) {
 			$this->appConfig->deleteKey(Application::APP_ID, 'config_path');
 		} else {
+			mkdir(
+				directory: $configPath,
+				recursive: true,
+			);
 			$this->appConfig->setValueString(Application::APP_ID, 'config_path', $configPath);
 		}
 		$this->configPath = $configPath;

--- a/lib/Handler/CertificateEngine/CfsslHandler.php
+++ b/lib/Handler/CertificateEngine/CfsslHandler.php
@@ -16,6 +16,7 @@ use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CfsslServerHandler;
 use OCA\Libresign\Helper\ConfigureCheckHelper;
+use OCA\Libresign\Service\CertificatePolicyService;
 use OCA\Libresign\Service\Install\InstallService;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\IAppConfig;
@@ -46,8 +47,9 @@ class CfsslHandler extends AEngineHandler implements IEngineHandler {
 		protected IDateTimeFormatter $dateTimeFormatter,
 		protected ITempManager $tempManager,
 		protected CfsslServerHandler $cfsslServerHandler,
+		protected CertificatePolicyService $certificatePolicyService,
 	) {
-		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager);
+		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager, $certificatePolicyService);
 
 		$this->cfsslServerHandler->configCallback(fn () => $this->getConfigPath());
 	}

--- a/lib/Handler/CertificateEngine/CfsslHandler.php
+++ b/lib/Handler/CertificateEngine/CfsslHandler.php
@@ -37,7 +37,6 @@ class CfsslHandler extends AEngineHandler implements IEngineHandler {
 	protected $client;
 	protected $cfsslUri;
 	private string $binary = '';
-	private CfsslServerHandler $cfsslServerHandler;
 
 	public function __construct(
 		protected IConfig $config,
@@ -46,10 +45,10 @@ class CfsslHandler extends AEngineHandler implements IEngineHandler {
 		protected IAppDataFactory $appDataFactory,
 		protected IDateTimeFormatter $dateTimeFormatter,
 		protected ITempManager $tempManager,
+		protected CfsslServerHandler $cfsslServerHandler,
 	) {
 		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager);
 
-		$this->cfsslServerHandler = new CfsslServerHandler();
 		$this->cfsslServerHandler->configCallback(fn () => $this->getConfigPath());
 	}
 

--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -10,6 +10,7 @@ namespace OCA\Libresign\Handler\CertificateEngine;
 
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\ConfigureCheckHelper;
+use OCA\Libresign\Service\CertificatePolicyService;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\IAppConfig;
 use OCP\IConfig;
@@ -30,6 +31,7 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 		protected IAppDataFactory $appDataFactory,
 		protected IDateTimeFormatter $dateTimeFormatter,
 		protected ITempManager $tempManager,
+		protected CertificatePolicyService $certificatePolicyService,
 	) {
 		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager);
 	}
@@ -44,7 +46,8 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 		]);
 
 		$csr = openssl_csr_new($this->getCsrNames(), $privateKey, ['digest_alg' => 'sha256']);
-		$x509 = openssl_csr_sign($csr, null, $privateKey, $days = 365 * 5, ['digest_alg' => 'sha256']);
+		$options = $this->getRootCertOptions();
+		$x509 = openssl_csr_sign($csr, null, $privateKey, $days = 365 * 5, $options);
 
 		openssl_csr_export($csr, $csrout);
 		openssl_x509_export($x509, $certout);
@@ -55,6 +58,18 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 		$this->saveFile('ca-key.pem', $pkeyout);
 
 		return $pkeyout;
+	}
+
+	private function getRootCertOptions(): array {
+		$this->generateRootCertConfig();
+		$configPath = $this->getConfigPath();
+
+		$options = [
+			'digest_alg' => 'sha256',
+			'config' => $configPath . DIRECTORY_SEPARATOR . 'openssl.cnf',
+			'x509_extensions' => 'v3_ca',
+		];
+		return $options;
 	}
 
 	public function generateCertificate(): string {
@@ -105,16 +120,51 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 				'subjectAltName' => $this->getSubjectAltNames(),
 				'authorityKeyIdentifier' => 'keyid',
 				'subjectKeyIdentifier' => 'hash',
-				// @todo Implement a feature to define this PDF at Administration Settings
-				// 'certificatePolicies' => '<policyOID> CPS: http://url/with/policy/informations.pdf',
-			]
+			],
 		];
+		$oid = $this->certificatePolicyService->getOid();
+		$url = $this->certificatePolicyService->getUrl();
+		if ($oid && $url) {
+			$config['v3_req']['certificatePolicies'] = '@policy_section';
+			$config['policy_section'] = [
+				'policyIdentifier' => $oid,
+				'CPS.1' => $url,
+			];
+		}
 		if (empty($config['v3_req']['subjectAltName'])) {
 			unset($config['v3_req']['subjectAltName']);
 		}
 		$config = $this->arrayToIni($config);
 		file_put_contents($temporaryFile, $config);
 		return $temporaryFile;
+	}
+
+	private function generateRootCertConfig(): void {
+		// More information about x509v3: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html
+		$config = [
+			'v3_ca' => [
+				'basicConstraints' => 'critical, CA:TRUE',
+				'keyUsage' => 'critical, digitalSignature, keyCertSign',
+				'extendedKeyUsage' => 'clientAuth, emailProtection',
+				'subjectAltName' => $this->getSubjectAltNames(),
+				'authorityKeyIdentifier' => 'keyid',
+				'subjectKeyIdentifier' => 'hash',
+			],
+		];
+		$oid = $this->certificatePolicyService->getOid();
+		$url = $this->certificatePolicyService->getUrl();
+		if ($oid && $url) {
+			$config['v3_ca']['certificatePolicies'] = '@policy_section';
+			$config['policy_section'] = [
+				'policyIdentifier' => $oid,
+				'CPS.1' => $url,
+			];
+		}
+		if (empty($config['v3_ca']['subjectAltName'])) {
+			unset($config['v3_ca']['subjectAltName']);
+		}
+		$iniContent = $this->arrayToIni($config);
+		$this->saveFile('openssl.cnf', $iniContent);
 	}
 
 	private function arrayToIni(array $config) {

--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -33,7 +33,7 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 		protected ITempManager $tempManager,
 		protected CertificatePolicyService $certificatePolicyService,
 	) {
-		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager);
+		parent::__construct($config, $appConfig, $appDataFactory, $dateTimeFormatter, $tempManager, $certificatePolicyService);
 	}
 
 	public function generateRootCert(
@@ -123,12 +123,12 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 			],
 		];
 		$oid = $this->certificatePolicyService->getOid();
-		$url = $this->certificatePolicyService->getUrl();
-		if ($oid && $url) {
+		$cps = $this->certificatePolicyService->getCps();
+		if ($oid && $cps) {
 			$config['v3_req']['certificatePolicies'] = '@policy_section';
 			$config['policy_section'] = [
 				'policyIdentifier' => $oid,
-				'CPS.1' => $url,
+				'CPS.1' => $cps,
 			];
 		}
 		if (empty($config['v3_req']['subjectAltName'])) {
@@ -152,12 +152,12 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 			],
 		];
 		$oid = $this->certificatePolicyService->getOid();
-		$url = $this->certificatePolicyService->getUrl();
-		if ($oid && $url) {
+		$cps = $this->certificatePolicyService->getCps();
+		if ($oid && $cps) {
 			$config['v3_ca']['certificatePolicies'] = '@policy_section';
 			$config['policy_section'] = [
 				'policyIdentifier' => $oid,
-				'CPS.1' => $url,
+				'CPS.1' => $cps,
 			];
 		}
 		if (empty($config['v3_ca']['subjectAltName'])) {

--- a/lib/Handler/CfsslServerHandler.php
+++ b/lib/Handler/CfsslServerHandler.php
@@ -10,12 +10,18 @@ namespace OCA\Libresign\Handler;
 
 use Closure;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\CertificatePolicyService;
 
 class CfsslServerHandler {
 	private string $csrServerFile = '';
 	private string $configServerFile = '';
 	private string $configServerFileHash = '';
 	private Closure $getConfigPath;
+
+	public function __construct(
+		private CertificatePolicyService $certificatePolicyService,
+	) {
+	}
 
 	/**
 	 * Create a callback to get config path not at the constructor because
@@ -98,6 +104,19 @@ class CfsslServerHandler {
 				],
 			],
 		];
+		$oid = $this->certificatePolicyService->getOid();
+		$url = $this->certificatePolicyService->getUrl();
+		if ($oid && $url) {
+			$config['signing']['profiles']['CA']['policies'][] = [
+				'id' => $oid,
+				'qualifiers' => [
+					[
+						'type' => 'id-qt-cps',
+						'value' => $url,
+					],
+				],
+			];
+		}
 		$this->saveConfig($config);
 	}
 

--- a/lib/Handler/CfsslServerHandler.php
+++ b/lib/Handler/CfsslServerHandler.php
@@ -105,14 +105,14 @@ class CfsslServerHandler {
 			],
 		];
 		$oid = $this->certificatePolicyService->getOid();
-		$url = $this->certificatePolicyService->getUrl();
-		if ($oid && $url) {
+		$cps = $this->certificatePolicyService->getCps();
+		if ($oid && $cps) {
 			$config['signing']['profiles']['CA']['policies'][] = [
 				'id' => $oid,
 				'qualifiers' => [
 					[
 						'type' => 'id-qt-cps',
-						'value' => $url,
+						'value' => $cps,
 					],
 				],
 			];

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -81,15 +81,14 @@ namespace OCA\Libresign;
  *     commonName: string,
  *     names: LibresignRootCertificateName[],
  * }
+ * @psalm-type LibresignPolicySection = array{
+ *      OID: string,
+ *      CPS: string,
+ *  }
  * @psalm-type LibresignEngineHandler = array{
  *     configPath: string,
  *     cfsslUri?: string,
- *     policySection: array{
- *         array{
- *             OID: string,
- *             CPS: string,
- *         },
- *     }|array{},
+ *     policySection: LibresignPolicySection[],
  *     rootCert: LibresignRootCertificate,
  * }
  * @psalm-type LibresignCetificateDataGenerated = LibresignEngineHandler&array{

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -84,13 +84,12 @@ namespace OCA\Libresign;
  * @psalm-type LibresignEngineHandler = array{
  *     configPath: string,
  *     cfsslUri?: string,
- *     generated: boolean,
  *     policySection: array{
  *         array{
  *             OID: string,
  *             CPS: string,
  *         },
- *     },
+ *     }|array{},
  *     rootCert: LibresignRootCertificate,
  * }
  * @psalm-type LibresignCetificateDataGenerated = LibresignEngineHandler&array{

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -84,6 +84,13 @@ namespace OCA\Libresign;
  * @psalm-type LibresignEngineHandler = array{
  *     configPath: string,
  *     cfsslUri?: string,
+ *     generated: boolean,
+ *     policySection: array{
+ *         array{
+ *             OID: string,
+ *             CPS: string,
+ *         },
+ *     },
  *     rootCert: LibresignRootCertificate,
  * }
  * @psalm-type LibresignCetificateDataGenerated = LibresignEngineHandler&array{

--- a/lib/Service/CertificatePolicyService.php
+++ b/lib/Service/CertificatePolicyService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Service;
+
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+
+class CertificatePolicyService {
+	public function __construct(
+		private IAppData $appData,
+	) {
+	}
+
+	public function updateFile(string $tmpFile): void {
+		$detectedMimeType = mime_content_type($tmpFile);
+		if (!in_array($detectedMimeType, ['application/pdf'], true)) {
+			throw new \Exception('Unsupported image type: ' . $detectedMimeType);
+		}
+
+		$blob = file_get_contents($tmpFile);
+		$rootFolder = $this->appData->getFolder('/');
+		try {
+			$rootFolder->newFile('certificate-policy.pdf', $blob);
+		} catch (NotFoundException $e) {
+			$file = $rootFolder->getFile('certificate-policy.pdf');
+			$file->putContent($blob);
+		}
+	}
+
+	public function getFile(): ISimpleFile {
+		return $this->appData->getFolder('/')->getFile('certificate-policy.pdf');
+	}
+
+	public function deleteFile(): void {
+		$this->appData->getFolder('/')->getFile('certificate-policy.pdf')->delete();
+	}
+}

--- a/lib/Service/CertificatePolicyService.php
+++ b/lib/Service/CertificatePolicyService.php
@@ -16,6 +16,7 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use UnexpectedValueException;
 
 class CertificatePolicyService {
 	public function __construct(
@@ -28,8 +29,8 @@ class CertificatePolicyService {
 
 	public function updateFile(string $tmpFile): string {
 		$detectedMimeType = mime_content_type($tmpFile);
-		if (!in_array($detectedMimeType, ['application/pdf'], true)) {
-			throw new \Exception('Unsupported image type: ' . $detectedMimeType);
+		if ($detectedMimeType !== 'application/pdf') {
+			throw new UnexpectedValueException('Unsupported image type: ' . $detectedMimeType);
 		}
 
 		$blob = file_get_contents($tmpFile);

--- a/lib/Service/CertificatePolicyService.php
+++ b/lib/Service/CertificatePolicyService.php
@@ -76,7 +76,7 @@ class CertificatePolicyService {
 		return $this->appConfig->getValueString(Application::APP_ID, 'certificate_policies_oid', '');
 	}
 
-	public function getUrl(): string {
+	public function getCps(): string {
 		try {
 			$this->getFile();
 		} catch (NotFoundException $e) {

--- a/lib/Service/CertificatePolicyService.php
+++ b/lib/Service/CertificatePolicyService.php
@@ -59,8 +59,8 @@ class CertificatePolicyService {
 			$this->appConfig->deleteKey(Application::APP_ID, 'certificate_policies_oid');
 			return '';
 		}
-		$regex = '/^(0|1|2)(\.\d+)+$/';
-		preg_match($regex, $oid, $matches);
+		$regex = '(0|1|2)(\.\d+)+';
+		preg_match('/^' . $regex . '$/', $oid, $matches);
 		if (empty($matches)) {
 			// TRANSLATORS This message appears when an invalid Object
 			// Identifier (OID) is entered. It informs the admin that the input

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -43,7 +43,7 @@ class Admin implements ISettings {
 		}
 		$this->initialState->provideInitialState('certificate_engine', $this->certificateEngineFactory->getEngine()->getName());
 		$this->initialState->provideInitialState('certificate_policies_oid', $this->certificatePolicyService->getOid());
-		$this->initialState->provideInitialState('certificate_policies_url', $this->certificatePolicyService->getUrl());
+		$this->initialState->provideInitialState('certificate_policies_cps', $this->certificatePolicyService->getCps());
 		$this->initialState->provideInitialState('config_path', $this->appConfig->getValueString(Application::APP_ID, 'config_path'));
 		$this->initialState->provideInitialState('default_signature_font_size', SignatureTextService::SIGNATURE_DEFAULT_FONT_SIZE);
 		$this->initialState->provideInitialState('default_signature_height', SignatureTextService::DEFAULT_SIGNATURE_HEIGHT);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -11,6 +11,7 @@ namespace OCA\Libresign\Settings;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
+use OCA\Libresign\Service\CertificatePolicyService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SignatureBackgroundService;
 use OCA\Libresign\Service\SignatureTextService;
@@ -25,6 +26,7 @@ class Admin implements ISettings {
 		private IInitialState $initialState,
 		private IdentifyMethodService $identifyMethodService,
 		private CertificateEngineFactory $certificateEngineFactory,
+		private CertificatePolicyService $certificatePolicyService,
 		private IAppConfig $appConfig,
 		private SignatureTextService $signatureTextService,
 		private SignatureBackgroundService $signatureBackgroundService,
@@ -40,6 +42,8 @@ class Admin implements ISettings {
 			$this->initialState->provideInitialState('signature_text_template_error', $e->getMessage());
 		}
 		$this->initialState->provideInitialState('certificate_engine', $this->certificateEngineFactory->getEngine()->getName());
+		$this->initialState->provideInitialState('certificate_policies_oid', $this->certificatePolicyService->getOid());
+		$this->initialState->provideInitialState('certificate_policies_url', $this->certificatePolicyService->getUrl());
 		$this->initialState->provideInitialState('config_path', $this->appConfig->getValueString(Application::APP_ID, 'config_path'));
 		$this->initialState->provideInitialState('default_signature_font_size', SignatureTextService::SIGNATURE_DEFAULT_FONT_SIZE);
 		$this->initialState->provideInitialState('default_signature_height', SignatureTextService::DEFAULT_SIGNATURE_HEIGHT);

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -142,34 +142,10 @@
                         "type": "string"
                     },
                     "policySection": {
-                        "anyOf": [
-                            {
-                                "type": "object",
-                                "required": [
-                                    null
-                                ],
-                                "properties": {
-                                    "": {
-                                        "type": "object",
-                                        "required": [
-                                            "OID",
-                                            "CPS"
-                                        ],
-                                        "properties": {
-                                            "OID": {
-                                                "type": "string"
-                                            },
-                                            "CPS": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object"
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PolicySection"
+                        }
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"
@@ -196,6 +172,21 @@
                         "type": "string"
                     },
                     "itemsperpage": {
+                        "type": "string"
+                    }
+                }
+            },
+            "PolicySection": {
+                "type": "object",
+                "required": [
+                    "OID",
+                    "CPS"
+                ],
+                "properties": {
+                    "OID": {
+                        "type": "string"
+                    },
+                    "CPS": {
                         "type": "string"
                     }
                 }
@@ -1833,7 +1824,7 @@
                                                     "type": "object",
                                                     "required": [
                                                         "status",
-                                                        "url"
+                                                        "CPS"
                                                     ],
                                                     "properties": {
                                                         "status": {
@@ -1842,7 +1833,7 @@
                                                                 "success"
                                                             ]
                                                         },
-                                                        "url": {
+                                                        "CPS": {
                                                             "type": "string"
                                                         }
                                                     }

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -131,6 +131,8 @@
                 "type": "object",
                 "required": [
                     "configPath",
+                    "generated",
+                    "policySection",
                     "rootCert"
                 ],
                 "properties": {
@@ -139,6 +141,32 @@
                     },
                     "cfsslUri": {
                         "type": "string"
+                    },
+                    "generated": {
+                        "type": "boolean"
+                    },
+                    "policySection": {
+                        "type": "object",
+                        "required": [
+                            null
+                        ],
+                        "properties": {
+                            "": {
+                                "type": "object",
+                                "required": [
+                                    "OID",
+                                    "CPS"
+                                ],
+                                "properties": {
+                                    "OID": {
+                                        "type": "string"
+                                    },
+                                    "CPS": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -1737,6 +1737,361 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy": {
+            "post": {
+                "operationId": "admin-save-certificate-policy",
+                "summary": "Update certificate policy of this instance",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "url"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "success"
+                                                            ]
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "failure"
+                                                            ]
+                                                        },
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "admin-delete-certificate-policy",
+                "summary": "Delete certificate policy of this instance",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy/oid": {
+            "post": {
+                "operationId": "admin-updateoid",
+                "summary": "Update OID",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "oid"
+                                ],
+                                "properties": {
+                                    "oid": {
+                                        "type": "string",
+                                        "description": "OID is a unique numeric identifier for certificate policies in digital certificates."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "success"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "failure"
+                                                            ]
+                                                        },
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/libresign/api/{apiVersion}/setting/has-root-cert": {
             "get": {
                 "operationId": "setting-has-root-cert",

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -131,7 +131,6 @@
                 "type": "object",
                 "required": [
                     "configPath",
-                    "generated",
                     "policySection",
                     "rootCert"
                 ],
@@ -142,31 +141,35 @@
                     "cfsslUri": {
                         "type": "string"
                     },
-                    "generated": {
-                        "type": "boolean"
-                    },
                     "policySection": {
-                        "type": "object",
-                        "required": [
-                            null
-                        ],
-                        "properties": {
-                            "": {
+                        "anyOf": [
+                            {
                                 "type": "object",
                                 "required": [
-                                    "OID",
-                                    "CPS"
+                                    null
                                 ],
                                 "properties": {
-                                    "OID": {
-                                        "type": "string"
-                                    },
-                                    "CPS": {
-                                        "type": "string"
+                                    "": {
+                                        "type": "object",
+                                        "required": [
+                                            "OID",
+                                            "CPS"
+                                        ],
+                                        "properties": {
+                                            "OID": {
+                                                "type": "string"
+                                            },
+                                            "CPS": {
+                                                "type": "string"
+                                            }
+                                        }
                                     }
                                 }
+                            },
+                            {
+                                "type": "object"
                             }
-                        }
+                        ]
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -237,7 +237,6 @@
                 "type": "object",
                 "required": [
                     "configPath",
-                    "generated",
                     "policySection",
                     "rootCert"
                 ],
@@ -248,31 +247,35 @@
                     "cfsslUri": {
                         "type": "string"
                     },
-                    "generated": {
-                        "type": "boolean"
-                    },
                     "policySection": {
-                        "type": "object",
-                        "required": [
-                            null
-                        ],
-                        "properties": {
-                            "": {
+                        "anyOf": [
+                            {
                                 "type": "object",
                                 "required": [
-                                    "OID",
-                                    "CPS"
+                                    null
                                 ],
                                 "properties": {
-                                    "OID": {
-                                        "type": "string"
-                                    },
-                                    "CPS": {
-                                        "type": "string"
+                                    "": {
+                                        "type": "object",
+                                        "required": [
+                                            "OID",
+                                            "CPS"
+                                        ],
+                                        "properties": {
+                                            "OID": {
+                                                "type": "string"
+                                            },
+                                            "CPS": {
+                                                "type": "string"
+                                            }
+                                        }
                                     }
                                 }
+                            },
+                            {
+                                "type": "object"
                             }
-                        }
+                        ]
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1057,6 +1057,55 @@
         }
     },
     "paths": {
+        "/index.php/apps/libresign/certificate-policy.pdf": {
+            "get": {
+                "operationId": "certificate_policy-get-certificate-policy",
+                "summary": "Certificate policy of this instance",
+                "tags": [
+                    "certificate_policy"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "Content-Disposition": {
+                                "schema": {
+                                    "type": "string",
+                                    "enum": [
+                                        "inline; filename=\"certificate-policy.pdf\""
+                                    ]
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/libresign/develop/pdf": {
             "get": {
                 "operationId": "develop-pdf",
@@ -9459,6 +9508,361 @@
                                                     ],
                                                     "properties": {
                                                         "error": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy": {
+            "post": {
+                "operationId": "admin-save-certificate-policy",
+                "summary": "Update certificate policy of this instance",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "url"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "success"
+                                                            ]
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "failure"
+                                                            ]
+                                                        },
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "admin-delete-certificate-policy",
+                "summary": "Delete certificate policy of this instance",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy/oid": {
+            "post": {
+                "operationId": "admin-updateoid",
+                "summary": "Update OID",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "admin"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "oid"
+                                ],
+                                "properties": {
+                                    "oid": {
+                                        "type": "string",
+                                        "description": "OID is a unique numeric identifier for certificate policies in digital certificates."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "success"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "status",
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "failure"
+                                                            ]
+                                                        },
+                                                        "message": {
                                                             "type": "string"
                                                         }
                                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -248,34 +248,10 @@
                         "type": "string"
                     },
                     "policySection": {
-                        "anyOf": [
-                            {
-                                "type": "object",
-                                "required": [
-                                    null
-                                ],
-                                "properties": {
-                                    "": {
-                                        "type": "object",
-                                        "required": [
-                                            "OID",
-                                            "CPS"
-                                        ],
-                                        "properties": {
-                                            "OID": {
-                                                "type": "string"
-                                            },
-                                            "CPS": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object"
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PolicySection"
+                        }
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"
@@ -637,6 +613,21 @@
                     "first": {
                         "type": "string",
                         "nullable": true
+                    }
+                }
+            },
+            "PolicySection": {
+                "type": "object",
+                "required": [
+                    "OID",
+                    "CPS"
+                ],
+                "properties": {
+                    "OID": {
+                        "type": "string"
+                    },
+                    "CPS": {
+                        "type": "string"
                     }
                 }
             },
@@ -9618,7 +9609,7 @@
                                                     "type": "object",
                                                     "required": [
                                                         "status",
-                                                        "url"
+                                                        "CPS"
                                                     ],
                                                     "properties": {
                                                         "status": {
@@ -9627,7 +9618,7 @@
                                                                 "success"
                                                             ]
                                                         },
-                                                        "url": {
+                                                        "CPS": {
                                                             "type": "string"
                                                         }
                                                     }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -237,6 +237,8 @@
                 "type": "object",
                 "required": [
                     "configPath",
+                    "generated",
+                    "policySection",
                     "rootCert"
                 ],
                 "properties": {
@@ -245,6 +247,32 @@
                     },
                     "cfsslUri": {
                         "type": "string"
+                    },
+                    "generated": {
+                        "type": "boolean"
+                    },
+                    "policySection": {
+                        "type": "object",
+                        "required": [
+                            null
+                        ],
+                        "properties": {
+                            "": {
+                                "type": "object",
+                                "required": [
+                                    "OID",
+                                    "CPS"
+                                ],
+                                "properties": {
+                                    "OID": {
+                                        "type": "string"
+                                    },
+                                    "CPS": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
                     },
                     "rootCert": {
                         "$ref": "#/components/schemas/RootCertificate"

--- a/openapi.json
+++ b/openapi.json
@@ -961,6 +961,55 @@
         }
     },
     "paths": {
+        "/index.php/apps/libresign/certificate-policy.pdf": {
+            "get": {
+                "operationId": "certificate_policy-get-certificate-policy",
+                "summary": "Certificate policy of this instance",
+                "tags": [
+                    "certificate_policy"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "headers": {
+                            "Content-Disposition": {
+                                "schema": {
+                                    "type": "string",
+                                    "enum": [
+                                        "inline; filename=\"certificate-policy.pdf\""
+                                    ]
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/libresign/develop/pdf": {
             "get": {
                 "operationId": "develop-pdf",

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -302,13 +302,12 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
-            generated: boolean;
             policySection: {
                 ""?: {
                     OID: string;
                     CPS: string;
                 };
-            };
+            } | Record<string, never>;
             rootCert: components["schemas"]["RootCertificate"];
         };
         OCSMeta: {

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -302,6 +302,13 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
+            generated: boolean;
+            policySection: {
+                ""?: {
+                    OID: string;
+                    CPS: string;
+                };
+            };
             rootCert: components["schemas"]["RootCertificate"];
         };
         OCSMeta: {

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -302,12 +302,7 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
-            policySection: {
-                ""?: {
-                    OID: string;
-                    CPS: string;
-                };
-            } | Record<string, never>;
+            policySection: components["schemas"]["PolicySection"][];
             rootCert: components["schemas"]["RootCertificate"];
         };
         OCSMeta: {
@@ -316,6 +311,10 @@ export type components = {
             message?: string;
             totalitems?: string;
             itemsperpage?: string;
+        };
+        PolicySection: {
+            OID: string;
+            CPS: string;
         };
         PublicCapabilities: {
             libresign?: components["schemas"]["Capabilities"];
@@ -981,7 +980,7 @@ export interface operations {
                             data: {
                                 /** @enum {string} */
                                 status: "success";
-                                url: string;
+                                CPS: string;
                             };
                         };
                     };

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -203,6 +203,50 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update certificate policy of this instance
+         * @description This endpoint requires admin access
+         */
+        post: operations["admin-save-certificate-policy"];
+        /**
+         * Delete certificate policy of this instance
+         * @description This endpoint requires admin access
+         */
+        delete: operations["admin-delete-certificate-policy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy/oid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update OID
+         * @description This endpoint requires admin access
+         */
+        post: operations["admin-updateoid"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/libresign/api/{apiVersion}/setting/has-root-cert": {
         parameters: {
             query?: never;
@@ -898,6 +942,146 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 error: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-save-certificate-policy": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "success";
+                                url: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "failure";
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-delete-certificate-policy": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: Record<string, never>;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-updateoid": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description OID is a unique numeric identifier for certificate policies in digital certificates. */
+                    oid: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "success";
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "failure";
+                                message: string;
                             };
                         };
                     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -4,6 +4,23 @@
  */
 
 export type paths = {
+    "/index.php/apps/libresign/certificate-policy.pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Certificate policy of this instance */
+        get: operations["certificate_policy-get-certificate-policy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/index.php/apps/libresign/develop/pdf": {
         parameters: {
             query?: never;
@@ -1113,6 +1130,50 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update certificate policy of this instance
+         * @description This endpoint requires admin access
+         */
+        post: operations["admin-save-certificate-policy"];
+        /**
+         * Delete certificate policy of this instance
+         * @description This endpoint requires admin access
+         */
+        delete: operations["admin-delete-certificate-policy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ocs/v2.php/apps/libresign/api/{apiVersion}/admin/certificate-policy/oid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update OID
+         * @description This endpoint requires admin access
+         */
+        post: operations["admin-updateoid"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ocs/v2.php/apps/libresign/api/{apiVersion}/setting/has-root-cert": {
         parameters: {
             query?: never;
@@ -1442,6 +1503,36 @@ export type components = {
 };
 export type $defs = Record<string, never>;
 export interface operations {
+    "certificate_policy-get-certificate-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Content-Disposition"?: "inline; filename=\"certificate-policy.pdf\"";
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/pdf": string;
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     "develop-pdf": {
         parameters: {
             query?: never;
@@ -4896,6 +4987,146 @@ export interface operations {
                             meta: components["schemas"]["OCSMeta"];
                             data: {
                                 error: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-save-certificate-policy": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "success";
+                                url: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "failure";
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-delete-certificate-policy": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: Record<string, never>;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "admin-updateoid": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                apiVersion: "v1";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description OID is a unique numeric identifier for certificate policies in digital certificates. */
+                    oid: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "success";
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {string} */
+                                status: "failure";
+                                message: string;
                             };
                         };
                     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1264,12 +1264,7 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
-            policySection: {
-                ""?: {
-                    OID: string;
-                    CPS: string;
-                };
-            } | Record<string, never>;
+            policySection: components["schemas"]["PolicySection"][];
             rootCert: components["schemas"]["RootCertificate"];
         };
         File: {
@@ -1373,6 +1368,10 @@ export type components = {
             prev: string | null;
             last: string | null;
             first: string | null;
+        };
+        PolicySection: {
+            OID: string;
+            CPS: string;
         };
         PublicCapabilities: {
             libresign?: components["schemas"]["Capabilities"];
@@ -5026,7 +5025,7 @@ export interface operations {
                             data: {
                                 /** @enum {string} */
                                 status: "success";
-                                url: string;
+                                CPS: string;
                             };
                         };
                     };

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1264,6 +1264,13 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
+            generated: boolean;
+            policySection: {
+                ""?: {
+                    OID: string;
+                    CPS: string;
+                };
+            };
             rootCert: components["schemas"]["RootCertificate"];
         };
         File: {

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1264,13 +1264,12 @@ export type components = {
         EngineHandler: {
             configPath: string;
             cfsslUri?: string;
-            generated: boolean;
             policySection: {
                 ""?: {
                     OID: string;
                     CPS: string;
                 };
-            };
+            } | Record<string, never>;
             rootCert: components["schemas"]["RootCertificate"];
         };
         File: {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -4,6 +4,23 @@
  */
 
 export type paths = {
+    "/index.php/apps/libresign/certificate-policy.pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Certificate policy of this instance */
+        get: operations["certificate_policy-get-certificate-policy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/index.php/apps/libresign/develop/pdf": {
         parameters: {
             query?: never;
@@ -1200,6 +1217,36 @@ export type components = {
 };
 export type $defs = Record<string, never>;
 export interface operations {
+    "certificate_policy-get-certificate-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Content-Disposition"?: "inline; filename=\"certificate-policy.pdf\"";
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/pdf": string;
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     "develop-pdf": {
         parameters: {
             query?: never;

--- a/src/views/Settings/CertificatePolicy.vue
+++ b/src/views/Settings/CertificatePolicy.vue
@@ -17,7 +17,7 @@
 		</fieldset>
 		<fieldset class="settings-section__row">
 			<NcButton id="signature-background"
-				:variant="url ? 'secondary' : 'error'"
+				:variant="CPS ? 'secondary' : 'error'"
 				:aria-label="t('libresign', 'Upload Certification Practice Statement (CPS) PDF')"
 				:disabled="loading || disabled"
 				@click="activateLocalFilePicker">
@@ -26,7 +26,7 @@
 				</template>
 				{{ t('libresign', 'Upload Certification Practice Statement (CPS) PDF') }}
 			</NcButton>
-			<NcButton v-if="url"
+			<NcButton v-if="CPS"
 				variant="tertiary"
 				:aria-label="t('libresign', 'Remove')"
 				:disabled="loading || disabled"
@@ -35,7 +35,7 @@
 					<Delete :size="20" />
 				</template>
 			</NcButton>
-			<NcButton v-if="url"
+			<NcButton v-if="CPS"
 				variant="tertiary"
 				:disabled="loading || disabled"
 				@click="view">
@@ -96,7 +96,7 @@ export default {
 		return {
 			acceptMime: ['application/pdf'],
 			OID: loadState('libresign', 'certificate_policies_oid'),
-			url: loadState('libresign', 'certificate_policies_url'),
+			CPS: loadState('libresign', 'certificate_policies_cps'),
 			loading: false,
 			dislaySuccessOID: false,
 			errorMessage: '',
@@ -104,7 +104,7 @@ export default {
 	},
 	computed: {
 		certificatePolicyValid() {
-			return this.OID && this.url
+			return this.OID && this.CPS
 		},
 	},
 	mounted() {
@@ -113,9 +113,9 @@ export default {
 	methods: {
 		view() {
 			if (OCA?.Viewer !== undefined) {
-				OCA.Viewer.open({ path: this.url })
+				OCA.Viewer.open({ path: this.CPS })
 			} else {
-				window.open(`${this.url}?_t=${Date.now()}`)
+				window.open(`${this.CPS}?_t=${Date.now()}`)
 			}
 		},
 		activateLocalFilePicker() {
@@ -134,7 +134,7 @@ export default {
 			this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'), formData)
 				.then(({ data }) => {
-					this.url = data.ocs.data.url
+					this.CPS = data.ocs.data.CPS
 					this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 					this.loading = false
 				})
@@ -150,7 +150,7 @@ export default {
 			this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 			await axios.delete(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'))
 				.then(() => {
-					this.url = ''
+					this.CPS = ''
 					this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 					this.loading = false
 				})

--- a/src/views/Settings/CertificatePolicy.vue
+++ b/src/views/Settings/CertificatePolicy.vue
@@ -131,6 +131,7 @@ export default {
 
 			this.errorMessage = ''
 			this.loading = true
+			this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'), formData)
 				.then(({ data }) => {
 					this.url = data.ocs.data.url
@@ -146,6 +147,7 @@ export default {
 		async removeCps() {
 			this.errorMessage = ''
 			this.loading = true
+			this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 			await axios.delete(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'))
 				.then(() => {
 					this.url = ''
@@ -156,6 +158,7 @@ export default {
 		async _saveOID() {
 			this.dislaySuccessOID = false
 			this.errorMessage = ''
+			this.$emit('certificate-policy-valid', this.certificatePolicyValid)
 			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy/oid'), {
 				oid: this.OID,
 			})

--- a/src/views/Settings/CertificatePolicy.vue
+++ b/src/views/Settings/CertificatePolicy.vue
@@ -1,0 +1,181 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 LibreCode coop and LibreCode contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcSettingsSection :name="name" :description="description">
+		<fieldset class="settings-section__row">
+			<NcTextField :value.sync="OID"
+				:label="t('libresign', 'Certificate Policy OID')"
+				:placeholder="t('libresign', 'Certificate Policy OID')"
+				:spellcheck="false"
+				:success="dislaySuccessOID"
+				@update:modelValue="saveOID" />
+		</fieldset>
+		<fieldset class="settings-section__row">
+			<NcButton id="signature-background"
+				type="secondary"
+				:aria-label="t('libresign', 'Upload Certification Practice Statement (CPS) PDF')"
+				:disabled="loading"
+				@click="activateLocalFilePicker">
+				<template #icon>
+					<Upload :size="20" />
+				</template>
+				{{ t('libresign', 'Upload') }}
+			</NcButton>
+			<NcButton v-if="url"
+				type="tertiary"
+				:aria-label="t('libresign', 'Remove')"
+				:disabled="loading"
+				@click="removeCps">
+				<template #icon>
+					<Delete :size="20" />
+				</template>
+			</NcButton>
+			<NcButton v-if="url"
+				type="tertiary"
+				:disabled="loading"
+				@click="view">
+				{{ t('libresign', 'View') }}
+			</NcButton>
+			<NcLoadingIcon v-if="loading"
+				class="settings-section__loading-icon"
+				:size="20" />
+			<input ref="input"
+				:accept="acceptMime"
+				type="file"
+				@change="onUploadCsp">
+		</fieldset>
+		<div class="settings-section__row">
+			<NcNoteCard v-if="errorMessage"
+				type="error"
+				:show-alert="true">
+				<p>{{ errorMessage }}</p>
+			</NcNoteCard>
+		</div>
+	</NcSettingsSection>
+</template>
+
+<script>
+import debounce from 'debounce'
+
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Upload from 'vue-material-design-icons/Upload.vue'
+
+import axios from '@nextcloud/axios'
+import { loadState } from '@nextcloud/initial-state'
+import { translate as t } from '@nextcloud/l10n'
+import { generateOcsUrl } from '@nextcloud/router'
+
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+
+import '@nextcloud/password-confirmation/dist/style.css'
+
+export default {
+	name: 'CertificatePolicy',
+	components: {
+		Delete,
+		NcButton,
+		NcLoadingIcon,
+		NcNoteCard,
+		NcSettingsSection,
+		NcTextField,
+		Upload,
+	},
+
+	data() {
+		return {
+			name: t('libresign', 'Certificate policies'),
+			description: t('libresign', 'Define OIDs and CPS for issued certificates.'),
+			acceptMime: ['application/pdf'],
+			OID: loadState('libresign', 'certificate_policies_oid'),
+			url: loadState('libresign', 'certificate_policies_url'),
+			loading: false,
+			dislaySuccessOID: false,
+			errorMessage: '',
+		}
+	},
+	methods: {
+		view() {
+			if (OCA?.Viewer !== undefined) {
+				OCA.Viewer.open({ path: this.url })
+			} else {
+				window.open(`${this.url}?_t=${Date.now()}`)
+			}
+		},
+		activateLocalFilePicker() {
+			// Set to null so that selecting the same file will trigger the change event
+			this.$refs.input.value = null
+			this.$refs.input.click()
+		},
+		async onUploadCsp(e) {
+			const file = e.target.files[0]
+
+			const formData = new FormData()
+			formData.append('pdf', file)
+
+			this.errorMessage = ''
+			this.loading = true
+			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'), formData)
+				.then(({ data }) => {
+					this.url = data.ocs.data.url
+					this.loading = false
+				})
+				.catch(({ response }) => {
+					this.errorMessage = response?.data?.ocs?.data?.message
+					this.loading = false
+				})
+		},
+		async removeCps() {
+			this.errorMessage = ''
+			this.loading = true
+			await axios.delete(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy'))
+				.then(() => {
+					this.url = ''
+					this.loading = false
+				})
+		},
+		async _saveOID() {
+			this.dislaySuccessOID = false
+			this.errorMessage = ''
+			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/certificate-policy/oid'), {
+				oid: this.OID,
+			})
+				.then(() => {
+					this.dislaySuccessOID = true
+					setTimeout(() => { this.dislaySuccessOID = false }, 2000)
+				})
+				.catch(({ response }) => {
+					this.errorMessage = response?.data?.ocs?.data?.message
+					this.loading = false
+				})
+		},
+		saveOID: debounce(function () {
+			this._saveOID()
+		}, 500)
+	},
+
+}
+</script>
+
+<style lang="scss" scoped>
+.settings-section{
+	display: flex;
+	flex-direction: column;
+	&:deep(.settings-section__name) {
+		justify-content: unset;
+	}
+	&__row {
+		display: flex;
+		gap: 0 4px;
+	}
+	input[type="file"] {
+		display: none;
+	}
+}
+</style>

--- a/src/views/Settings/RootCertificateCfssl.vue
+++ b/src/views/Settings/RootCertificateCfssl.vue
@@ -22,6 +22,14 @@
 						<td>{{ t('libresign', 'CFSSL API URI') }}</td>
 						<td>{{ certificate.cfsslUri }}</td>
 					</tr>
+					<tr v-if="OID" class="customNames">
+						<td>OID</td>
+						<td>{{ OID }}</td>
+					</tr>
+					<tr v-if="CPS" class="customNames">
+						<td>CPS</td>
+						<td>{{ CPS }}</td>
+					</tr>
 					<tr>
 						<td>{{ t('libresign', 'Config path') }}</td>
 						<td>{{ certificate.configPath }}</td>
@@ -139,7 +147,7 @@ export default {
 	},
 	data() {
 		const OID = loadState('libresign', 'certificate_policies_oid')
-		const url = loadState('libresign', 'certificate_policies_url')
+		const CPS = loadState('libresign', 'certificate_policies_cps')
 		return {
 			isThisEngine: loadState('libresign', 'certificate_engine') === 'cfssl',
 			modal: false,
@@ -159,14 +167,14 @@ export default {
 			submitLabel: t('libresign', 'Generate root certificate'),
 			formDisabled: false,
 			OID,
-			url,
-			toggleCertificatePolicy: !!(OID || url),
-			certificatePolicyValid: !!OID && !!url,
+			CPS,
+			toggleCertificatePolicy: !!(OID || CPS),
+			certificatePolicyValid: !!OID && !!CPS,
 		}
 	},
 	computed: {
 		includeCertificatePolicy() {
-			return this.toggleCertificatePolicy || this.url || this.OID
+			return this.toggleCertificatePolicy || this.CPS || this.OID
 		},
 		canSave() {
 			if (this.formDisabled) {

--- a/src/views/Settings/RootCertificateOpenSsl.vue
+++ b/src/views/Settings/RootCertificateOpenSsl.vue
@@ -57,7 +57,17 @@
 			</div>
 			<CertificateCustonOptions :names.sync="certificate.rootCert.names" />
 			<div>
-				<NcCheckboxRadioSwitch v-if="!customData || !formDisabled"
+				<NcCheckboxRadioSwitch :disabled="formDisabled"
+					type="switch"
+					:checked.sync="toggleCertificatePolicy">
+					{{ t('libresign', 'Include certificate policy') }}
+				</NcCheckboxRadioSwitch>
+			</div>
+			<CertificatePolicy v-if="toggleCertificatePolicy"
+				:disabled="formDisabled"
+				@certificate-policy-valid="handleCertificatePolicyValid" />
+			<div>
+				<NcCheckboxRadioSwitch :disabled="formDisabled"
 					type="switch"
 					:checked.sync="customData">
 					{{ t('libresign', 'Define custom values to use {engine}', {engine: 'OpenSSL'}) }}
@@ -71,7 +81,7 @@
 					:placeholder="t('libresign', 'Not mandatory, don\'t fill to use default value.')"
 					:disabled="formDisabled" />
 			</div>
-			<NcButton :disabled="formDisabled"
+			<NcButton :disabled="!canSave"
 				type="primary"
 				@click="generateCertificate">
 				{{ submitLabel }}
@@ -95,6 +105,7 @@ import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 
 import CertificateCustonOptions from './CertificateCustonOptions.vue'
+import CertificatePolicy from './CertificatePolicy.vue'
 
 import { selectCustonOption } from '../../helpers/certification.js'
 import logger from '../../logger.js'
@@ -109,12 +120,15 @@ export default {
 		NcButton,
 		NcTextField,
 		CertificateCustonOptions,
+		CertificatePolicy,
 	},
 	setup() {
 		const configureCheckStore = useConfigureCheckStore()
 		return { configureCheckStore }
 	},
 	data() {
+		const OID = loadState('libresign', 'certificate_policies_oid')
+		const url = loadState('libresign', 'certificate_policies_url')
 		return {
 			isThisEngine: loadState('libresign', 'certificate_engine') === 'openssl',
 			modal: false,
@@ -131,9 +145,25 @@ export default {
 			description: t('libresign', 'To generate new signatures, you must first generate the root certificate.'),
 			submitLabel: t('libresign', 'Generate root certificate'),
 			formDisabled: false,
+			OID,
+			url,
+			toggleCertificatePolicy: !!(OID || url),
+			certificatePolicyValid: !!OID && !!url,
 		}
 	},
 	computed: {
+		includeCertificatePolicy() {
+			return this.toggleCertificatePolicy || this.url || this.OID
+		},
+		canSave() {
+			if (this.formDisabled) {
+				return false
+			}
+			if (!this.toggleCertificatePolicy) {
+				return true
+			}
+			return this.certificatePolicyValid
+		},
 		configureOk() {
 			return this.configureCheckStore.isConfigureOk('openssl')
 		},
@@ -154,6 +184,9 @@ export default {
 		unsubscribe('libresign:update:certificateToSave')
 	},
 	methods: {
+		handleCertificatePolicyValid(isValid) {
+			this.certificatePolicyValid = isValid
+		},
 		updateNames(names) {
 			this.certificate.rootCert.names = names
 		},

--- a/src/views/Settings/RootCertificateOpenSsl.vue
+++ b/src/views/Settings/RootCertificateOpenSsl.vue
@@ -18,6 +18,14 @@
 						<td>{{ getLabelFromId(customName.id) }} ({{ customName.id }})</td>
 						<td>{{ customName.value }}</td>
 					</tr>
+					<tr v-if="OID" class="customNames">
+						<td>OID</td>
+						<td>{{ OID }}</td>
+					</tr>
+					<tr v-if="CPS" class="customNames">
+						<td>CPS</td>
+						<td>{{ CPS }}</td>
+					</tr>
 					<tr>
 						<td>{{ t('libresign', 'Config path') }}</td>
 						<td>{{ certificate.configPath }}</td>
@@ -128,7 +136,7 @@ export default {
 	},
 	data() {
 		const OID = loadState('libresign', 'certificate_policies_oid')
-		const url = loadState('libresign', 'certificate_policies_url')
+		const CPS = loadState('libresign', 'certificate_policies_cps')
 		return {
 			isThisEngine: loadState('libresign', 'certificate_engine') === 'openssl',
 			modal: false,
@@ -146,14 +154,14 @@ export default {
 			submitLabel: t('libresign', 'Generate root certificate'),
 			formDisabled: false,
 			OID,
-			url,
-			toggleCertificatePolicy: !!(OID || url),
-			certificatePolicyValid: !!OID && !!url,
+			CPS,
+			toggleCertificatePolicy: !!(OID || CPS),
+			certificatePolicyValid: !!OID && !!CPS,
 		}
 	},
 	computed: {
 		includeCertificatePolicy() {
-			return this.toggleCertificatePolicy || this.url || this.OID
+			return this.toggleCertificatePolicy || this.CPS || this.OID
 		},
 		canSave() {
 			if (this.formDisabled) {

--- a/src/views/Settings/Settings.vue
+++ b/src/views/Settings/Settings.vue
@@ -10,7 +10,6 @@
 		<ConfigureCheck />
 		<RootCertificateCfssl />
 		<RootCertificateOpenSsl />
-		<CertificatePolicy />
 		<IdentificationFactors />
 		<ExpirationRules />
 		<Validation />

--- a/src/views/Settings/Settings.vue
+++ b/src/views/Settings/Settings.vue
@@ -10,6 +10,7 @@
 		<ConfigureCheck />
 		<RootCertificateCfssl />
 		<RootCertificateOpenSsl />
+		<CertificatePolicy />
 		<IdentificationFactors />
 		<ExpirationRules />
 		<Validation />
@@ -28,6 +29,7 @@ import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 
 import AllowedGroups from './AllowedGroups.vue'
 import CertificateEngine from './CertificateEngine.vue'
+import CertificatePolicy from './CertificatePolicy.vue'
 import CollectMetadata from './CollectMetadata.vue'
 import ConfigureCheck from './ConfigureCheck.vue'
 import DefaultUserFolder from './DefaultUserFolder.vue'
@@ -45,22 +47,23 @@ import Validation from './Validation.vue'
 export default {
 	name: 'Settings',
 	components: {
-		NcSettingsSection,
+		AllowedGroups,
 		CertificateEngine,
-		DownloadBinaries,
+		CertificatePolicy,
+		CollectMetadata,
 		ConfigureCheck,
+		DefaultUserFolder,
+		DownloadBinaries,
+		ExpirationRules,
+		IdentificationDocuments,
+		IdentificationFactors,
+		LegalInformation,
+		NcSettingsSection,
 		RootCertificateCfssl,
 		RootCertificateOpenSsl,
-		IdentificationFactors,
-		ExpirationRules,
-		Validation,
-		AllowedGroups,
-		LegalInformation,
-		IdentificationDocuments,
-		CollectMetadata,
-		SignatureStamp,
 		SignatureHashAlgorithm,
-		DefaultUserFolder,
+		SignatureStamp,
+		Validation,
 	},
 	data() {
 		return {

--- a/src/views/Settings/Settings.vue
+++ b/src/views/Settings/Settings.vue
@@ -29,7 +29,6 @@ import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 
 import AllowedGroups from './AllowedGroups.vue'
 import CertificateEngine from './CertificateEngine.vue'
-import CertificatePolicy from './CertificatePolicy.vue'
 import CollectMetadata from './CollectMetadata.vue'
 import ConfigureCheck from './ConfigureCheck.vue'
 import DefaultUserFolder from './DefaultUserFolder.vue'
@@ -49,7 +48,6 @@ export default {
 	components: {
 		AllowedGroups,
 		CertificateEngine,
-		CertificatePolicy,
 		CollectMetadata,
 		ConfigureCheck,
 		DefaultUserFolder,

--- a/tests/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
+++ b/tests/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
@@ -10,6 +10,7 @@ use bovigo\vfs\vfsStream;
 use OCA\Libresign\Exception\EmptyCertificateException;
 use OCA\Libresign\Exception\InvalidPasswordException;
 use OCA\Libresign\Handler\CertificateEngine\OpenSslHandler;
+use OCA\Libresign\Service\CertificatePolicyService;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\IAppConfig;
 use OCP\IConfig;
@@ -23,12 +24,14 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IDateTimeFormatter $dateTimeFormatter;
 	private ITempManager $tempManager;
 	private OpenSslHandler $openSslHandler;
+	protected CertificatePolicyService $certificatePolicyService;
 	public function setUp(): void {
 		$this->config = \OCP\Server::get(IConfig::class);
 		$this->appConfig = \OCP\Server::get(IAppConfig::class);
 		$this->appDataFactory = \OCP\Server::get(IAppDataFactory::class);
 		$this->dateTimeFormatter = \OCP\Server::get(IDateTimeFormatter::class);
 		$this->tempManager = \OCP\Server::get(ITempManager::class);
+		$this->certificatePolicyService = \OCP\Server::get(certificatePolicyService::class);
 
 		// The storage can't be modified when create a new instance to
 		// don't lost the root cert
@@ -42,6 +45,7 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->appDataFactory,
 			$this->dateTimeFormatter,
 			$this->tempManager,
+			$this->certificatePolicyService,
 		);
 		$this->openSslHandler->setConfigPath('vfs://certificate/');
 		return $this->openSslHandler;

--- a/tests/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
+++ b/tests/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-use bovigo\vfs\vfsStream;
 use OCA\Libresign\Exception\EmptyCertificateException;
 use OCA\Libresign\Exception\InvalidPasswordException;
 use OCA\Libresign\Handler\CertificateEngine\OpenSslHandler;
@@ -25,6 +24,7 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private ITempManager $tempManager;
 	private OpenSslHandler $openSslHandler;
 	protected CertificatePolicyService $certificatePolicyService;
+	private string $tempDir;
 	public function setUp(): void {
 		$this->config = \OCP\Server::get(IConfig::class);
 		$this->appConfig = \OCP\Server::get(IAppConfig::class);
@@ -32,10 +32,7 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->dateTimeFormatter = \OCP\Server::get(IDateTimeFormatter::class);
 		$this->tempManager = \OCP\Server::get(ITempManager::class);
 		$this->certificatePolicyService = \OCP\Server::get(certificatePolicyService::class);
-
-		// The storage can't be modified when create a new instance to
-		// don't lost the root cert
-		vfsStream::setup('certificate');
+		$this->tempDir = $this->tempManager->getTemporaryFolder('certificate');
 	}
 
 	private function getInstance(): OpenSslHandler {
@@ -47,7 +44,7 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->tempManager,
 			$this->certificatePolicyService,
 		);
-		$this->openSslHandler->setConfigPath('vfs://certificate/');
+		$this->openSslHandler->setConfigPath($this->tempDir);
 		return $this->openSslHandler;
 	}
 

--- a/tests/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Unit\Service;
 
-use bovigo\vfs\vfsStream;
 use Jeidison\JSignPDF\JSignPDF;
 use Jeidison\JSignPDF\Sign\JSignParam;
 use OCA\Libresign\AppInfo\Application;
@@ -42,14 +41,11 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		parent::setUpBeforeClass();
 
 		self::$certificateEngineFactory = \OCP\Server::get(CertificateEngineFactory::class);
-		// The storage can't be modified when create a new instance to
-		// don't lost the root cert
-		vfsStream::setup('certificate');
 		$appConfig = self::getMockAppConfig();
 		$appConfig->setValueString(Application::APP_ID, 'certificate_engine', 'openssl');
 		$certificateEngine = self::$certificateEngineFactory->getEngine();
 		$certificateEngine
-			->setConfigPath('vfs://certificate/')
+			->setConfigPath(\OCP\Server::get(ITempManager::class)->getTemporaryFolder('certificate'))
 			->generateRootCert('', []);
 
 		self::$certificateContent = $certificateEngine

--- a/tests/Unit/Service/CertificatePolicyServiceTest.php
+++ b/tests/Unit/Service/CertificatePolicyServiceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service;
+
+use bovigo\vfs\vfsStream;
+use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\CertificatePolicyService;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory as IL10NFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class CertificatePolicyServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
+
+	private IAppData&MockObject $appData;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IAppConfig $appConfig;
+	private IL10N $l10n;
+
+	public function setUp(): void {
+		$this->appData = $this->createMock(IAppData::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->appConfig = $this->getMockAppConfig();
+		$this->l10n = \OCP\Server::get(IL10NFactory::class)->get(Application::APP_ID);
+	}
+
+	private function getService(): CertificatePolicyService {
+		return new CertificatePolicyService(
+			$this->appData,
+			$this->urlGenerator,
+			$this->appConfig,
+			$this->l10n
+		);
+	}
+
+	#[DataProvider('providerUpdateOidWithValidValue')]
+	public function testUpdateOidWithValidValue(string $oid): void {
+		$result = $this->getService()->updateOid($oid);
+		$this->assertEquals($oid, $result);
+	}
+
+	public static function providerUpdateOidWithValidValue(): array {
+		return [
+			['1.2.3.4'],
+			['2.5.4.10'],
+			['0.9.2342.19200300.100.1.1'],
+			[''],
+		];
+	}
+
+	#[DataProvider('providerUpdateOidWithInvalidValue')]
+	public function testUpdateOidWithInvalidValue(string $oid): void {
+		$this->expectException(LibresignException::class);
+		$this->getService()->updateOid($oid);
+	}
+
+	public static function providerUpdateOidWithInvalidValue(): array {
+		return [
+			['1.2..3'],
+			['3.2.1'],
+			['1'],
+		];
+	}
+
+	public function testUpdateOid(): void {
+		$service = $this->getService();
+
+		$result = $service->updateOid('1.2.3');
+		$this->assertEquals('1.2.3', $result);
+		$current = $this->appConfig->getValueString('libresign', 'certificate_policies_oid');
+		$this->assertEquals('1.2.3', $current);
+		$this->assertEquals('1.2.3', $service->getOid());
+
+		$result = $service->updateOid('');
+		$this->assertEquals('', $result);
+		$this->assertEquals('', $service->getOid());
+
+		$condition = $this->appConfig->hasKey('libresign', 'certificate_policies_oid');
+		$this->assertFalse($condition);
+	}
+
+	#[DataProvider('providerGetCps')]
+	public function testGetCps(bool $fileExists, string $expected): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+
+		if ($fileExists) {
+			$file = $this->createMock(ISimpleFile::class);
+			$folder->method('getFile')->willReturn($file);
+			$this->urlGenerator->method('linkToRouteAbsolute')->willReturn($expected);
+		} else {
+			$folder->method('getFile')->willThrowException(new NotFoundException());
+		}
+
+		$this->appData->method('getFolder')->willReturn($folder);
+		$service = $this->getService();
+		$this->assertSame($expected, $service->getCps());
+	}
+
+	public static function providerGetCps(): array {
+		return [
+			'file exists' => [true, 'https://example.coop/cps'],
+			'file not found' => [false, ''],
+		];
+	}
+
+	#[DataProvider('providerGetFile')]
+	public function testGetFile(bool $exists): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$this->appData->method('getFolder')->willReturn($folder);
+		$service = $this->getService();
+
+		if ($exists) {
+			$file = $this->createMock(ISimpleFile::class);
+			$folder->method('getFile')->with('certificate-policy.pdf')->willReturn($file);
+			$this->assertSame($file, $service->getFile());
+		} else {
+			$folder->method('getFile')->willThrowException(new NotFoundException());
+			$this->expectException(NotFoundException::class);
+			$service->getFile();
+		}
+	}
+
+	public static function providerGetFile(): array {
+		return [
+			'success' => [true],
+			'not found' => [false],
+		];
+	}
+
+	#[DataProvider('providerUpdateFileWithValidPdf')]
+	public function testUpdateFileWithValidPdf(string $pdfContent): void {
+		vfsStream::setup('uploaded');
+		$pdfPath = 'vfs://uploaded/test.pdf';
+		file_put_contents($pdfPath, $pdfContent);
+
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://example.coop/cps');
+
+		$service = $this->getService();
+		$result = $service->updateFile($pdfPath);
+		$this->assertSame('https://example.coop/cps', $result);
+	}
+
+	public static function providerUpdateFileWithValidPdf(): array {
+		return [
+			['%PDF-1.0' . "\n" . '%LibreSign Test File' . "\n", '1.0'],
+			['%PDF-1.1' . "\n" . '%LibreSign Test File' . "\n", '1.1'],
+			['%PDF-1.2' . "\n" . '%LibreSign Test File' . "\n", '1.2'],
+			['%PDF-1.3' . "\n" . '%LibreSign Test File' . "\n", '1.3'],
+			['%PDF-1.4' . "\n" . '%LibreSign Test File' . "\n", '1.4'],
+			['%PDF-1.5' . "\n" . '%LibreSign Test File' . "\n", '1.5'],
+			['%PDF-1.6' . "\n" . '%LibreSign Test File' . "\n", '1.6'],
+			['%PDF-1.7' . "\n" . '%LibreSign Test File' . "\n", '1.7'],
+			['%PDF-2.0' . "\n" . '%LibreSign Test File' . "\n", '2.0'],
+		];
+	}
+
+	public function testUpdateFileWithInvalidType(): void {
+		$tmpFile = tempnam(sys_get_temp_dir(), 'txt');
+		file_put_contents($tmpFile, 'just text');
+
+		$service = $this->getService();
+		$this->expectException(\Exception::class);
+		$service->updateFile($tmpFile);
+	}
+}

--- a/tests/Unit/Settings/AdminTest.php
+++ b/tests/Unit/Settings/AdminTest.php
@@ -10,6 +10,7 @@ namespace OCA\Libresign\Tests\Unit\Service;
 
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
+use OCA\Libresign\Service\CertificatePolicyService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SignatureBackgroundService;
 use OCA\Libresign\Service\SignatureTextService;
@@ -26,6 +27,7 @@ final class AdminTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IInitialState&MockObject $initialState;
 	private IdentifyMethodService&MockObject $identifyMethodService;
 	private CertificateEngineFactory&MockObject $certificateEngineFactory;
+	private CertificatePolicyService&MockObject $certificatePolicyService;
 	private IAppConfig&MockObject $appConfig;
 	private SignatureTextService&MockObject $signatureTextService;
 	private SignatureBackgroundService&MockObject $signatureBackgroundService;
@@ -33,6 +35,7 @@ final class AdminTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
 		$this->certificateEngineFactory = $this->createMock(CertificateEngineFactory::class);
+		$this->certificatePolicyService = $this->createMock(CertificatePolicyService::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->signatureTextService = $this->createMock(SignatureTextService::class);
 		$this->signatureBackgroundService = $this->createMock(SignatureBackgroundService::class);
@@ -40,6 +43,7 @@ final class AdminTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->initialState,
 			$this->identifyMethodService,
 			$this->certificateEngineFactory,
+			$this->certificatePolicyService,
 			$this->appConfig,
 			$this->signatureTextService,
 			$this->signatureBackgroundService,

--- a/tests/lib/AppConfigOverwrite.php
+++ b/tests/lib/AppConfigOverwrite.php
@@ -94,4 +94,8 @@ class AppConfigOverwrite extends AppConfig {
 		$this->overWrite[$app][$key] = $value;
 		return true;
 	}
+
+	public function deleteKey(string $app, string $key): void {
+		unset($this->overWrite[$app][$key]);
+	}
 }


### PR DESCRIPTION
At `Administration Settings > LibreSign`

Before generate certificate:

![image](https://github.com/user-attachments/assets/0f16ae4f-4344-4634-acd4-7645ed4ad793)

After generate certificate:

![image](https://github.com/user-attachments/assets/d7e90653-fc4a-4a7d-9548-542693af91fb)

Reading certificate data is possible to see the certificate policies at owner and issuer certificate:
![image](https://github.com/user-attachments/assets/45b9679f-0cd2-4151-8cb1-b524bf85f66e)

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [feat/manage-certificate-policy](https://github.com/LibreSign/libresign/tree/feat/manage-certificate-policy)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
<details>