### PR TITLE
fix: certificate chain toggle not working on button click

### DIFF
--- a/src/views/Validation.vue
+++ b/src/views/Validation.vue
@@ -622,7 +622,8 @@
 								</template>
 								<template #extra-actions>
 									<NcButton variant="tertiary"
-										:aria-label="chainOpenState[signerIndex] ? t('libresign', 'Collapse certificate chain') : t('libresign', 'Expand certificate chain')">
+										:aria-label="chainOpenState[signerIndex] ? t('libresign', 'Collapse certificate chain') : t('libresign', 'Expand certificate chain')"
+										@click.stop="toggleState(chainOpenState, signerIndex)">
 										<template #icon>
 											<NcIconSvgWrapper v-if="chainOpenState[signerIndex]"
 												:path="mdiUnfoldLessHorizontal" />


### PR DESCRIPTION
When clicking directly on the toggle button icon, the event was not properly triggering the expand/collapse action. This fix adds @click.stop to the NcButton to ensure the toggle action is executed and prevents event bubbling issues.