### PR TITLE
fix: user userId when validate file

### DIFF
--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -27,7 +27,6 @@ use OCA\Libresign\Service\FileService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SignerElementsService;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -74,7 +73,6 @@ class ValidateHelper {
 		private IGroupManager $groupManager,
 		private IUserManager $userManager,
 		private IRootFolder $root,
-		private IUserMountCache $userMountCache,
 	) {
 	}
 	public function validateNewFile(array $data, int $type = self::TYPE_TO_SIGN, ?IUser $user = null): void {

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -29,7 +29,6 @@ use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Config\IMountProviderCollection;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
@@ -57,7 +56,6 @@ class AccountService {
 		private IUserManager $userManager,
 		private IAccountManager $accountManager,
 		private IRootFolder $root,
-		private IUserMountCache $userMountCache,
 		private IMimeTypeDetector $mimeTypeDetector,
 		private FileMapper $fileMapper,
 		private FileTypeMapper $fileTypeMapper,

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -27,7 +27,6 @@ use OCA\Libresign\ResponseDefinitions;
 use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -85,7 +84,6 @@ class FileService {
 		private IURLGenerator $urlGenerator,
 		protected IMimeTypeDetector $mimeTypeDetector,
 		protected Pkcs12Handler $pkcs12Handler,
-		private IUserMountCache $userMountCache,
 		private IRootFolder $root,
 		protected LoggerInterface $logger,
 		protected IL10N $l10n,

--- a/lib/Service/FolderService.php
+++ b/lib/Service/FolderService.php
@@ -11,7 +11,6 @@ namespace OCA\Libresign\Service;
 use OCA\Libresign\Exception\LibresignException;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Files\AppData\IAppDataFactory;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
@@ -27,7 +26,6 @@ class FolderService {
 	protected IAppData $appData;
 	public function __construct(
 		private IRootFolder $root,
-		private IUserMountCache $userMountCache,
 		protected IAppDataFactory $appDataFactory,
 		protected IGroupManager $groupManager,
 		private IAppConfig $appConfig,

--- a/lib/Service/IdentifyMethod/IdentifyService.php
+++ b/lib/Service/IdentifyMethod/IdentifyService.php
@@ -16,7 +16,6 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Service\SessionService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -35,7 +34,6 @@ class IdentifyService {
 		private IRootFolder $root,
 		private IAppConfig $appConfig,
 		private SignRequestMapper $signRequestMapper,
-		private IUserMountCache $userMountCache,
 		private IL10N $l10n,
 		private FileMapper $fileMapper,
 		private IHasher $hasher,
@@ -109,10 +107,6 @@ class IdentifyService {
 
 	public function getSignRequestMapper(): SignRequestMapper {
 		return $this->signRequestMapper;
-	}
-
-	public function getUserMountCache(): IUserMountCache {
-		return $this->userMountCache;
 	}
 
 	public function getL10n(): IL10N {

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -39,7 +39,6 @@ use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\EmailToken;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -92,7 +91,6 @@ class SignFileService {
 		private IRootFolder $root,
 		private IUserSession $userSession,
 		private IDateTimeZone $dateTimeZone,
-		private IUserMountCache $userMountCache,
 		private FileElementMapper $fileElementMapper,
 		private UserElementMapper $userElementMapper,
 		private IEventDispatcher $eventDispatcher,

--- a/tests/Unit/Helper/ValidateHelperTest.php
+++ b/tests/Unit/Helper/ValidateHelperTest.php
@@ -189,7 +189,7 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->userMountCache
 			->method('getMountsForFileId')
 			->willreturn([]);
-		$actual = $this->getValidateHelper()->validateMimeTypeAcceptedByNodeId(171, $destination);
+		$actual = $this->getValidateHelper()->validateMimeTypeAcceptedByNodeId(171, '', $destination);
 		if (!$exception) {
 			$this->assertNull($actual);
 		}

--- a/tests/Unit/Service/AccountServiceTest.php
+++ b/tests/Unit/Service/AccountServiceTest.php
@@ -29,7 +29,6 @@ use OCA\Libresign\Service\SignFileService;
 use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccountManager;
 use OCP\Files\Config\IMountProviderCollection;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
@@ -50,7 +49,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IUserManager&MockObject $userManager;
 	private IAccountManager $accountManager;
 	private IRootFolder&MockObject $root;
-	private IUserMountCache&MockObject $userMountCache;
 	private IMimeTypeDetector&MockObject $mimeTypeDetector;
 	private FileMapper&MockObject $fileMapper;
 	private FileTypeMapper&MockObject $fileTypeMapper;
@@ -84,7 +82,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->accountManager = $this->createMock(IAccountManager::class);
 		$this->root = $this->createMock(IRootFolder::class);
-		$this->userMountCache = $this->createMock(IUserMountCache::class);
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->fileTypeMapper = $this->createMock(FileTypeMapper::class);
@@ -116,7 +113,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->userManager,
 			$this->accountManager,
 			$this->root,
-			$this->userMountCache,
 			$this->mimeTypeDetector,
 			$this->fileMapper,
 			$this->fileTypeMapper,
@@ -369,9 +365,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->fileMapper
 			->method('getByUuid')
 			->will($this->returnValue($libresignFile));
-		$this->userMountCache
-			->method('getMountsForFileId')
-			->willreturn([]);
 		$node = $this->createMock(\OCP\Files\File::class);
 		$this->root
 			->method('getUserFolder')
@@ -389,9 +382,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->fileMapper
 			->method('getByUuid')
 			->will($this->returnValue($libresignFile));
-		$this->userMountCache
-			->method('getMountsForFileId')
-			->willreturn([]);
 		$node = $this->createMock(\OCP\Files\File::class);
 		$this->root
 			->method('getUserFolder')

--- a/tests/Unit/Service/FileServiceTest.php
+++ b/tests/Unit/Service/FileServiceTest.php
@@ -35,7 +35,6 @@ use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\PdfParserService;
 use OCA\Libresign\Tests\lib\AppConfigOverwrite;
 use OCP\Accounts\IAccountManager;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Http\Client\IClientService;
@@ -72,7 +71,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IURLGenerator $urlGenerator;
 	protected IMimeTypeDetector $mimeTypeDetector;
 	protected Pkcs12Handler $pkcs12Handler;
-	private IUserMountCache $userMountCache;
 	private IRootFolder $root;
 	protected LoggerInterface $logger;
 	protected IL10N $l10n;
@@ -108,7 +106,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->urlGenerator = \OCP\Server::get(IURLGenerator::class);
 		$this->mimeTypeDetector = \OCP\Server::get(IMimeTypeDetector::class);
 		$this->pkcs12Handler = \OCP\Server::get(Pkcs12Handler::class);
-		$this->userMountCache = \OCP\Server::get(IUserMountCache::class);
 		$this->root = \OCP\Server::get(IRootFolder::class);
 		$this->logger = \OCP\Server::get(LoggerInterface::class);
 		$this->l10n = \OCP\Server::get(IL10NFactory::class)->get(Application::APP_ID);
@@ -131,7 +128,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->urlGenerator,
 			$this->mimeTypeDetector,
 			$this->pkcs12Handler,
-			$this->userMountCache,
 			$this->root,
 			$this->logger,
 			$this->l10n,

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -12,7 +12,6 @@ use Exception;
 use OCA\Libresign\Service\FolderService;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Files\AppData\IAppDataFactory;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
@@ -59,7 +58,6 @@ final class FakeFolder implements ISimpleFolder {
 
 final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IRootFolder&MockObject $root;
-	private IUserMountCache&MockObject $userMountCache;
 	private IAppDataFactory&MockObject $appDataFactory;
 	private IGroupManager&MockObject $groupManager;
 	private IAppConfig&MockObject $appConfig;
@@ -68,7 +66,6 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->root = $this->createMock(IRootFolder::class);
-		$this->userMountCache = $this->createMock(IUserMountCache::class);
 		$this->appDataFactory = $this->createMock(IAppDataFactory::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
@@ -78,7 +75,6 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private function getFolderService(?string $userId = '171'): FolderSErvice {
 		$service = new FolderService(
 			$this->root,
-			$this->userMountCache,
 			$this->appDataFactory,
 			$this->groupManager,
 			$this->appConfig,
@@ -106,7 +102,6 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetFileWithInvalidNodeId():void {
-		$this->userMountCache->method('getMountsForFileId')->wilLReturn([]);
 		$folder = $this->createMock(\OCP\Files\Folder::class);
 		$folder->method('isUpdateable')->willReturn(true);
 		$this->root->method('getUserFolder')->willReturn($folder);
@@ -117,9 +112,6 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetFolderWithValidNodeId():void {
-		$this->userMountCache
-			->method('getMountsForFileId')
-			->willreturn([]);
 		$node = $this->createMock(\OCP\Files\File::class);
 		$folder = $this->createMock(\OCP\Files\Folder::class);
 		$node->method('getParent')

--- a/tests/Unit/Service/SignFileServiceTest.php
+++ b/tests/Unit/Service/SignFileServiceTest.php
@@ -22,7 +22,6 @@ use OCA\Libresign\Service\SignerElementsService;
 use OCA\Libresign\Service\SignFileService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
@@ -57,7 +56,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IRootFolder&MockObject $root;
 	private IUserSession&MockObject $userSession;
 	private IDateTimeZone $dateTimeZone;
-	private IUserMountCache&MockObject $userMountCache;
 	private FileElementMapper&MockObject $fileElementMapper;
 	private UserElementMapper&MockObject $userElementMapper;
 	private IEventDispatcher&MockObject $eventDispatcher;
@@ -89,7 +87,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->root = $this->createMock(\OCP\Files\IRootFolder::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->dateTimeZone = \OCP\Server::get(IDateTimeZone::class);
-		$this->userMountCache = $this->createMock(IUserMountCache::class);
 		$this->fileElementMapper = $this->createMock(FileElementMapper::class);
 		$this->userElementMapper = $this->createMock(UserElementMapper::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -119,7 +116,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->root,
 			$this->userSession,
 			$this->dateTimeZone,
-			$this->userMountCache,
 			$this->fileElementMapper,
 			$this->userElementMapper,
 			$this->eventDispatcher,
@@ -193,9 +189,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->willReturn($this->root);
 		$this->root->method('getById')
 			->willReturn([]);
-		$this->userMountCache
-			->method('getMountsForFileId')
-			->wilLReturn([]);
 
 		$signRequest = new \OCA\Libresign\Db\SignRequest();
 		$this->getService()
@@ -222,7 +215,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->root->method('getUserFolder')->willReturn($this->root);
 		$this->root->method('getById')->willReturn([$nextcloudFile]);
 		$this->root->method('newFile')->willReturn($nextcloudFile);
-		$this->userMountCache->method('getMountsForFileId')->willReturn([]);
 
 		$this->pkcs12Handler->method('setInputFile')->willReturn($this->pkcs12Handler);
 		$this->pkcs12Handler->method('setCertificate')->willReturn($this->pkcs12Handler);


### PR DESCRIPTION
Every when we load a file from Nextcloud, would be good to have the fileId to be quicky. When we request to sign a file from fileId, the file already exists before create the sign request and because this, we haven't a LibreSign file. To prevent error, I get the userId of who requessted to sign the document and sent to validation methods and after whis, was possible to validate the file.

close #4847