### PR TITLE
chore: hide JSignPDF config check

### DIFF
--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -79,7 +79,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 				$this->jSignParam->setJavaPath(
 					$this->getEnvironments() .
 					$javaPath .
-					' -Duser.home="' . $this->getHome() . '" '
+					' -Duser.home=' . escapeshellarg($this->getHome()) . ' '
 				);
 			}
 		}
@@ -87,7 +87,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 	}
 
 	private function getEnvironments(): string {
-		return 'JSIGNPDF_HOME=' . $this->getHome() . ' ';
+		return 'JSIGNPDF_HOME=' . escapeshellarg($this->getHome()) . ' ';
 	}
 
 	/**

--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -76,10 +76,26 @@ class JSignPdfHandler extends Pkcs12Handler {
 				if (!file_exists($javaPath)) {
 					throw new \Exception('Invalid Java binary. Run occ libresign:install --java');
 				}
-				$this->jSignParam->setJavaPath($javaPath);
+				$this->jSignParam->setJavaPath(
+					'JSIGNPDF_HOME=' . $this->getTempConfigFolder() . ' ' . $javaPath
+				);
 			}
 		}
 		return $this->jSignParam;
+	}
+
+	private function getTempConfigFolder(): string {
+		$jsignpdfTempFolder = $this->tempManager->getTemporaryFolder('jsignpdf');
+		if (!$jsignpdfTempFolder) {
+			throw new \Exception('Temporary file not accessible');
+		}
+		mkdir(
+			directory: $jsignpdfTempFolder . '/conf',
+			recursive: true
+		);
+		$file = fopen($jsignpdfTempFolder . '/conf/conf.properties', 'w');
+		fclose($file);
+		return $jsignpdfTempFolder;
 	}
 
 	private function getHashAlgorithm(): string {

--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -77,11 +77,19 @@ class JSignPdfHandler extends Pkcs12Handler {
 					throw new \Exception('Invalid Java binary. Run occ libresign:install --java');
 				}
 				$this->jSignParam->setJavaPath(
-					'JSIGNPDF_HOME=' . $this->getTempConfigFolder() . ' ' . $javaPath
+					$this->getEnvironments() . $javaPath
 				);
 			}
 		}
 		return $this->jSignParam;
+	}
+
+	private function getEnvironments(): string {
+		$jSignPdfHome = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home', '');
+		if ($jSignPdfHome) {
+			return 'JSIGNPDF_HOME=' . $jSignPdfHome . ' ';
+		}
+		return 'JSIGNPDF_HOME=' . $this->getTempConfigFolder() . ' ';
 	}
 
 	private function getTempConfigFolder(): string {

--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -77,7 +77,9 @@ class JSignPdfHandler extends Pkcs12Handler {
 					throw new \Exception('Invalid Java binary. Run occ libresign:install --java');
 				}
 				$this->jSignParam->setJavaPath(
-					$this->getEnvironments() . $javaPath
+					$this->getEnvironments() .
+					$javaPath .
+					' -Duser.home="' . $this->getHome() . '" '
 				);
 			}
 		}
@@ -85,14 +87,20 @@ class JSignPdfHandler extends Pkcs12Handler {
 	}
 
 	private function getEnvironments(): string {
-		$jSignPdfHome = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home', '');
-		if ($jSignPdfHome) {
-			return 'JSIGNPDF_HOME=' . $jSignPdfHome . ' ';
-		}
-		return 'JSIGNPDF_HOME=' . $this->getTempConfigFolder() . ' ';
+		return 'JSIGNPDF_HOME=' . $this->getHome() . ' ';
 	}
 
-	private function getTempConfigFolder(): string {
+	/**
+	 * It's a workaround to create the folder structure that JSignPdf needs. Without
+	 * this, the JSignPdf will return the follow message to all commands:
+	 * > FINE Config file conf/conf.properties doesn't exists.
+	 * > FINE Default property file /root/.JSignPdf doesn't exists.
+	 */
+	private function getHome(): string {
+		$jSignPdfHome = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home', '');
+		if ($jSignPdfHome) {
+			return $jSignPdfHome;
+		}
 		$jsignpdfTempFolder = $this->tempManager->getTemporaryFolder('jsignpdf');
 		if (!$jsignpdfTempFolder) {
 			throw new \Exception('Temporary file not accessible');
@@ -101,8 +109,10 @@ class JSignPdfHandler extends Pkcs12Handler {
 			directory: $jsignpdfTempFolder . '/conf',
 			recursive: true
 		);
-		$file = fopen($jsignpdfTempFolder . '/conf/conf.properties', 'w');
-		fclose($file);
+		$configFile = fopen($jsignpdfTempFolder . '/conf/conf.properties', 'w');
+		fclose($configFile);
+		$propertyFile = fopen($jsignpdfTempFolder . '/.JSignPdf', 'w');
+		fclose($propertyFile);
 		return $jsignpdfTempFolder;
 	}
 

--- a/lib/Service/Install/InstallService.php
+++ b/lib/Service/Install/InstallService.php
@@ -488,15 +488,17 @@ class InstallService {
 	 * It's a workaround to create the folder structure that JSignPdf needs. Without
 	 * this, the JSignPdf will return the follow message to all commands:
 	 * > FINE Config file conf/conf.properties doesn't exists.
+	 * > FINE Default property file /root/.JSignPdf doesn't exists.
 	 */
 	private function saveJsignPdfHome(): void {
 		if ($this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home')) {
 			return;
 		}
-		$configFolder = $this->getFolder('/jsignpdf/conf/');
+		$homeFolder = $this->getFolder('/jsignpdf/');
+		$homeFolder->newFile('.JSignPdf', '');
+		$configFolder = $this->getFolder('conf', $homeFolder);
 		$configFolder->newFile('conf.properties', '');
-		$configFolder->newFolder('conf')->newFile('conf.properties', '');
-		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_home', $this->getInternalPathOfFolder($configFolder));
+		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_home', $this->getInternalPathOfFolder($homeFolder));
 	}
 
 	public function uninstallJSignPdf(): void {

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -396,7 +396,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 		$expected = new JSignParam();
 		if ($java_path) {
-			$expected->setJavaPath('JSIGNPDF_HOME=/ ' . $java_path);
+			$expected->setJavaPath("JSIGNPDF_HOME='/' $java_path -Duser.home='/' ");
 		}
 		$expected->setTempPath($temp_path);
 		$expected->setjSignPdfJarPath($jar_path);

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -389,15 +389,16 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	#[DataProvider('providerGetJSignParam')]
 	public function testGetJSignParam(string $temp_path, string $java_path, string $jar_path, bool $throwException): void {
-		$expected = new JSignParam();
-
+		$this->appConfig->setValueString('libresign', 'jsignpdf_home', '/');
 		$this->appConfig->setValueString('libresign', 'java_path', $java_path);
-		$expected->setJavaPath($java_path);
-
 		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', $temp_path);
-		$expected->setTempPath($temp_path);
-
 		$this->appConfig->setValueString('libresign', 'jsignpdf_jar_path', $jar_path);
+
+		$expected = new JSignParam();
+		if ($java_path) {
+			$expected->setJavaPath('JSIGNPDF_HOME=/ ' . $java_path);
+		}
+		$expected->setTempPath($temp_path);
 		$expected->setjSignPdfJarPath($jar_path);
 
 		$jSignPdfHandler = $this->getInstance();


### PR DESCRIPTION
JSignPdf request a config file but this isn't necessary at LibreSign scope and show the follow message:

> FINE Config file conf/conf.properties doesn't exists.

Isn't possible suppress the usage of this file and to prevent this message, I created a temporary file. JSignPdf don't will get nothing from this file because using at CLI, we always send all the necessary properties to the command.