### PR TITLE
test: add status and statusText fields to expected test output

### DIFF
--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -454,6 +454,8 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 							],
 							'crl_validation' => 'missing',
 							'crl_urls' => [],
+							'status' => 2,
+							'statusText' => 'Signed',
 						],
 					],
 				],


### PR DESCRIPTION
The FileService now includes status and statusText fields in the signer data structure when processing signed files outside LibreSign. This update adjusts the test expectations to match the actual behavior.