### PR TITLE
fix: handle undefined signers in getAllFiles filter

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -282,7 +282,7 @@ export const useFilesStore = function(...args) {
 							Object.entries(this.files).filter(([key, value]) => {
 								if (filter.signer_uuid) {
 									// return true when found signer by signer_uuid
-									return value.signers.filter((signer) => {
+									return value.signers?.filter((signer) => {
 										// filter signers by signer_uuid
 										return signer.sign_uuid === filter.signer_uuid
 									}).length > 0


### PR DESCRIPTION
Add optional chaining to prevent TypeError when value.signers is undefined in file filtering by signer_uuid. This resolves the error 'can't access property "filter", value.signers is undefined' that occurred when navigating to sign PDF page.

The issue occurred when files without initialized signers array were being filtered, causing the application to crash on the SignPDF view.