### PR TITLE
chore: improve tip to sysadmin

### DIFF
--- a/lib/Service/Install/ConfigureCheckService.php
+++ b/lib/Service/Install/ConfigureCheckService.php
@@ -351,7 +351,7 @@ class ConfigureCheckService {
 		$this->logger->error('Invalid hash of binaries files', ['result' => $result]);
 		return [
 			'Invalid hash of binaries files.',
-			'Run occ libresign:install --all',
+			'Check your nextcloud.log file an run occ libresign:install --all',
 		];
 	}
 


### PR DESCRIPTION
I identified some issues related to `Invalid hash of binaries files.` but when this message is throw, also is regitered a log with what's happening and it's important to sysadmins.