### PR TITLE
fix: timezone of preview signature stamp

### DIFF
--- a/lib/Service/SignatureTextService.php
+++ b/lib/Service/SignatureTextService.php
@@ -121,13 +121,14 @@ class SignatureTextService {
 			];
 		}
 		if (empty($context)) {
+			$date = new \DateTime('now', $this->dateTimeZone->getTimeZone());
 			$context = [
 				'DocumentUUID' => UUIDUtil::getUUID(),
 				'IssuerCommonName' => 'Acme Cooperative',
-				'LocalSignerSignatureDateOnly' => (new \DateTime())->format('Y-m-d'),
-				'LocalSignerSignatureDateTime' => (new \DateTime())->format(DateTimeInterface::ATOM),
+				'LocalSignerSignatureDateOnly' => ($date)->format('Y-m-d'),
+				'LocalSignerSignatureDateTime' => ($date)->format(DateTimeInterface::ATOM),
 				'LocalSignerTimezone' => $this->dateTimeZone->getTimeZone()->getName(),
-				'ServerSignatureDate' => (new \DateTime())->format(DateTimeInterface::ATOM),
+				'ServerSignatureDate' => ($date)->format(DateTimeInterface::ATOM),
 				'SignerIP' => $this->request->getRemoteAddress(),
 				'SignerCommonName' => $this->userSession?->getUser()?->getDisplayName() ?? 'John Doe',
 				'SignerEmail' => $this->userSession?->getUser()?->getEMailAddress() ?? 'john.doe@libresign.coop',


### PR DESCRIPTION
### Pull Request Description

Wasn't using the timezone.

I didn't implemented any test because it's related do a date and the output of parse method is mutable.

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
