### PR TITLE
Set TZ=UTC for pdfsig and pdfinfo command

### DIFF
--- a/lib/Handler/SignEngine/Pkcs12Handler.php
+++ b/lib/Handler/SignEngine/Pkcs12Handler.php
@@ -151,7 +151,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		$tempFile = $this->tempManager->getTemporaryFile('file.pdf');
 		file_put_contents($tempFile, $content);
 
-		$content = shell_exec('pdfsig ' . $tempFile);
+		$content = shell_exec('env TZ=UTC pdfsig ' . $tempFile);
 		if (empty($content)) {
 			return [];
 		}

--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -118,7 +118,6 @@ class PdfParserService {
 
 		// The output of this command go to STDERR and shell_exec get the STDOUT
 		// With 2>&1 the STRERR is redirected to STDOUT
-		$pdfinfo = shell_exec('env TZ=UTC pdfinfo ' . $filename . ' -l -1 2>&1');
 		if (!$pdfinfo) {
 			return [];
 		}

--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -118,6 +118,7 @@ class PdfParserService {
 
 		// The output of this command go to STDERR and shell_exec get the STDOUT
 		// With 2>&1 the STRERR is redirected to STDOUT
+		$pdfinfo = shell_exec('pdfinfo ' . $filename . ' -l -1 2>&1');
 		if (!$pdfinfo) {
 			return [];
 		}

--- a/lib/Service/PdfParserService.php
+++ b/lib/Service/PdfParserService.php
@@ -118,7 +118,7 @@ class PdfParserService {
 
 		// The output of this command go to STDERR and shell_exec get the STDOUT
 		// With 2>&1 the STRERR is redirected to STDOUT
-		$pdfinfo = shell_exec('pdfinfo ' . $filename . ' -l -1 2>&1');
+		$pdfinfo = shell_exec('env TZ=UTC pdfinfo ' . $filename . ' -l -1 2>&1');
 		if (!$pdfinfo) {
 			return [];
 		}


### PR DESCRIPTION
### Pull Request Description
Servers whose time zone is not UTC will receive "Invalid signingTime in certificate chain. We found Marty McFly" error.
pdfsig and pdfinfo commands TZ=UTC variable with when executed problem fixed

NextCloud 31
LibreSign 11.3.2

### Related Issue
Issue Number: #5347

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] Did you provide a general summary of your changes ?
- [x] I implemented tests that cover my contribution