### PR TITLE
fix: validate empty commonName in certificate generation

### DIFF
--- a/lib/Handler/CertificateEngine/CfsslHandler.php
+++ b/lib/Handler/CertificateEngine/CfsslHandler.php
@@ -15,6 +15,7 @@ use OC\SystemConfig;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Db\CrlMapper;
 use OCA\Libresign\Enum\CertificateType;
+use OCA\Libresign\Exception\EmptyCertificateException;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CfsslServerHandler;
 use OCA\Libresign\Helper\ConfigureCheckHelper;
@@ -78,6 +79,10 @@ class CfsslHandler extends AEngineHandler implements IEngineHandler {
 		string $commonName,
 		array $names = [],
 	): void {
+		if (empty($commonName)) {
+			throw new EmptyCertificateException('Common Name (CN) cannot be empty for root certificate');
+		}
+
 		$this->cfsslServerHandler->createConfigServer(
 			$commonName,
 			$names,

--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -10,6 +10,7 @@ namespace OCA\Libresign\Handler\CertificateEngine;
 
 use OCA\Libresign\Db\CrlMapper;
 use OCA\Libresign\Enum\CertificateType;
+use OCA\Libresign\Exception\EmptyCertificateException;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\CaIdentifierService;
 use OCA\Libresign\Service\CertificatePolicyService;
@@ -61,6 +62,10 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 		string $commonName,
 		array $names = [],
 	): void {
+		if (empty($commonName)) {
+			throw new EmptyCertificateException('Common Name (CN) cannot be empty for root certificate');
+		}
+
 		$privateKey = openssl_pkey_new([
 			'private_key_bits' => 2048,
 			'private_key_type' => OPENSSL_KEYTYPE_RSA,

--- a/tests/php/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
+++ b/tests/php/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
@@ -77,6 +77,13 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signerInstance->readCertificate('', '');
 	}
 
+	public function testEmptyCommonNameThrowsException(): void {
+		$rootInstance = $this->getInstance();
+		$this->expectException(EmptyCertificateException::class);
+		$this->expectExceptionMessage('Common Name (CN) cannot be empty for root certificate');
+		$rootInstance->generateRootCert('', []);
+	}
+
 	public function testInvalidPassword(): void {
 		// Create root cert
 		$rootInstance = $this->getInstance();

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -50,7 +50,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$certificateEngine = self::$certificateEngineFactory->getEngine();
 			$certificateEngine
 				->setConfigPath(\OCP\Server::get(ITempManager::class)->getTemporaryFolder('certificate'))
-				->generateRootCert('', []);
+				->generateRootCert('Test Root CA', []);
 
 			self::$certificateContent = $certificateEngine
 				->setHosts(['user@email.tld'])
@@ -92,6 +92,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				$this->signatureBackgroundService,
 				$certificateEngineFactory,
 				$this->javaHelper,
+				$this->createMock(\OCA\Libresign\Service\DocMdpConfigService::class),
 			);
 		}
 		return $this->getMockBuilder(JSignPdfHandler::class)
@@ -103,6 +104,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				$this->signatureBackgroundService,
 				$certificateEngineFactory,
 				$this->javaHelper,
+				$this->createMock(\OCA\Libresign\Service\DocMdpConfigService::class),
 			])
 			->onlyMethods($methods)
 			->getMock();


### PR DESCRIPTION
- Add validation to prevent empty Common Name (CN) in OpenSslHandler and CfsslHandler
- Throw EmptyCertificateException with clear message when CN is empty
- Fix JSignPdfHandlerTest to use valid commonName 'Test Root CA'
- Add unit test to verify empty CN validation works correctly

The owner field in libresign_crl table is mandatory without default value. Previously, generateRootCert('') would fail at database level with unclear error. Now it fails early with proper validation message.