### PR TITLE
fix: prevent warning when install first time

### DIFF
--- a/lib/Migration/DeleteOldBinaries.php
+++ b/lib/Migration/DeleteOldBinaries.php
@@ -64,7 +64,7 @@ class DeleteOldBinaries implements IRepairStep {
 		$this->output = $output;
 		$folder = $this->appData->getFolder('/');
 
-		$this->deleteFolder($folder, $this->allowedFiles);
+		$this->deleteInvalidFolder($folder, $this->allowedFiles);
 	}
 
 	private function scan(): void {
@@ -79,7 +79,7 @@ class DeleteOldBinaries implements IRepairStep {
 		$application->run($input, $output);
 	}
 
-	private function deleteFolder(ISimpleFolder $folder, array $allowedFiles): void {
+	private function deleteInvalidFolder(ISimpleFolder $folder, array $allowedFiles): void {
 		$list = $this->getSimpleFolderList($folder);
 		foreach ($list as $node) {
 			if (!in_array($node->getName(), $allowedFiles)) {


### PR DESCRIPTION
This change will prevent the follow message when is the first install of
LibreSign:

```
Path not found: /appdata_ocj14jptbq3n/libresign
```

And the follow message every when update LibreSign:

```
Scanning AppData for files

+---------+-------+--------------+
| Folders | Files | Elapsed time |
+---------+-------+--------------+
| 1       | 0     | 00:00:00     |
+---------+-------+--------------+
```