### PR TITLE
feat(dependabot): add missing composer paths to config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@
 version: 2
 updates:
   # Maintain dependencies for Composer
-  - package-ecosystem: "composer" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "composer"
+    directories:
+      - "/"
+      - "/vendor-bin/coding-standard"
+      - "/vendor-bin/openapi-extractor"
+      - "/vendor-bin/php-coveralls"
+      - "/vendor-bin/php-scoper"
+      - "/vendor-bin/phpunit"
+      - "/vendor-bin/psalm"
+      - "/vendor-bin/rector"
+      - "/tests/integration"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
### Pull Request Description

This PR updates the `.github/dependabot.yml` configuration to include all directories that contain a `composer.json` file.

Currently, Dependabot only checks the root directory for Composer dependencies, which causes it to miss several others in subdirectories (like `/vendor-bin/*` and `/tests/integration`). This change ensures that dependencies in all relevant project locations are now tracked and kept up-to-date automatically.

### Related Issue
Resolves #5464
Issue Number: #5464 

### Pull Request Type
- Feature

### Pull request checklist

- [ ] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.
- After that, the terminal will show the build process.
- Wait until you see the message:
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>

