### PR TITLE
fix: ignore vendor bin at transifex sync

### DIFF
--- a/.l10nignore
+++ b/.l10nignore
@@ -9,3 +9,4 @@ js/
 node_modules/
 tests/
 vendor/
+vendor-bin/


### PR DESCRIPTION
```php
echo count(array_filter($translatableFiles, fn($v) => strpos($v, "vendor-bin")));
```
Output: 9320

After this change was found any entry with vendor-bin

```php
echo count(array_filter($translatableFiles, fn($v) => strpos($v, "vendor-bin")));
```
Output: 0

This could affect the translatable strings that is send do Transifex.