### PR TITLE
fix: fallback when system haven't a TTF font

### DIFF
--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -69,6 +69,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			\OCP\Server::get(IDateTimeZone::class),
 			\OCP\Server::get(IRequest::class),
 			\OCP\Server::get(IUserSession::class),
+			\OCP\Server::get(LoggerInterface::class),
 		);
 		if (empty($methods)) {
 			return new JSignPdfHandler(

--- a/tests/php/Unit/Service/SignatureTextServiceTest.php
+++ b/tests/php/Unit/Service/SignatureTextServiceTest.php
@@ -16,6 +16,7 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory as IL10NFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private SignatureTextService $service;
@@ -24,6 +25,8 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 	private IDateTimeZone $dateTimeZone;
 	private IRequest&MockObject $request;
 	private IUserSession&MockObject $userSession;
+	private LoggerInterface&MockObject $logger;
+
 
 	public function setUp(): void {
 		$this->l10n = \OCP\Server::get(IL10NFactory::class)->get(Application::APP_ID);
@@ -31,8 +34,8 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 		$this->dateTimeZone = \OCP\Server::get(IDateTimeZone::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 	}
-
 
 	private function getClass(): SignatureTextService {
 		$this->service = new SignatureTextService(
@@ -41,6 +44,7 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 			$this->dateTimeZone,
 			$this->request,
 			$this->userSession,
+			$this->logger,
 		);
 		return $this->service;
 	}
@@ -200,5 +204,9 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 			'left 175x50 scale 3' => ['Sign now', 175, 50, 'left',3],
 			'right 175x50 scale 4' => ['Signed 🔐', 175, 50, 'right', 4],
 		];
+	}
+
+	public function testHasFont(): void {
+		$this->assertFileExists($fallbackFond = __DIR__ . '/../../../../vendor/mpdf/mpdf/ttfonts/DejaVuSerifCondensed.ttf');
 	}
 }


### PR DESCRIPTION
Before this PR, when we open `Administration Settings > LibreSign` and the installation of extension Imagick haven't access to any ttf font, throws the follow error:

```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message></message>
 </meta>
 <data>
  <error>No fonts available at system</error>
 </data>
</ocs>
```

As fallback, I added the packed DejaVuSerif font and implemented an unit test to verify if mpdf have this font.

I used this font because we already pack this font with LibreSign and the test is to prevent problems if this font is renamed, moved or removed from mpdf.