### PR TITLE
refactor: replace deprecated PHPUnit returnValue() with willReturn() 

### DIFF
--- a/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
@@ -48,9 +48,9 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testSavePfxWhenPfxFileIsAFolder():void {
 		$node = $this->createMock(\OCP\Files\Folder::class);
-		$node->method('nodeExists')->will($this->returnValue(true));
-		$node->method('get')->will($this->returnValue($node));
-		$this->folderService->method('getFolder')->will($this->returnValue($node));
+		$node->method('nodeExists')->willReturn(true);
+		$node->method('get')->willReturn($node);
+		$this->folderService->method('getFolder')->willReturn($node);
 
 		$this->expectExceptionMessage('path signature.pfx already exists and is not a file!');
 		$this->getHandler()->savePfx('userId', 'content');
@@ -58,10 +58,10 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testSavePfxWhenPfxFileExsitsAndIsAFile():void {
 		$node = $this->createMock(\OCP\Files\Folder::class);
-		$node->method('nodeExists')->will($this->returnValue(true));
+		$node->method('nodeExists')->willReturn(true);
 		$file = $this->createMock(\OCP\Files\File::class);
-		$node->method('get')->will($this->returnValue($file));
-		$this->folderService->method('getFolder')->will($this->returnValue($node));
+		$node->method('get')->willReturn($file);
+		$this->folderService->method('getFolder')->willReturn($node);
 
 		$actual = $this->getHandler()->savePfx('userId', 'content');
 		$this->assertEquals('content', $actual);
@@ -69,8 +69,8 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testGetPfxOfCurrentSignerWithInvalidPfx():void {
 		$node = $this->createMock(\OCP\Files\Folder::class);
-		$node->method('nodeExists')->will($this->returnValue(false));
-		$this->folderService->method('getFolder')->will($this->returnValue($node));
+		$node->method('nodeExists')->willReturn(false);
+		$this->folderService->method('getFolder')->willReturn($node);
 		$this->expectExceptionMessage('Password to sign not defined. Create a password to sign');
 		$this->expectExceptionCode(400);
 		$this->getHandler()->getPfxOfCurrentSigner('userId');
@@ -78,12 +78,12 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testGetPfxOfCurrentSignerOk():void {
 		$folder = $this->createMock(\OCP\Files\Folder::class);
-		$folder->method('nodeExists')->will($this->returnValue(true));
+		$folder->method('nodeExists')->willReturn(true);
 		$file = $this->createMock(\OCP\Files\File::class);
 		$file->method('getContent')
 			->willReturn('valid pfx content');
-		$folder->method('get')->will($this->returnValue($file));
-		$this->folderService->method('getFolder')->will($this->returnValue($folder));
+		$folder->method('get')->willReturn($file);
+		$this->folderService->method('getFolder')->willReturn($folder);
 		$actual = $this->getHandler()->getPfxOfCurrentSigner('userId');
 		$this->assertEquals('valid pfx content', $actual);
 	}

--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -145,7 +145,7 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testValidateNotRequestedSignWhenAlreadyAskedToSignThisDocument():void {
-		$this->signRequestMapper->method('getByNodeId')->will($this->returnValue('exists'));
+		$this->signRequestMapper->method('getByNodeId')->willReturn('exists');
 		$this->expectExceptionMessage('Already asked to sign this document');
 		$this->getValidateHelper()->validateNotRequestedSign(1);
 	}
@@ -417,7 +417,7 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testValidateFileUuidWithValidUuid():void {
 		$file = $this->createMock(\OCA\Libresign\Db\File::class);
-		$this->fileMapper->method('getByUuid')->will($this->returnValue($file));
+		$this->fileMapper->method('getByUuid')->willReturn($file);
 		$actual = $this->getValidateHelper()->validateFileUuid(['uuid' => 'valid']);
 		$this->assertNull($actual);
 	}
@@ -565,14 +565,14 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				);
 			$libresignFile->method('getUserId')
 				->willReturn('fake_user');
-			$this->fileMapper->method('getByUuid')->will($this->returnValue($libresignFile));
-			$this->fileMapper->method('getByFileId')->will($this->returnValue($libresignFile));
+			$this->fileMapper->method('getByUuid')->willReturn($libresignFile);
+			$this->fileMapper->method('getByFileId')->willReturn($libresignFile);
 
 			$data['uuid'] = $uuid;
 		} elseif (!empty($dataFile)) {
 			$libresignFile->method('getUserId')
 				->willReturn('fake_user');
-			$this->fileMapper->method('getByFileId')->will($this->returnValue($libresignFile));
+			$this->fileMapper->method('getByFileId')->willReturn($libresignFile);
 
 			$file = $this->createMock(\OCP\Files\File::class);
 			$file

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -322,10 +322,10 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest
 			->method('__call')
 			->with($this->equalTo('getEmail'), $this->anything())
-			->will($this->returnValue('valid@test.coop'));
+			->willReturn('valid@test.coop');
 		$this->signRequestMapper
 			->method('getByUuid')
-			->will($this->returnValue($signRequest));
+			->willReturn($signRequest);
 		$actual = $this->getService()->validateCertificateData([
 			'uuid' => '12345678-1234-1234-1234-123456789012',
 			'user' => [
@@ -347,12 +347,12 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					'getId' => 1,
 				}
 			);
-		$this->signRequestMapper->method('getByUuid')->will($this->returnValue($signRequest));
+		$this->signRequestMapper->method('getByUuid')->willReturn($signRequest);
 		$userToSign = $this->createMock(\OCP\IUser::class);
-		$this->userManager->method('createUser')->will($this->returnValue($userToSign));
-		$this->config->method('getAppValue')->will($this->returnValue('yes'));
+		$this->userManager->method('createUser')->willReturn($userToSign);
+		$this->config->method('getAppValue')->willReturn('yes');
 		$template = $this->createMock(\OCP\Mail\IEMailTemplate::class);
-		$this->newUserMail->method('generateTemplate')->will($this->returnValue($template));
+		$this->newUserMail->method('generateTemplate')->willReturn($template);
 		$this->newUserMail->method('sendMail')->will($this->returnCallback(function ():void {
 			throw new \Exception('Error Processing Request', 1);
 		}));
@@ -397,7 +397,7 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			);
 		$this->fileMapper
 			->method('getByUuid')
-			->will($this->returnValue($libresignFile));
+			->willReturn($libresignFile);
 		$node = $this->createMock(\OCP\Files\File::class);
 		$this->root
 			->method('getUserFolder')

--- a/tests/php/Unit/Service/MailServiceTest.php
+++ b/tests/php/Unit/Service/MailServiceTest.php
@@ -69,10 +69,10 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$file
 			->method('__call')
 			->with($this->equalTo('getName'), $this->anything())
-			->will($this->returnValue('Filename'));
+			->willReturn('Filename');
 		$this->fileMapper
 			->method('getById')
-			->will($this->returnValue($file));
+			->willReturn($file);
 		$this->appConfig
 			->method('getValueBool')
 			->willReturn(true);
@@ -98,10 +98,10 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$file
 			->method('__call')
 			->with($this->equalTo('getName'), $this->anything())
-			->will($this->returnValue('Filename'));
+			->willReturn('Filename');
 		$this->fileMapper
 			->method('getById')
-			->will($this->returnValue($file));
+			->willReturn($file);
 		$this->mailer
 			->method('send')
 			->willReturnCallback(function ():void {
@@ -109,7 +109,7 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			});
 		$this->appConfig
 			->method('getValueBool')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$actual = $this->service->notifyUnsignedUser($signRequest, 'a@b.coop');
 		$this->assertNull($actual);
 	}

--- a/tests/php/Unit/Service/RequestSignatureServiceTest.php
+++ b/tests/php/Unit/Service/RequestSignatureServiceTest.php
@@ -103,14 +103,14 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 		$response = $this->createMock(IResponse::class);
 		$response
 			->method('getHeaders')
-			->will($this->returnValue(['Content-Type' => ['application/pdf']]));
+			->willReturn(['Content-Type' => ['application/pdf']]);
 		$client = $this->createMock(IClient::class);
 		$client
 			->method('get')
-			->will($this->returnValue($response));
+			->willReturn($response);
 		$this->clientService
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->getService()->validateNewRequestToFile([
 			'file' => ['url' => 'http://test.coop'],

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -175,8 +175,8 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testCanDeleteRequestSignatureWhenDocumentAlreadySigned():void {
 		$file = $this->createMock(\OCA\Libresign\Db\File::class);
-		$file->method('__call')->with($this->equalTo('getId'))->will($this->returnValue(1));
-		$this->fileMapper->method('getByUuid')->will($this->returnValue($file));
+		$file->method('__call')->with($this->equalTo('getId'))->willReturn(1);
+		$this->fileMapper->method('getByUuid')->willReturn($file);
 		$signRequest = $this->createMock(\OCA\Libresign\Db\SignRequest::class);
 		$signRequest
 			->method('__call')
@@ -185,15 +185,15 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					'getSigned' => '2021-01-01 01:01:01',
 				}
 			);
-		$this->signRequestMapper->method('getByFileUuid')->will($this->returnValue([$signRequest]));
+		$this->signRequestMapper->method('getByFileUuid')->willReturn([$signRequest]);
 		$this->expectExceptionMessage('Document already signed');
 		$this->getService()->canDeleteRequestSignature(['uuid' => 'valid']);
 	}
 
 	public function testCanDeleteRequestSignatureWhenNoSignatureWasRequested():void {
 		$file = $this->createMock(\OCA\Libresign\Db\File::class);
-		$file->method('__call')->with($this->equalTo('getId'))->will($this->returnValue(1));
-		$this->fileMapper->method('getByUuid')->will($this->returnValue($file));
+		$file->method('__call')->with($this->equalTo('getId'))->willReturn(1);
+		$this->fileMapper->method('getByUuid')->willReturn($file);
 		$signRequest = $this->createMock(\OCA\Libresign\Db\SignRequest::class);
 		$signRequest
 			->method('__call')
@@ -203,7 +203,7 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					'getId' => 171,
 				}
 			);
