### PR TITLE
[stable30] chore(deps): Bump coverallsapp/github-action from 2.0.0 to 2.3.6

### DIFF
--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Let Coveralls know that all tests have finished
-        uses: coverallsapp/github-action@v2.0.0
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
Backport of #5284