### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -11,6 +11,9 @@ name: REUSE Compliance Check
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   reuse-compliance-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LibreSign/libresign/security/code-scanning/5](https://github.com/LibreSign/libresign/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs a compliance check and does not modify repository contents, the minimal permissions required are `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow. This change ensures that the `GITHUB_TOKEN` operates with restricted privileges, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