-		$this->signRequestMapper->method('getByFileUuid')->will($this->returnValue([$signRequest]));
+		$this->signRequestMapper->method('getByFileUuid')->willReturn([$signRequest]);
 		$this->expectExceptionMessage('No signature was requested to %');
 		$this->getService()->canDeleteRequestSignature([
 			'uuid' => 'valid',


### PR DESCRIPTION
Pull Request Description
This pull request refactors all deprecated usages of the PHPUnit method ->will($this->returnValue(...)) to the modern syntax ->willReturn(...).
A total of 37 instances were updated across the codebase to comply with newer PHPUnit versions and eliminate warnings.

Related Issue
Issue Number: Closes #5242

Pull Request Type
Refactoring (no functional changes, no api changes)

Pull request checklist

-  Did you explain or provide a way of how can we test your code ?
Reply: Run the existing PHPUnit test suite to confirm no regressions.
-  If your pull request is related to frontend modifications provide a print of before and after screen
Reply: Not applicable (backend/test refactor only)
-  Did you provide a general summary of your changes ?
Reply: Yes, see Pull Request Description section above.
-  Try to limit your pull request to one type, submit multiple pull requests if needed
Reply: Yes, only refactoring is done.
-  I implemented tests that cover my contribution
Reply: Not required — existing tests already validate the logic.

