### PR TITLE
chore: valdiate display name at API side

### DIFF
--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -522,7 +522,15 @@ class ValidateHelper {
 			throw new LibresignException($this->l10n->t('No signers'));
 		}
 
+		$this->validateSignerDisplayName($signer);
 		$this->validateSignerIdentifyMethods($signer);
+	}
+
+	private function validateSignerDisplayName(array $signer): void {
+		if (isset($signer['displayName']) && strlen($signer['displayName']) > 64) {
+			// It's an api error, don't translate
+			throw new LibresignException('Display name must not be longer than 64 characters');
+		}
 	}
 
 	private function validateSignerIdentifyMethods(array $signer): void {

--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -851,6 +851,60 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				true, // should throw
 				'Invalid identify method structure'
 			],
+			'valid displayName within 64 characters' => [
+				[
+					'users' => [
+						[
+							'displayName' => 'Valid Display Name',
+							'identify' => [
+								'account' => 'user@example.com'
+							]
+						]
+					]
+				],
+				false, // should not throw
+			],
+			'displayName exactly 64 characters' => [
+				[
+					'users' => [
+						[
+							'displayName' => str_repeat('A', 64),
+							'identify' => [
+								'account' => 'user@example.com'
+							]
+						]
+					]
+				],
+				false, // should not throw
+			],
+			'displayName too long - 65 characters' => [
+				[
+					'users' => [
+						[
+							'displayName' => str_repeat('A', 65),
+							'identify' => [
+								'account' => 'user@example.com'
+							]
+						]
+					]
+				],
+				true, // should throw
+				'Display name must not be longer than 64 characters'
+			],
+			'displayName too long - 100 characters' => [
+				[
+					'users' => [
+						[
+							'displayName' => str_repeat('B', 100),
+							'identify' => [
+								'account' => 'user@example.com'
+							]
+						]
+					]
+				],
+				true, // should throw
+				'Display name must not be longer than 64 characters'
+			],
 		];
 	}
 }


### PR DESCRIPTION
### Pull Request Description

Validate if display name have the right length.

### Related Issue

- https://github.com/LibreSign/libresign/issues/5479

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
