### PR TITLE
docs: add donation link to appear on Nextcloud appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,6 +41,7 @@ Developed with ❤️ by [LibreCode](https://librecode.coop). Help us transform 
     <repository type="git">https://github.com/LibreSign/libresign</repository>
     <screenshot>https://raw.githubusercontent.com/LibreSign/libresign/main/img/screenshot/request-signature.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/LibreSign/libresign/main/img/screenshot/presentation.gif</screenshot>
+	<donation>https://github.com/sponsors/LibreSign</donation>
     <dependencies>
         <lib>openssl</lib>
         <nextcloud min-version="32" max-version="32"/>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,7 +41,8 @@ Developed with ❤️ by [LibreCode](https://librecode.coop). Help us transform 
     <repository type="git">https://github.com/LibreSign/libresign</repository>
     <screenshot>https://raw.githubusercontent.com/LibreSign/libresign/main/img/screenshot/request-signature.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/LibreSign/libresign/main/img/screenshot/presentation.gif</screenshot>
-	<donation>https://github.com/sponsors/LibreSign</donation>
+	<donation title="Donate via GitHub Sponsors">https://github.com/sponsors/LibreSign</donation>
+    <donation type="stripe" title="Donate via Stripe">https://buy.stripe.com/eVqfZibhx8QO3LseWc2kw00</donation>
     <dependencies>
         <lib>openssl</lib>
         <nextcloud min-version="32" max-version="32"/>


### PR DESCRIPTION
For better visibility to users (who will not visit github page)

For preview of result see for example https://apps.nextcloud.com/apps/passwords

URL copied from "Sponsor this project" section.