### PR TITLE
fix: show 'Dismiss notification' button on signed file notification

### DIFF
--- a/lib/Listener/NotificationListener.php
+++ b/lib/Listener/NotificationListener.php
@@ -139,8 +139,8 @@ class NotificationListener implements IEventListener {
 						'path' => 'validation/' . $libreSignFile->getUuid(),
 					]),
 				],
-				'sign-request' => [
-					'type' => 'sign-request',
+				'signedFile' => [
+					'type' => 'signer',
 					'id' => (string)$signRequest->getId(),
 					'name' => $signRequest->getDisplayName(),
 				],

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -135,24 +135,6 @@ class Notifier implements INotifier {
 		IL10N $l,
 	): INotification {
 
-		$this->definitions->definitions['sign-request'] = [
-			'author' => 'LibreSign',
-			'since' => '30.0.0',
-			'parameters' => [
-				'id' => [
-					'since' => '30.0.0',
-					'required' => true,
-					'description' => 'The id of SignRequest object',
-					'example' => '12345',
-				],
-				'name' => [
-					'since' => '30.0.0',
-					'required' => true,
-					'description' => 'The display name of signer',
-					'example' => 'John Doe',
-				],
-			],
-		];
 		$this->definitions->definitions['signer'] = [
 			'author' => 'LibreSign',
 			'since' => '30.0.0',


### PR DESCRIPTION
### Pull Request Description

The 'Dismiss notification' button was not appearing due to a rendering issue. This commit ensures the button is correctly displayed after a file is signed.


| Before: | After: |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/6e76b3ea-1bf8-49f9-a5a0-6e8dfc977a63" alt="before" /> | <img src="https://github.com/user-attachments/assets/5b29763e-c7d3-4ab5-a0ef-66e09f9fdfd3" alt="after" /> |

### Pull Request Type

- Bugfix