### PR TITLE
fix: open file at app files

### DIFF
--- a/src/Components/RightSidebar/AppFilesTab.vue
+++ b/src/Components/RightSidebar/AppFilesTab.vue
@@ -12,6 +12,9 @@
 </template>
 
 <script>
+import { getCurrentUser } from '@nextcloud/auth'
+import { generateRemoteUrl } from '@nextcloud/router'
+
 import RequestSignatureTab from '../RightSidebar/RequestSignatureTab.vue'
 
 import { useFilesStore } from '../../store/files.js'
@@ -38,6 +41,8 @@ export default {
 			this.filesStore.addFile({
 				nodeId: fileInfo.id,
 				name: fileInfo.name,
+				file: generateRemoteUrl(`dav/files/${getCurrentUser()?.uid}/${fileInfo.path + '/' + fileInfo.name}`)
+					.replace(/\/\/$/, '/'),
 				signers: [],
 			})
 			this.filesStore.selectFile(fileInfo.id)

--- a/src/Components/RightSidebar/RequestSignatureTab.vue
+++ b/src/Components/RightSidebar/RequestSignatureTab.vue
@@ -275,11 +275,12 @@ export default {
 		},
 		openFile() {
 			if (OCA?.Viewer !== undefined) {
+				const file = this.filesStore.getFile()
 				const fileInfo = {
-					source: this.document.file,
-					basename: this.document.name,
+					source: file.file,
+					basename: file.name,
 					mime: 'application/pdf',
-					fileid: this.document.nodeId,
+					fileid: file.nodeId,
 				}
 				OCA.Viewer.open({
 					fileInfo,


### PR DESCRIPTION
### Pull Request Description

The right sidebar now have a button to open file at Viewer app. When we stay at LibreSign file, works fine because we generate a LibreSign route to view the PDF file using the LibreSign UUID, when we stay at app Files, isn't the same because we haven't a LibreSign file and need to generate the file URL using the webdav URL.

### Related Issue

Ref. #5368

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
