### PR TITLE
fix: Only accept pfx files.

### DIFF
--- a/src/views/Account/partials/ManagePassword.vue
+++ b/src/views/Account/partials/ManagePassword.vue
@@ -101,7 +101,7 @@ export default {
 		uploadCertificate() {
 			const input = document.createElement('input')
 			// @todo PFX file, didn't worked, wrong code
-			input.accept = 'application/x-pkcs12'
+			input.accept = '.pfx'
 			input.type = 'file'
 
 			input.onchange = async (ev) => {


### PR DESCRIPTION
### Pull Request Description

The previous code accept pfx and p12, with the new code only will accept pfx.


🏚️ Before | 🏡 After
-- | --
<img width="227" height="125" alt="Screenshot_20251028_113418" src="https://github.com/user-attachments/assets/0d2f662a-7f72-45d6-8c18-d6d30e9534af" /> | <img width="253" height="171" alt="Screenshot_20251028_113338" src="https://github.com/user-attachments/assets/52f64b0c-7598-4355-b0b3-4a4f1626ef0e" />


### Related Issue

Issue Number:
- https://github.com/LibreSign/libresign/issues/5596

### Pull Request Type

- Bugfix

### Pull request checklist

- [x] Did you explain or provide a way of how can we test your code ?
- [x] If your pull request is related to frontend modifications provide a print of before and after screen
- [x] Did you provide a general summary of your changes ?
- [x] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution

<details>
<summary>How to see this running using GitHub Codespaces</summary>

### 1. Open the Codespace
- Authenticate to GitHub
- Go to the branch: [chore/reduce-configure-check-time](https://github.com/LibreSign/libresign/tree/chore/reduce-configure-check-time)
- Click the `Code` button and select the `Codespaces` tab.
- Click **"Create codespace on feat/customize-signature-stamp"**

### 2. Wait for the environment to start
- A progress bar will appear on the left.  
- After that, the terminal will show the build process.
- Wait until you see the message:  
  ```bash
  ✍️ LibreSign is up!
  ```
  This may take a few minutes.

### 3. Access LibreSign in the browser
- Open the **Ports** tab (next to the **Terminal**).
- Look for the service running on port **80**.
- Hover over the URL and click the **globe icon** 🌐 to open it in your browser.

### 4. (Optional) Make the service public
- If you want to share the app with people **not logged in to GitHub**, you must change the port visibility:
  - Click the three dots `⋮` on the row for port 80.
  - Select `Change visibility` → `Public`.

### 5. Login credentials
- **Username**: `admin`  
- **Password**: `admin`

Done! 🎉
You're now ready to test this.
</details>
