### PR TITLE
fix: resolve NcColorPicker focus-trap error and improve UX

### DIFF
--- a/src/Components/Draw/Editor.vue
+++ b/src/Components/Draw/Editor.vue
@@ -8,11 +8,10 @@
 			<NcColorPicker ref="colorPicker"
 				v-model="color"
 				:palette="customPalette"
-				:palette-only="true"
-				@input="updateColor">
-				<NcButton>
+				@submit="updateColor">
+				<NcButton type="tertiary">
 					<template #icon>
-						<PaletteIcon :size="20" />
+						<PaletteIcon :size="20" :fill-color="color" />
 					</template>
 					{{ t('libresign', 'Change color') }}
 				</NcButton>


### PR DESCRIPTION
- Remove palette-only prop to fix focus-trap error
- Use @submit event instead of @update:value for better compatibility
- Add fill-color to palette icon to show current selected color
- Change button type to tertiary for proper styling