### PR TITLE
fix: notification and activity parameters

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -141,6 +141,7 @@ class Listener implements IEventListener {
 					$identifyMethod->getEntity()->getIdentifierKey(),
 					$identifyMethod->getEntity()->getIdentifierValue(),
 					$signRequest->getDisplayName(),
+					$identifyMethod->getEntity()->getId(),
 				),
 				'file' => [
 					'type' => 'file',
@@ -151,8 +152,8 @@ class Listener implements IEventListener {
 						'path' => 'validation/' . $libreSignFile->getUuid(),
 					]),
 				],
-				'signedFile' => [
-					'type' => 'signed-file',
+				'sign-request' => [
+					'type' => 'sign-request',
 					'id' => (string)$signRequest->getId(),
 					'name' => $signRequest->getDisplayName(),
 				],
@@ -193,6 +194,7 @@ class Listener implements IEventListener {
 		string $type,
 		string $identifier,
 		string $displayName,
+		int $identifyMethodId,
 	): array {
 
 		if ($type === 'account') {
@@ -203,6 +205,8 @@ class Listener implements IEventListener {
 		}
 
 		return [
+			'type' => 'signer',
+			'id' => (string) $identifyMethodId,
 			'name' => $displayName,
 		];
 	}

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -206,7 +206,7 @@ class Listener implements IEventListener {
 
 		return [
 			'type' => 'signer',
-			'id' => (string) $identifyMethodId,
+			'id' => (string)$identifyMethodId,
 			'name' => $displayName,
 		];
 	}

--- a/lib/Activity/Provider/Signed.php
+++ b/lib/Activity/Provider/Signed.php
@@ -37,7 +37,7 @@ class Signed implements IProvider {
 			throw new UnknownActivityException('subject');
 		}
 
-		$this->definitions->definitions['signed-file'] = [
+		$this->definitions->definitions['sign-request'] = [
 			'author' => 'LibreSign',
 			'since' => '30.0.0',
 			'parameters' => [
@@ -45,6 +45,24 @@ class Signed implements IProvider {
 					'since' => '30.0.0',
 					'required' => true,
 					'description' => 'The id of SignRequest object',
+					'example' => '12345',
+				],
+				'name' => [
+					'since' => '30.0.0',
+					'required' => true,
+					'description' => 'The display name of signer',
+					'example' => 'John Doe',
+				],
+			],
+		];
+		$this->definitions->definitions['signer'] = [
+			'author' => 'LibreSign',
+			'since' => '30.0.0',
+			'parameters' => [
+				'id' => [
+					'since' => '30.0.0',
+					'required' => true,
+					'description' => 'The identify method id',
 					'example' => '12345',
 				],
 				'name' => [

--- a/lib/Activity/Settings/FileSigned.php
+++ b/lib/Activity/Settings/FileSigned.php
@@ -12,6 +12,7 @@ use OCA\Libresign\Events\SignedEvent;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCP\IL10N;
+use OCP\IUser;
 use OCP\IUserSession;
 
 class FileSigned extends LibresignActivitySettings {
@@ -47,6 +48,9 @@ class FileSigned extends LibresignActivitySettings {
 	 * {@inheritdoc}
 	 */
 	public function canChangeNotification(): bool {
+		if (!$this->userSession->getUser() instanceof IUser) {
+			return true;
+		}
 		try {
 			$this->validateHelper->canrequestSign($this->userSession->getUser());
 		} catch (LibresignException) {
@@ -59,6 +63,9 @@ class FileSigned extends LibresignActivitySettings {
 	 * {@inheritdoc}
 	 */
 	public function canChangeMail() {
+		if (!$this->userSession->getUser() instanceof IUser) {
+			return true;
+		}
 		try {
 			$this->validateHelper->canrequestSign($this->userSession->getUser());
 		} catch (LibresignException) {

--- a/lib/Listener/NotificationListener.php
+++ b/lib/Listener/NotificationListener.php
@@ -128,6 +128,7 @@ class NotificationListener implements IEventListener {
 					$identifyMethod->getEntity()->getIdentifierKey(),
 					$identifyMethod->getEntity()->getIdentifierValue(),
 					$signRequest->getDisplayName(),
+					$identifyMethod->getEntity()->getId(),
 				),
 				'file' => [
 					'type' => 'file',
@@ -138,8 +139,8 @@ class NotificationListener implements IEventListener {
 						'path' => 'validation/' . $libreSignFile->getUuid(),
 					]),
 				],
-				'signedFile' => [
-					'type' => 'signed-file',
+				'sign-request' => [
+					'type' => 'sign-request',
 					'id' => (string)$signRequest->getId(),
 					'name' => $signRequest->getDisplayName(),
 				],
@@ -194,6 +195,7 @@ class NotificationListener implements IEventListener {
 		string $type,
 		string $identifier,
 		string $displayName,
+		int $identifyMethodId,
 	): array {
 
 		if ($type === 'account') {
@@ -204,6 +206,8 @@ class NotificationListener implements IEventListener {
 		}
 
 		return [
+			'type' => 'signer',
+			'id' => (string) $identifyMethodId,
 			'name' => $displayName,
 		];
 	}

--- a/lib/Listener/NotificationListener.php
+++ b/lib/Listener/NotificationListener.php
@@ -207,7 +207,7 @@ class NotificationListener implements IEventListener {
 
 		return [
 			'type' => 'signer',
-			'id' => (string) $identifyMethodId,
+			'id' => (string)$identifyMethodId,
 			'name' => $displayName,
 		];
 	}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -135,7 +135,7 @@ class Notifier implements INotifier {
 		IL10N $l,
 	): INotification {
 
-		$this->definitions->definitions['signed-file'] = [
+		$this->definitions->definitions['sign-request'] = [
 			'author' => 'LibreSign',
 			'since' => '30.0.0',
 			'parameters' => [
@@ -143,6 +143,24 @@ class Notifier implements INotifier {
 					'since' => '30.0.0',
 					'required' => true,
 					'description' => 'The id of SignRequest object',
+					'example' => '12345',
+				],
+				'name' => [
+					'since' => '30.0.0',
+					'required' => true,
+					'description' => 'The display name of signer',
+					'example' => 'John Doe',
+				],
+			],
+		];
+		$this->definitions->definitions['signer'] = [
+			'author' => 'LibreSign',
+			'since' => '30.0.0',
+			'parameters' => [
+				'id' => [
+					'since' => '30.0.0',
+					'required' => true,
+					'description' => 'The identify method id',
 					'example' => '12345',
 				],
 				'name' => [

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -199,10 +199,10 @@ class FeatureContext extends NextcloudApiContext implements OpenedEmailStorageAw
 	}
 
 	/**
-	 * @When reset notifications of user :user
+	 * @When reset :type of user :user
 	 */
-	public function resetNotifications($user): void {
-		self::runCommand('libresign:developer:reset --notifications=' . $user);
+	public function resetNotifications($type, $user): void {
+		self::runCommand('libresign:developer:reset --' . $type . '=' . $user);
 	}
 
 	/**

--- a/tests/integration/features/sign/signed.feature
+++ b/tests/integration/features/sign/signed.feature
@@ -63,6 +63,7 @@ Feature: signed
     And my inbox is empty
     And reset notifications of user "signer1"
     And reset notifications of user "admin"
+    And reset activity of user "admin"
     When sending "post" to ocs "/apps/libresign/api/v1/request-signature"
       | file | {"url":"<BASE_URL>/apps/libresign/develop/pdf"} |
       | users | [{"displayName": "Signer Name","identify": {"account": "signer1"}},{"displayName": "Admin","identify": {"account": "admin"}}] |
@@ -126,6 +127,7 @@ Feature: signed
     And my inbox is empty
     And reset notifications of user "signer1"
     And reset notifications of user "admin"
+    And reset activity of user "admin"
     When sending "post" to ocs "/apps/libresign/api/v1/request-signature"
       | file | {"url":"<BASE_URL>/apps/libresign/develop/pdf"} |
       | users | [{"displayName": "Signer Name","identify": {"account": "signer1"}},{"displayName": "Admin","identify": {"account": "admin"}}] |

--- a/tests/integration/features/sign/signed.feature
+++ b/tests/integration/features/sign/signed.feature
@@ -162,3 +162,47 @@ Feature: signed
     And the response should be a JSON array with the following mandatory values
       | key | value                                                          |
       | ocs | (jq).data\|any(.subject == "Signer Name signed Document Name") |
+
+  Scenario: Signing a file using unauthenticatd signer
+    Given as user "admin"
+    And run the command "config:app:set activity notify_notification_libresign_file_to_sign --value=1" with result code 0
+    And run the command "config:app:set activity notify_email_libresign_file_to_sign --value=1" with result code 0
+    And run the command "config:app:set activity notify_notification_libresign_file_signed --value=1" with result code 0
+    And run the command "config:app:set activity notify_email_libresign_file_signed --value=1" with result code 0
+    And run the command "user:setting admin activity notify_notification_libresign_file_signed 1" with result code 0
+    And run the command "user:setting admin activity notify_email_libresign_file_signed 1" with result code 0
+    And run the command "libresign:install --use-local-cert --java" with result code 0
+    And run the command "libresign:install --use-local-cert --jsignpdf" with result code 0
+    And run the command "libresign:install --use-local-cert --pdftk" with result code 0
+    And run the command "libresign:configure:openssl --cn=Common\ Name --c=BR --o=Organization --st=State\ of\ Company --l=City\ Name --ou=Organization\ Unit" with result code 0
+    And sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+    And sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | (string)[{"name":"email","enabled":true,"mandatory":true,"signatureMethods":{"clickToSign":{"enabled":true}},"can_create_account":false}] |
+    And my inbox is empty
+    And reset notifications of user "admin"
+    And reset activity of user "admin"
+    When sending "post" to ocs "/apps/libresign/api/v1/request-signature"
+      | file | {"url":"<BASE_URL>/apps/libresign/develop/pdf"} |
+      | users | [{"displayName": "Signer Name","identify": {"email": "unauthenticated@email.tld"}}] |
+      | name | Document Name |
+    And the response should have a status code 200
+    And I open the latest email to "unauthenticated@email.tld" with subject "LibreSign: There is a file for you to sign"
+    And I fetch the signer UUID from opened email
+    And as user ""
+    And sending "post" to ocs "/apps/libresign/api/v1/sign/uuid/<SIGN_UUID>"
+      | method | clickToSign |
+    And the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key                     | value       |
+      | (jq).ocs.data.message   | File signed |
+    When as user "admin"
+    And sending "get" to ocs "/apps/notifications/api/v2/notifications"
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key | value                                                         |
+      | ocs | (jq).data\|any(.subject == "Signer Name signed Document Name")|
+    When sending "get" to ocs "/apps/activity/api/v2/activity/libresign?since=0"
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key | value                                                          |
+      | ocs | (jq).data\|any(.subject == "Signer Name signed Document Name") |


### PR DESCRIPTION
When the signer haven't an account, also is necessary to notify who requested to sign the file.

- Added: Signer representing the item of identify method
- Renamed: signed-file to sign-request, the new name is more clear

Solve:
- #5011