### PR TITLE
chore: change save signed file logic

### DIFF
--- a/tests/Unit/Service/SignFileServiceTest.php
+++ b/tests/Unit/Service/SignFileServiceTest.php
@@ -212,9 +212,17 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$nextcloudFile->method('getContent')->willReturn('fake content');
 		$nextcloudFile->method('getId')->willReturn(171);
 
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('getUID')->willReturn('john.doe');
+		$nextcloudFile->method('getOwner')->willReturn($user);
+
 		$this->root->method('getUserFolder')->willReturn($this->root);
 		$this->root->method('getById')->willReturn([$nextcloudFile]);
 		$this->root->method('newFile')->willReturn($nextcloudFile);
+
+		$nextcloudFolder = $this->createMock(\OCP\Files\Folder::class);
+		$nextcloudFolder->method('newFile')->willReturn($nextcloudFile);
+		$this->root->method('getFirstNodeById')->willReturn($nextcloudFolder);
 
 		$this->pkcs12Handler->method('setInputFile')->willReturn($this->pkcs12Handler);
 		$this->pkcs12Handler->method('setCertificate')->willReturn($this->pkcs12Handler);


### PR DESCRIPTION
Previous logic:

- Try to create the file using full path at root folder
- Save the file content at created file.

Problem: Nextcloud server disalowed to write a content into a file that isn't of authenticated user because will use the authenticated user to handle root folder.

Current logic:

- Get the parent nodeId of original file. This is the folder of original file.
- Get the owner of original file
- Get the user folder of onwer
- Using the nodeId from first step, get the parent folder by ID
- Create the signed file inside the parent folder

Possible solution: When we get the user folder of owner of file, will get with permission to write.
