### PR TITLE
fix: change display name

### DIFF
--- a/src/Components/Request/IdentifySigner.vue
+++ b/src/Components/Request/IdentifySigner.vue
@@ -13,7 +13,7 @@
 			@update:display-name="updateDisplayName" />
 		<label v-if="signerSelected" for="name-input">{{ t('libresign', 'Signer name') }}</label>
 		<NcTextField v-if="signerSelected"
-			v-model="signerSelected"
+			v-model="displayName"
 			aria-describedby="name-input"
 			autocapitalize="none"
 			:label="t('libresign', 'Signer name')"


### PR DESCRIPTION
The model was wrong, I fixed it.

Reference:
- #5137

|🏚️ Before|🏡 After|
|---|---|
|![Screenshot_20250614_163101](https://github.com/user-attachments/assets/25e2c5af-c22c-4b2f-b27c-f7f6727b85f7)|![Screenshot_20250614_162641](https://github.com/user-attachments/assets/cf661daa-33cf-4ac6-9b84-9a1a150f0294)|


<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
<details>