### PR TITLE
fix: prevent merge when haven't a signature

### DIFF
--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -212,11 +212,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 					} else {
 						// --render-mode DESCRIPTION_ONLY, this is the default
 						// render-mode, because this, is unecessary to set here
-						$params['--bg-path'] = $this->mergeBackgroundWithSignature(
-							$backgroundPath,
-							$signatureImagePath,
-							$scaleFactor < 5 ? 5 : $scaleFactor
-						);
+						$params['--bg-path'] = $backgroundPath;
 					}
 				}
 

--- a/tests/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -243,7 +243,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => 10,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path merged.png --hash-algorithm SHA256'
+				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path background.png --hash-algorithm SHA256'
 			],
 			'font size != 10' => [
 				'visibleElements' => [self::getElement([
@@ -261,7 +261,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => 11,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --font-size 11 --bg-path merged.png --hash-algorithm SHA256'
+				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --font-size 11 --bg-path background.png --hash-algorithm SHA256'
 			],
 			'background = deleted: bg-path = signature' => [
 				'visibleElements' => [self::getElement([


### PR DESCRIPTION
When the signature stamp is SIGNAME_AND_DESCRIPTION or DESCRIPTION_ONLY, the signer don't will have a personal signature stamp.