### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -8,6 +8,11 @@
 
 name: Build and publish app release
 
+permissions:
+  contents: read
+  actions: write
+  packages: write
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/LibreSign/libresign/security/code-scanning/1](https://github.com/LibreSign/libresign/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are recommended:
- `contents: read` for reading repository contents.
- `actions: write` for uploading artifacts and interacting with GitHub Actions.
- `packages: write` for publishing packages if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build_and_publish` job to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
