### PR TITLE
fix: ensure organizationalUnit is converted before engine initialization

### DIFF
--- a/lib/Migration/Version13000Date20251031165700.php
+++ b/lib/Migration/Version13000Date20251031165700.php
@@ -52,8 +52,8 @@ class Version13000Date20251031165700 extends SimpleMigrationStep {
 	 */
 	#[Override]
 	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		$this->addConfigPathToOpenSsl();
 		$this->convertRootCertOuStringToArray();
+		$this->addConfigPathToOpenSsl();
 		$this->backupCrlDataToDisk();
 	}
 


### PR DESCRIPTION
The migration was failing during upgrade to stable32 because it tried to set organizationalUnit as a string when the property expects an array.

The issue occurred because addConfigPathToOpenSsl() (which calls getEngine() and triggers populateInstance()) was executed before convertRootCertOuStringToArray().

This fix reorders the method calls in preSchemaChange() to convert the OU value to an array before initializing the engine, preventing the TypeError.

Fixes the error:
TypeError: Cannot assign string to property
OCA\Libresign\Handler\CertificateEngine\AEngineHandler::$organizationalUnit of type array