### PR TITLE
Add missing Spanish translation for "Document information"

### DIFF
--- a/l10n/es.js
+++ b/l10n/es.js
@@ -489,6 +489,7 @@ OC.L10N.register(
     "Open in LibreSign" : "Abrir en LibreSign",
     "not a LibreSign file" : " no es un archivo LibreSign",
     "New signature request" : "Nueva solicitud de firma",
-    "Requested by {name}, at {date}" : "Solicitada por {name}, el {date}"
+    "Requested by {name}, at {date}" : "Solicitada por {name}, el {date}",
+    "Document information" : "Información del documento"
 },
 "nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -487,6 +487,7 @@
     "Open in LibreSign" : "Abrir en LibreSign",
     "not a LibreSign file" : " no es un archivo LibreSign",
     "New signature request" : "Nueva solicitud de firma",
-    "Requested by {name}, at {date}" : "Solicitada por {name}, el {date}"
+    "Requested by {name}, at {date}" : "Solicitada por {name}, el {date}",
+    "Document information" : "Información del documento"
 },"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }


### PR DESCRIPTION
### Pull Request Description

This PR adds the missing Spanish translation for the string "Document information".

The translation has been added to both:
- l10n/es.json
- l10n/es.js

This ensures that the string appears in Spanish in the UI instead of English.

### Related Issue
<!--
If this PR is related to an issue, put here, if not, remove this block
-->
Issue Number: #5779 

### Pull Request Type

- Documentation content changes

### Pull request checklist

- [x ] Did you explain or provide a way of how can we test your code ?
- [ ] If your pull request is related to frontend modifications provide a print of before and after screen
- [x ] Did you provide a general summary of your changes ?
- [x ] Try to limit your pull request to one type, submit multiple pull requests if needed
- [ ] I implemented tests that cover my contribution
