### PR TITLE
fix: prevent flakiness at scenario with time

### DIFF
--- a/tests/integration/features/sign/request.feature
+++ b/tests/integration/features/sign/request.feature
@@ -149,12 +149,15 @@ Feature: request-signature
     And I open the latest email to "signer2@domain.test" with subject "LibreSign: Changes into a file for you to sign"
     And I fetch the signer UUID from opened email
     And as user ""
-    # setting the renewal interval to 2 and making 3 requests, one by second,
-    # the 3rd don't will fail because on each valid request, the renewal
+    # setting the renewal interval to 3 and making 4 requests, one by second,
+    # the 4rd don't will fail because on each valid request, the renewal
     # interval is renewed.
-    And run the command "config:app:set libresign renewal_interval --value=2 --type=integer" with result code 0
+    And run the command "config:app:set libresign renewal_interval --value=3 --type=integer" with result code 0
     When sending "get" to "/apps/libresign/p/sign/<SIGN_UUID>"
     And the response should have a status code 200
+    Given wait for 1 second
+    When sending "get" to "/apps/libresign/p/sign/<SIGN_UUID>"
+    Then the response should have a status code 200
     Given wait for 1 second
     When sending "get" to "/apps/libresign/p/sign/<SIGN_UUID>"
     Then the response should have a status code 200


### PR DESCRIPTION
I increased the renewal interval to be bigger than a possible delay at a request.