### PR TITLE
fix: prevent show add signers early

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -108,6 +108,10 @@ export const useFilesStore = function(...args) {
 					&& file.signers
 						.filter(signer => signer.signed?.length > 0).length === file.signers.length
 			},
+			loadedAllData(file) {
+				file = this.getFile(file)
+				return Object.hasOwn(file, 'status')
+			},
 			canSign(file) {
 				file = this.getFile(file)
 				return !this.isFullSigned(file)
@@ -132,6 +136,7 @@ export const useFilesStore = function(...args) {
 			canAddSigner(file) {
 				file = this.getFile(file)
 				return this.canRequestSign
+					&& this.loadedAllData(file)
 					&& (
 						!Object.hasOwn(file, 'requested_by')
 						|| file.requested_by.userId === getCurrentUser()?.uid


### PR DESCRIPTION
### Pull Request Description

Currently, some buttons are displayed **too early** when opening the sidebar in the Files app.
These buttons only make sense after all the necessary data has been loaded from the LibreSign API.

A few seconds later, once the API response arrives, the application can correctly determine whether the buttons should be displayed or not.

### Problem

* Buttons appear before the API response.
* This causes users to see options that should not be available yet.

### Screenshots

**Before fix** (buttons are shown even before the API returns data): <img width="549" height="271" alt="without fix" src="https://github.com/user-attachments/assets/fe8d1bf1-7c8c-49d3-8e74-532c948af2e8" />

**After fix** (buttons are hidden until the API response is ready): 
<img width="549" height="271" alt="with fix" src="https://github.com/user-attachments/assets/b42f22bf-ff10-41ac-9d53-503ca10c4eb5" />

### Pull Request Type

- Bugfix
### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution
