### PR TITLE
fix: prevent error when send reminders

### DIFF
--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -199,7 +199,7 @@ class ReminderService {
 					$entityIdentifyMethod->getIdentifierValue(),
 				);
 			} catch (LibresignException $e) {
-				$this->logger->error('Failed to get instance of identify method' , [
+				$this->logger->error('Failed to get instance of identify method', [
 					'error' => $e->getMessage(),
 					'identifier_key' => $entityIdentifyMethod->getIdentifierKey(),
 					'identifier_value' => $entityIdentifyMethod->getIdentifierValue(),


### PR DESCRIPTION
### Pull Request Description

LibreSign stores the username of each account responsible for signing. When checking for pending signatures to send reminders, the query could return a user that no longer exists in Active Directory. Although LibreSign is designed to ignore deleted accounts, it cannot detect when an account simply disappears (i.e., is no longer returned by AD). As a result, the process stopped when it encountered the missing user.

Added an error handler to skip such cases and continue processing the remaining notifications. This fix will be included in the next release.

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
