### PR TITLE
fix: error handler to prevent JS error when receive 4xx from API

### DIFF
--- a/src/views/Settings/Reminders.vue
+++ b/src/views/Settings/Reminders.vue
@@ -179,6 +179,7 @@ export default {
 			this.displaySuccessReminderDaysBefore = false
 			this.displaySuccessReminderDaysBetween = false
 			this.displaySuccessReminderSendTimer = false
+			this.loading = true
 
 			await axios.post(generateOcsUrl('/apps/libresign/api/v1/admin/reminder'), {
 				daysBefore: parseInt(this.reminderDaysBefore),
@@ -209,6 +210,12 @@ export default {
 						setTimeout(() => { this.displaySuccessReminderSendTimer = false }, 2000)
 					}
 					this.nextRun = response.next_run
+				})
+				.catch(() => {
+					this.nextRun = null
+				})
+				.finally(() => {
+					this.loading = false
 				})
 		}, 1000),
 		formatHourMinute(date) {


### PR DESCRIPTION
### Pull Request Description

When the data to save is invalid, the API will return 400 and before this, will erase all settings and the next execution will be empty.

With error:

<img width="1181" height="401" alt="Screenshot_20251008_162829" src="https://github.com/user-attachments/assets/fb743e4f-2057-4837-8ea9-d066f300a836" />

With success:

<img width="575" height="443" alt="Screenshot_20251008_163210" src="https://github.com/user-attachments/assets/17a687d3-6c8d-4295-ba3c-feaf98894397" />


### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>


