### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -3,6 +3,10 @@
 
 name: Update Psalm baseline
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/LibreSign/libresign/security/code-scanning/7](https://github.com/LibreSign/libresign/security/code-scanning/7)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for checking out the repository.
- `pull-requests: write` for creating pull requests.

The `permissions` block should be added at the root level, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
