### PR TITLE
fix: display error message instead of json

### DIFF
--- a/src/views/DefaultPageError.vue
+++ b/src/views/DefaultPageError.vue
@@ -16,7 +16,7 @@
 				:key="index"
 				type="error"
 				heading="Error">
-				{{ error }}
+				{{ error.message }}
 			</NcNoteCard>
 		</div>
 	</div>


### PR DESCRIPTION
|🏚️ Before|🏡 After|
|---|---|
|![Screenshot_20250520_143249](https://github.com/user-attachments/assets/791e650a-cb77-4c8a-b0c7-ed251631d993)|![Screenshot_20250520_143154](https://github.com/user-attachments/assets/48727eff-7ada-4f6e-9a68-6ea00b175b45)|