### PR TITLE
chore: handle error and cover with tests

### DIFF
--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -86,7 +86,11 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 			'private_key_type' => OPENSSL_KEYTYPE_RSA,
 		]);
 
-		$csr = openssl_csr_new($this->getCsrNames(), $privateKey);
+		$csr = @openssl_csr_new($this->getCsrNames(), $privateKey);
+		if ($csr === false) {
+			$message = openssl_error_string();
+			throw new LibresignException('OpenSSL error: ' . $message);
+		}
 
 		$x509 = openssl_csr_sign($csr, $rootCertificate, $rootPrivateKey, $this->expirity(), [
 			'config' => $this->getFilenameToLeafCert(),


### PR DESCRIPTION
### Pull Request Description

Prevent error when the common name is bigger than 64 chars

### Related Issue

Issue Number:

- https://github.com/LibreSign/libresign/issues/5479

### Pull Request Type

- Bugfix

### Pull request checklist

- [ ] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [ ] Did you provide a general summary of your changes ?
- [ ] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
