### PR TITLE
fix: validate file answer

### DIFF
--- a/src/views/Validation.vue
+++ b/src/views/Validation.vue
@@ -401,7 +401,7 @@ export default {
 	},
 	created() {
 		this.$set(this, 'document', loadState('libresign', 'file_info', {}))
-		this.hasInfo = Object.keys(this.document).length > 0
+		this.hasInfo = !!this.document?.name
 		if (this.hasInfo) {
 			this.document.signers.forEach(signer => {
 				this.$set(signer, 'opened', false)


### PR DESCRIPTION
### Pull Request Type

- Bugfix

The document object came from backend with content every time. If the backend return invalid file content, will have a key inside this array and need to be ignored. Considering that the name is returned every time, I used this to check if is a valid answer or not.

Considering that is a frontend fix and that we haven't any test at frontend side, this PR only will have handmade tests.

How to reproduce:

```gherkin
Scenario: Validate with success
  When sign a file
  And go to validation page
  Then You will see that the file is valid

Scenario: Validate with deleted file
  When sign a file
  And delete the file ".signed.pdf"
  And go to validation page
  Then you need to see the components to validate a new file
```

|🏚️ Before|🏡 After|
|---|---|
|![Screenshot_20250623_123901](https://github.com/user-attachments/assets/60132847-50f6-460b-9d78-b9fd542976e7)|![Screenshot_20250623_123652](https://github.com/user-attachments/assets/48fea801-1581-4f63-9b0d-63d190f6f7c2)|

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
~- [ ] I implemented tests that cover my contribution~
