### PR TITLE
fix: handle null signer in updateSigner method

### DIFF
--- a/src/Components/Request/IdentifySigner.vue
+++ b/src/Components/Request/IdentifySigner.vue
@@ -109,9 +109,9 @@ export default {
 	},
 	methods: {
 		updateSigner(signer) {
-			this.signer = signer
-			this.displayName = signer.displayName ?? ''
-			this.identify = signer.id ?? ''
+			this.signer = signer ?? {}
+			this.displayName = signer?.displayName ?? ''
+			this.identify = signer?.id ?? ''
 		},
 		saveSigner() {
 			if (!this.signer?.method || !this.signer?.id) {


### PR DESCRIPTION
Fixes TypeError when clearing signer selection by adding proper null checks using optional chaining and default values.

Prevents 'can't access property displayName, signer is null' error.