### PR TITLE
feat: add administration settings to settings menu

### DIFF
--- a/src/Components/Settings/Settings.vue
+++ b/src/Components/Settings/Settings.vue
@@ -8,6 +8,13 @@
 		<NcAppNavigationItem icon="icon-user"
 			:name="t('libresign', 'Account')"
 			:to=" {name: 'Account'} " />
+		<NcAppNavigationItem v-if="isAdmin"
+			:name="t('libresign', 'Administration')"
+			:href="getAdminRoute()">
+			<template #icon>
+				<TuneIcon :size="20" />
+			</template>
+		</NcAppNavigationItem>
 		<NcAppNavigationItem :name="t('libresign', 'Rate LibreSign  ❤️')"
 			href="https://apps.nextcloud.com/apps/libresign#comments">
 			<template #icon>
@@ -19,6 +26,10 @@
 
 <script>
 import StarIcon from 'vue-material-design-icons/Star.vue'
+import TuneIcon from 'vue-material-design-icons/Tune.vue'
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { generateUrl } from '@nextcloud/router'
 
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 
@@ -27,6 +38,17 @@ export default {
 	components: {
 		NcAppNavigationItem,
 		StarIcon,
+		TuneIcon,
+	},
+	data() {
+		return {
+			isAdmin: getCurrentUser().isAdmin,
+		}
+	},
+	methods: {
+		getAdminRoute() {
+			return generateUrl('settings/admin/libresign')
+		},
 	},
 }
 </script>


### PR DESCRIPTION
Added link to administration settings at settings menu:

|🏚️ Before|🏡 After|
|---|---|
|![Screenshot_20250513_150916](https://github.com/user-attachments/assets/1ac2e7c2-24ae-4ae7-8fc5-fb3f165ee6a2)|![Screenshot_20250513_150604](https://github.com/user-attachments/assets/40fb954f-7ed5-4136-97b6-9b1737cf52bf)|

This don't will open administration settings as modal, this use the href attribute.