### PR TITLE
fix: Return correct pagination structure in IdDocsService::list()

### DIFF
--- a/lib/Service/IdDocsService.php
+++ b/lib/Service/IdDocsService.php
@@ -130,9 +130,7 @@ class IdDocsService {
 		$pagination = $data['pagination']->getPagination($page, $length, $filter);
 		return [
 			'data' => $data['data'],
-			'total' => $pagination['total'],
-			'page' => $page,
-			'length' => $length,
+			'pagination' => $pagination,
 		];
 	}
 


### PR DESCRIPTION
The method was returning individual keys (total, page, length) instead of the expected 'pagination' object that matches the LibresignPagination type definition and API contract.

This change aligns the response format with other services like FileService::listAssociatedFilesOfSignFlow() and fixes the test failure in IdDocsControllerTest::testApprovalListWithSuccess.