### PR TITLE
[stable31] chore(deps): Bump coverallsapp/github-action from 2.0.0 to 2.3.6

### DIFF
--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Let Coveralls know that all tests have finished
-        uses: coverallsapp/github-action@v2.0.0
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Types of changes:
 <!-- changelog-linker -->
 <!-- changelog-linker -->
 
-## 11.2.5 - 2025-07-17
+## 11.2.5 - 2025-07-21
 ### Changes
 - Update translations
 - Bump dependencies


### PR DESCRIPTION
Backport of #5284