### PR TITLE
feat: auto-save signer with status 0 when added

### DIFF
--- a/src/Components/Request/IdentifySigner.vue
+++ b/src/Components/Request/IdentifySigner.vue
@@ -113,7 +113,7 @@ export default {
 			this.displayName = signer?.displayName ?? ''
 			this.identify = signer?.id ?? ''
 		},
-		saveSigner() {
+		async saveSigner() {
 			if (!this.signer?.method || !this.signer?.id) {
 				return
 			}
@@ -127,6 +127,13 @@ export default {
 					},
 				],
 			})
+
+			try {
+				await this.filesStore.saveWithVisibleElements({ visibleElements: [] })
+			} catch (error) {
+				console.error('Error saving signer:', error)
+			}
+
 			this.displayName = ''
 			this.identify = ''
 			this.signer = {}


### PR DESCRIPTION
Automatically saves the signer to the server with status 0 (draft) when the user adds a new signer through the Add Signer dialog. This eliminates the need for a separate manual save action after adding each signer.

The PATCH request is sent to /apps/libresign/api/v1/request-signature with status: 0 immediately after the signer is added to the local state.