### PR TITLE
fix: implemented debounce on signer search field

### DIFF
--- a/src/Components/Request/AccountOrEmail.vue
+++ b/src/Components/Request/AccountOrEmail.vue
@@ -29,6 +29,7 @@
 	</div>
 </template>
 <script>
+import debounce from 'debounce'
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 
 import axios from '@nextcloud/axios'
@@ -98,7 +99,7 @@ export default {
 		}
 	},
 	methods: {
-		async asyncFind(search, lookup = false) {
+		async _asyncFind(search, lookup = false) {
 			search = search.trim()
 			this.loading = true
 
@@ -117,6 +118,9 @@ export default {
 			this.options = response.data.ocs.data
 			this.loading = false
 		},
+		asyncFind: debounce(function(search, lookup = false) {
+			this._asyncFind(search,lookup)
+		}, 500),
 	},
 }
 </script>

--- a/src/Components/Request/AccountOrEmail.vue
+++ b/src/Components/Request/AccountOrEmail.vue
@@ -30,6 +30,7 @@
 </template>
 <script>
 import debounce from 'debounce'
+
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 
 import axios from '@nextcloud/axios'
@@ -119,7 +120,7 @@ export default {
 			this.loading = false
 		},
 		asyncFind: debounce(function(search, lookup = false) {
-			this._asyncFind(search,lookup)
+			this._asyncFind(search, lookup)
 		}, 500),
 	},
 }


### PR DESCRIPTION
### Pull Request Description
This pull request implements a 500ms debounce on the signer search field, previously each keystroke triggered an API request, This update improves the performance by reducing unnecessary API request. 

I Implemented debounce in the asyncFind method. I renamed the original asyncFind method to _asyncFind to separate the functionality, then I placed the asyncFind method wrapped in a 500ms debounce function, and imported debounce from the debounce package near the top of the file. 

You can manually test this by going to the LibreSign tab in NextCloud, open your browser's develop tools -> go to Network -> filter by "Fetch/XHR", then quickly type into the signer search input field, you should see one API request sent only after you stop typing. Previously, an API request was sent on every keystroke.

### Related Issue
Issue Number: #5004 

### Pull Request Type
- Other (please describe): Fix / Feature enhancement

### Pull request checklist

- [✅] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [✅] Did you provide a general summary of your changes ?
- [] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution
