### PR TITLE
Replace deprecated PHPUnit methods

### DIFF
--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -110,9 +110,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testValidateFileWhenFileIdDoesNotExist():void {
 		$this->expectExceptionMessage('Invalid fileID');
-		$this->root->method('getById')->will($this->returnCallback(function ():void {
+		$this->root->method('getById')->willReturnCallback(function ():void {
 			throw new \Exception('not found');
-		}));
+		});
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('john.doe');
 		$this->getValidateHelper()->validateFile([
@@ -151,17 +151,17 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testValidateNotRequestedSignWithSuccessWhenNotFound():void {
-		$this->signRequestMapper->method('getByNodeId')->will($this->returnCallback(function ():void {
+		$this->signRequestMapper->method('getByNodeId')->willReturnCallback(function ():void {
 			throw new \Exception('not found');
-		}));
+		});
 		$actual = $this->getValidateHelper()->validateNotRequestedSign(1);
 		$this->assertNull($actual);
 	}
 
 	public function testValidateLibreSignNodeIdWhenFileIdNotExists():void {
-		$this->signRequestMapper->method('getByNodeId')->will($this->returnCallback(function ():void {
+		$this->signRequestMapper->method('getByNodeId')->willReturnCallback(function ():void {
 			throw new \Exception('not found');
-		}));
+		});
 		$this->expectExceptionMessage('Invalid fileID');
 		$this->getValidateHelper()->validateLibreSignNodeId(1);
 	}
@@ -343,9 +343,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->expectExceptionMessage('File not loaded');
 		$this->fileMapper
 			->method('getByFileId')
-			->will($this->returnCallback(function ():void {
+			->willReturnCallback(function ():void {
 				throw new \Exception('not found');
-			}));
+			});
 		$this->getValidateHelper()->signerWasAssociated([
 			'email' => 'invalid@test.coop'
 		]);
@@ -372,9 +372,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->expectExceptionMessage('File not loaded');
 		$this->fileMapper
 			->method('getByFileId')
-			->will($this->returnCallback(function ():void {
+			->willReturnCallback(function ():void {
 				throw new \Exception('not found');
-			}));
+			});
 		$this->getValidateHelper()->notSigned([]);
 	}
 
@@ -382,9 +382,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->expectExceptionMessage('Invalid fileID');
 		$this->root
 			->method('getById')
-			->will($this->returnCallback(function ():void {
+			->willReturnCallback(function ():void {
 				throw new \Exception('not found');
-			}));
+			});
 		$this->getValidateHelper()->validateIfNodeIdExists(171);
 	}
 
@@ -409,9 +409,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testValidateFileUuidWithInvalidUuid():void {
 		$this->expectExceptionMessage('Invalid UUID file');
-		$this->fileMapper->method('getByUuid')->will($this->returnCallback(function ():void {
+		$this->fileMapper->method('getByUuid')->willReturnCallback(function ():void {
 			throw new \Exception('not found');
-		}));
+		});
 		$this->getValidateHelper()->validateFileUuid(['uuid' => 'invalid']);
 	}
 
@@ -450,9 +450,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	public function testUserHasNoFileWithThisType():void {
 		$this->accountFileMapper
 			->method('getByUserAndType')
-			->will($this->returnCallback(function ():void {
+			->willReturnCallback(function ():void {
 				throw new \Exception('not found');
-			}));
+			});
 		$actual = $this->getValidateHelper()->validateUserHasNoFileWithThisType('username', (string)ValidateHelper::TYPE_TO_SIGN);
 		$this->assertNull($actual);
 	}
@@ -464,9 +464,9 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function testNotASignerOfFile():void {
 		$this->expectExceptionMessage('Signer not associated to this file');
-		$this->signRequestMapper->method('getByFileIdAndSignRequestId')->will($this->returnCallback(function ():void {
+		$this->signRequestMapper->method('getByFileIdAndSignRequestId')->willReturnCallback(function ():void {
 			throw new \Exception('not found');
-		}));
+		});
 		$this->getValidateHelper()->validateIsSignerOfFile(1, 1);
 	}
 

--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -52,7 +52,7 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->fileTypeMapper = $this->createMock(FileTypeMapper::class);

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -77,7 +77,7 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->accountManager = $this->createMock(IAccountManager::class);

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -165,9 +165,9 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$self->signRequestMapper = $self->createMock(SignRequestMapper::class);
 					$self->signRequestMapper
 						->method('getByUuid')
-						->will($self->returnCallback(function ():void {
+						->willReturnCallback(function ():void {
 							throw new \Exception('Beep, beep, not found!', 1);
-						}));
+						});
 					return [
 						'uuid' => $uuid
 					];
@@ -180,10 +180,10 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$signRequest
 						->method('__call')
 						->with($self->equalTo('getEmail'), $self->anything())
-						->will($self->returnValue('valid@test.coop'));
+						->willReturn('valid@test.coop');
 					$self->signRequestMapper
 						->method('getByUuid')
-						->will($self->returnValue($signRequest));
+						->willReturn($signRequest);
 					return [
 						'uuid' => '12345678-1234-1234-1234-123456789012',
 						'user' => [
@@ -200,13 +200,13 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$signRequest
 						->method('__call')
 						->with($self->equalTo('getEmail'), $self->anything())
-						->will($self->returnValue('valid@test.coop'));
+						->willReturn('valid@test.coop');
 					$self->signRequestMapper
 						->method('getByUuid')
-						->will($self->returnValue($signRequest));
+						->willReturn($signRequest);
 					$self->userManager
 						->method('userExists')
-						->will($self->returnValue(true));
+						->willReturn(true);
 					return [
 						'uuid' => '12345678-1234-1234-1234-123456789012',
 						'user' => [
@@ -223,10 +223,10 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$signRequest
 						->method('__call')
 						->with($self->equalTo('getEmail'), $self->anything())
-						->will($self->returnValue('valid@test.coop'));
+						->willReturn('valid@test.coop');
 					$self->signRequestMapper
 						->method('getByUuid')
-						->will($self->returnValue($signRequest));
+						->willReturn($signRequest);
 					return [
 						'uuid' => '12345678-1234-1234-1234-123456789012',
 						'user' => [
@@ -253,14 +253,14 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$file = $this->createMock(\OCA\Libresign\Db\File::class);
 					$self->fileMapper
 						->method('getById')
-						->will($self->returnValue($file));
+						->willReturn($file);
 					$self->signRequestMapper
 						->method('getByUuid')
-						->will($self->returnValue($signRequest));
+						->willReturn($signRequest);
 
 					$self->root
 						->method('getById')
-						->will($self->returnValue([]));
+						->willReturn([]);
 					$folder = $this->createMock(\OCP\Files\Folder::class);
 					$folder
 						->method('getById')
@@ -353,9 +353,9 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->config->method('getAppValue')->willReturn('yes');
 		$template = $this->createMock(\OCP\Mail\IEMailTemplate::class);
 		$this->newUserMail->method('generateTemplate')->willReturn($template);
-		$this->newUserMail->method('sendMail')->will($this->returnCallback(function ():void {
+		$this->newUserMail->method('sendMail')->willReturnCallback(function ():void {
 			throw new \Exception('Error Processing Request', 1);
-		}));
+		});
 		$this->expectExceptionMessage('Unable to send the invitation');
 		$this->getService()->createToSign('uuid', 'username', 'passwordOfUser', 'passwordToSign');
 	}

--- a/tests/php/Unit/Service/MailServiceTest.php
+++ b/tests/php/Unit/Service/MailServiceTest.php
@@ -39,7 +39,7 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->service = new MailService(

--- a/tests/php/Unit/Service/RequestSignatureServiceTest.php
+++ b/tests/php/Unit/Service/RequestSignatureServiceTest.php
@@ -50,7 +50,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->identifyMethodMapper = $this->createMock(IdentifyMethodMapper::class);

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -89,7 +89,7 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->accountFileMapper = $this->createMock(AccountFileMapper::class);

--- a/tests/php/Unit/Settings/AdminSettingsTest.php
+++ b/tests/php/Unit/Settings/AdminSettingsTest.php
@@ -22,7 +22,7 @@ final class AdminSettingsTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$l10n = $this->createMock(IL10N::class);
 		$l10n
 			->method('t')
-			->will($this->returnArgument(0));
+			->willReturnArgument(0);
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->adminSettings = new AdminSettings(
 			$l10n,


### PR DESCRIPTION
### Pull Request Description

## Replace deprecated PHPUnit methods 

### Changes Made:
- Replaced `->will($this->returnArgument())` with `->willReturnArgument()`  
- Replaced `->will($this->returnCallback())` with `->willReturnCallback()`
- Replaced `->will($self->returnValue())` with `->willReturn()` in data providers
- Replaced `->will($self->returnCallback())` with `->willReturnCallback()` in data providers

### Impact:
- ✅ Forward compatibility with newer PHPUnit versions
- ✅ Eliminates PHPUnit deprecation warnings  
- ✅ Cleaner, more readable test code

### Testing:
All existing functionality preserved - these are purely syntax updates to use modern PHPUnit methods.

### Related Issue
Issue Number: #5261 

### Pull Request Type

<!--
Please check the type of change your pull request introduces. Remove all that is unrelated and remove the comment block too, maintaining only the type of your PR:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Build related changes
- Documentation content changes
- Other (please describe):
-->

- Code style update (formatting, renaming)

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [x] I implemented tests that cover my contribution
