### PR TITLE
fix: remove signature from store when delete returns 404

### DIFF
--- a/src/store/signatureElements.js
+++ b/src/store/signatureElements.js
@@ -136,8 +136,11 @@ export const useSignatureElementsStore = function(...args) {
 						this.signs[type] = emptyElement
 						this.success = data.ocs.data.message
 					})
-					.catch(({ data }) => {
-						this.error = { message: data.ocs.data.message }
+					.catch(({ response }) => {
+						if (response?.status === 404) {
+							this.signs[type] = emptyElement
+						}
+						this.error = { message: response?.data?.ocs?.data?.message || 'Error deleting signature' }
 					})
 			},
 		},


### PR DESCRIPTION
When attempting to delete a signature that no longer exists on the server (404 response), the signature was not being removed from the Pinia store, leaving stale data in the UI.

This fix checks for 404 status in the error handler and clears the signature from the store, ensuring the UI state matches the server state even when the signature was already deleted.

Also improved error handling to safely access nested response properties and provide a fallback error message.