### PR TITLE
fix: add maxlength

### DIFF
--- a/src/Components/Request/IdentifySigner.vue
+++ b/src/Components/Request/IdentifySigner.vue
@@ -14,6 +14,7 @@
 			v-model="displayName"
 			aria-describedby="name-input"
 			autocapitalize="none"
+			maxlength="64"
 			:label="t('libresign', 'Signer name')"
 			:required="true"
 			:error="nameHaveError"


### PR DESCRIPTION
According to RFC 5280, the CN must not exceed 64 characters.

ref: https://www.rfc-editor.org/rfc/rfc5280#page-124

Related with:
- https://github.com/LibreSign/libresign/issues/5479