### PR TITLE
fix: prevent error when check binaries of JSignPdf

### DIFF
--- a/lib/Service/Install/InstallService.php
+++ b/lib/Service/Install/InstallService.php
@@ -489,10 +489,12 @@ class InstallService {
 	 * > FINE Default property file /root/.JSignPdf doesn't exists.
 	 */
 	private function saveJsignPdfHome(): void {
-		if ($this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home')) {
+		$home = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_home');
+		if ($home && preg_match('/libresign\/jsignpdf_home/', $home)) {
 			return;
 		}
-		$homeFolder = $this->getFolder('/jsignpdf/');
+		$libresignFolder = $this->appData->getFolder('/');
+		$homeFolder = $libresignFolder->newFolder('jsignpdf_home');
 		$homeFolder->newFile('.JSignPdf', '');
 		$configFolder = $this->getFolder('conf', $homeFolder);
 		$configFolder->newFile('conf.properties', '');


### PR DESCRIPTION
Every when the message "Invalid hash of binaries files" is throws, is added a log with the reason. At this case was consequence of previous change at setup of JSignPdf when was added a folder called jsignpdf_home to prevent warning of JSignPdf when is executed at CLI mode.

The folder in question is `conf`, and with this, will be created into another place.

At the log I got this:

```json
{
    "EXTRA_FILE": {
        "conf/conf.properties": {
            "expected": "",
            "current": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
        },
        ".JSignPdf": {
            "expected": "",
            "current": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
        }
    }
}
```

This don't affect LibreSign but could generate a false image that could
not work fine.