### PR TITLE
[stable30] fix: build and publish workflow permission

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -9,9 +9,8 @@
 name: Build and publish app release
 
 permissions:
-  contents: read
+  contents: write
   actions: write
-  packages: write
 
 on:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Types of changes:
 <!-- changelog-linker -->
 <!-- changelog-linker -->
 
-## 10.8.5 - 2025-06-16
+## 10.8.5 - 2025-07-21
 ### Changes
 - Update translations
 - Bump dependencies


### PR DESCRIPTION
Backport of #5217