### PR TITLE
fix: add close button to signature modal

### DIFF
--- a/src/Components/RightSidebar/RequestSignatureTab.vue
+++ b/src/Components/RightSidebar/RequestSignatureTab.vue
@@ -61,6 +61,7 @@
 			size="full"
 			:name="fileName"
 			:close-button-contained="false"
+			:close-button-outside="true"
 			@close="closeModal()">
 			<iframe :src="modalSrc" class="iframe" />
 		</NcModal>


### PR DESCRIPTION
The modal for signing documents was missing the close button when opened from the Files app sidebar.

This fix adds the :close-button-outside property to NcModal to display the close button in the modal header, making it accessible to users after signing a document.