### PR TITLE
fix: respect status 0 (DRAFT) when adding new signers

### DIFF
--- a/lib/Service/RequestSignatureService.php
+++ b/lib/Service/RequestSignatureService.php
@@ -53,7 +53,7 @@ class RequestSignatureService {
 	public function save(array $data): FileEntity {
 		$file = $this->saveFile($data);
 		$this->saveVisibleElements($data, $file);
-		if (empty($data['status'])) {
+		if (!isset($data['status'])) {
 			$data['status'] = $file->getStatus();
 		}
 		$this->associateToSigners($data, $file->getId());
@@ -289,6 +289,8 @@ class RequestSignatureService {
 	}
 
 	private function determineInitialStatus(int $signingOrder, ?int $fileStatus = null): \OCA\Libresign\Enum\SignRequestStatus {
+		// If fileStatus is explicitly DRAFT (0), keep signer as DRAFT
+		// This allows adding new signers in DRAFT mode even when file is not in DRAFT status
 		if ($fileStatus === FileEntity::STATUS_DRAFT) {
 			return \OCA\Libresign\Enum\SignRequestStatus::DRAFT;
 		}


### PR DESCRIPTION
When adding a new signer with status 0, the backend was ignoring it because empty() treated 0 as falsy. Changed to isset() to properly handle status 0.

Also updated determineInitialStatus() to allow new signers to be added in DRAFT mode even when the file is not in DRAFT status, allowing gradual signer addition before requesting signatures.