### PR TITLE
fix: add spacing between action buttons in RequestSignatureTab

### DIFF
--- a/src/Components/RightSidebar/RequestSignatureTab.vue
+++ b/src/Components/RightSidebar/RequestSignatureTab.vue
@@ -351,8 +351,13 @@ export default {
 
 .action-buttons{
 	display: flex;
-	box-sizing: border-box;
-	grid-gap: 10px;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 12px;
+
+	button {
+		margin: 0 !important;
+	}
 }
 
 .iframe {


### PR DESCRIPTION

🏚️ Before | 🏡 After
-- | --
<img width="144" height="100" alt="image" src="https://github.com/user-attachments/assets/79bf1b70-dd65-40ae-aaa4-1b1498b8174a" />|<img width="125" height="101" alt="Screenshot_20251201_230231" src="https://github.com/user-attachments/assets/cb9bf2eb-a7ed-45f7-bb23-79a45ff4979d" />
