### PR TITLE
fix: remove condition that restricts LibreSign tab to LibreSign files

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -108,10 +108,6 @@ export const useFilesStore = function(...args) {
 					&& file.signers
 						.filter(signer => signer.signed?.length > 0).length === file.signers.length
 			},
-			loadedAllData(file) {
-				file = this.getFile(file)
-				return Object.hasOwn(file, 'status')
-			},
 			canSign(file) {
 				file = this.getFile(file)
 				return !this.isFullSigned(file)
@@ -136,7 +132,6 @@ export const useFilesStore = function(...args) {
 			canAddSigner(file) {
 				file = this.getFile(file)
 				return this.canRequestSign
-					&& this.loadedAllData(file)
 					&& (
 						!Object.hasOwn(file, 'requested_by')
 						|| file.requested_by.userId === getCurrentUser()?.uid


### PR DESCRIPTION
### Pull Request Description

In the Files app, users should be able to open the LibreSign tab even with non-LibreSign files to start the sign flow.

The condition was introduced in the last release because the same sidebar tab is used in the LibreSign app, where the file is always a LibreSign file.

To reproduce this:

Go to app Files
Upload a new PDF file
Click over this file and go to open in LibreSign file

The expected is to see the button "Add signer"

|🏚️ Before|🏡 After|
|---|---|
|<img width="501" height="237" alt="Screenshot_20250831_094809" src="https://github.com/user-attachments/assets/04156a3e-4255-43c4-9a52-a001ba1404f5" />|<img width="523" height="247" alt="Screenshot_20250831_094715" src="https://github.com/user-attachments/assets/f4aec2d3-c032-4634-a243-14eb37028b22" />|

### Related Issue

Ref. #5362

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
