### PR TITLE
fix(crl-management): Remove lateral margins from table

### DIFF
--- a/src/views/CrlManagement/CrlManagement.vue
+++ b/src/views/CrlManagement/CrlManagement.vue
@@ -636,7 +636,7 @@ export default {
 
 <style lang="scss" scoped>
 .crl-management {
-	padding: 20px;
+	padding: 20px 0;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
@@ -646,6 +646,8 @@ export default {
 		align-items: center;
 		justify-content: flex-end;
 		gap: 8px;
+		margin-top: 12px;
+		margin-right: 12px;
 		margin-bottom: 12px;
 
 		.filter-wrapper {


### PR DESCRIPTION
Remove padding lateral do container .crl-management e adiciona margens específicas no toolbar para manter o espaçamento correto do botão de filtros, seguindo o mesmo padrão aplicado em IdDocsValidation.