### PR TITLE
fix: use source data instead of document state in openFile method

### DIFF
--- a/src/views/FilesList/FileEntry/FileEntryActions.vue
+++ b/src/views/FilesList/FileEntry/FileEntryActions.vue
@@ -223,17 +223,17 @@ export default {
 		openFile() {
 			if (OCA?.Viewer !== undefined) {
 				const fileInfo = {
-					source: this.document.file,
-					basename: this.document.name,
+					source: this.source.file,
+					basename: this.source.name,
 					mime: 'application/pdf',
-					fileid: this.document.nodeId,
+					fileid: this.source.nodeId,
 				}
 				OCA.Viewer.open({
 					fileInfo,
 					list: [fileInfo],
 				})
 			} else {
-				window.open(`${this.document.file}?_t=${Date.now()}`)
+				window.open(`${this.source.file}?_t=${Date.now()}`)
 			}
 		},
 	},


### PR DESCRIPTION
The openFile method in FileEntryActions was using this.document which comes from loadState and may be empty or incorrect in the files list context. Changed to use this.source which contains the actual file data from the list, fixing the issue where 'Open file' was trying to access an invalid URL.