### PR TITLE
fix: force cache update

### DIFF
--- a/lib/Command/Developer/Reset.php
+++ b/lib/Command/Developer/Reset.php
@@ -10,7 +10,6 @@ namespace OCA\Libresign\Command\Developer;
 
 use OC\Core\Command\Base;
 use OCA\Libresign\AppInfo\Application;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;


### PR DESCRIPTION
When we delete values of appconfig directly from database, the cache layer isn't updated. Is necessary to use Nextcloud methods to prevent outdated cache content.