### PR TITLE
chore: cover the sign method using pkcs7 engine

### DIFF
--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -303,6 +303,8 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		return [
 			['application/pdf', 'file.PDF', 'PDF'],
 			['application/pdf', 'file.pdf', 'pdf'],
+			['application/xml', 'file.XML', 'XML'],
+			['application/xml', 'file.xml', 'xml'],
 		];
 	}
 


### PR DESCRIPTION
### Pull Request Description

When we sign a PDF we can use PKCS12, but when we sign other files, is necessary to use PKCS7.

I added xml as file extension to be possible check if the signature is made with success using a file different of PDF.

Note: For now we haven't an entry point to sign a non PDF file, this is only a concept and is necessary to implement the changes at frontend and at API side too to be possible sign usign non PDF files.

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [x] I implemented tests that cover my contribution
