### PR TITLE
Fix ConfigurationCheck failure on poppler-utils

### DIFF
--- a/lib/Service/Install/ConfigureCheckService.php
+++ b/lib/Service/Install/ConfigureCheckService.php
@@ -78,7 +78,10 @@ class ConfigureCheckService {
 		if (!empty($this->result['poppler'])) {
 			return $this->result['poppler'];
 		}
-		if (shell_exec('which pdfsig') === null) {
+		// The output of this command go to STDERR and exec get the STDOUT
+		// With 2>&1 the STRERR is redirected to STDOUT
+		exec('pdfsig -v 2>&1', $version, $retval);
+		if ($retval !== 0) {
 			return $this->result['poppler'] = [
 				(new ConfigureCheckHelper())
 					->setInfoMessage('Poppler utils not installed')
@@ -86,9 +89,6 @@ class ConfigureCheckService {
 					->setTip('Install the package poppler-utils at your operational system to be possible get more details about validation of signatures.'),
 			];
 		}
-		// The output of this command go to STDERR and shell_exec get the STDOUT
-		// With 2>&1 the STRERR is redirected to STDOUT
-		$version = shell_exec('pdfsig -v 2>&1');
 		if (!$version) {
 			return $this->result['poppler'] = [
 				(new ConfigureCheckHelper())
@@ -97,7 +97,7 @@ class ConfigureCheckService {
 					->setTip("The command <pdfsig -v> executed by PHP haven't any output."),
 			];
 		}
-		$version = preg_match('/pdfsig version (?<version>.*)/', $version, $matches);
+		$version = preg_match('/pdfsig version (?<version>.*)/', implode(PHP_EOL, $version), $matches);
 		if (!$version) {
 			return $this->result['poppler'] = [
 				(new ConfigureCheckHelper())
@@ -116,7 +116,10 @@ class ConfigureCheckService {
 		if (!empty($this->result['pdfinfo'])) {
 			return $this->result['pdfinfo'];
 		}
-		if (shell_exec('which pdfinfo') === null) {
+		// The output of this command go to STDERR and exec get the STDOUT
+		// With 2>&1 the STRERR is redirected to STDOUT
+		exec('pdfinfo -v 2>&1', $version, $retval);
+		if ($retval !== 0) {
 			return $this->result['pdfinfo'] = [
 				(new ConfigureCheckHelper())
 					->setInfoMessage('Poppler utils not installed')
@@ -124,9 +127,6 @@ class ConfigureCheckService {
 					->setTip('Install the package poppler-utils at your operational system have a fallback to fetch page dimensions.'),
 			];
 		}
-		// The output of this command go to STDERR and shell_exec get the STDOUT
-		// With 2>&1 the STRERR is redirected to STDOUT
-		$version = shell_exec('pdfinfo -v 2>&1');
 		if (!$version) {
 			return $this->result['pdfinfo'] = [
 				(new ConfigureCheckHelper())
@@ -135,7 +135,7 @@ class ConfigureCheckService {
 					->setTip("The command <pdfinfo -v> executed by PHP haven't any output."),
 			];
 		}
-		$version = preg_match('/pdfinfo version (?<version>.*)/', $version, $matches);
+		$version = preg_match('/pdfinfo version (?<version>.*)/', implode(PHP_EOL, $version), $matches);
 		if (!$version) {
 			return $this->result['pdfinfo'] = [
 				(new ConfigureCheckHelper())


### PR DESCRIPTION
By default, PHP-FPM clears all environment variables in workers. The result of this is that the "which" command, previously used to determine that pdfsig and pdfinfo commands are available on the system would return NULL instead of the path to the commands.

We solve this by instead simply executing the command "pdfinfo -v" or "pdfsig -v" and checking the return value. A return value of anything besides "0" indicates that the command failed.

### Pull Request Description


### Related Issue
<!--
If this PR is related to an issue, put here, if not, remove this block
-->
Issue Number:

### Pull Request Type

<!--
Please check the type of change your pull request introduces. Remove all that is unrelated and remove the comment block too, maintaining only the type of your PR:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no api changes)
- Build related changes
- Documentation content changes
- Other (please describe):
-->

### Pull request checklist

- [ ] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [ ] Did you provide a general summary of your changes ?
- [ ] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution
