### PR TITLE
fix: remove validation at serialization function

### DIFF
--- a/lib/Service/IdentifyMethod/SignatureMethod/EmailToken.php
+++ b/lib/Service/IdentifyMethod/SignatureMethod/EmailToken.php
@@ -41,13 +41,6 @@ class EmailToken extends AbstractSignatureMethod implements IToken {
 			default => '',
 		};
 
-		if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-			throw new LibresignException(json_encode([
-				'action' => JSActions::ACTION_DO_NOTHING,
-				'errors' => [['message' => $this->identifyService->getL10n()->t('Invalid email')]],
-			]));
-		}
-
 		$emailLowercase = strtolower($email);
 
 		$code = $entity->getCode();
@@ -63,8 +56,8 @@ class EmailToken extends AbstractSignatureMethod implements IToken {
 		$return['identifyMethod'] = $entity->getIdentifierKey();
 		$return['needCode'] = $needCode;
 		$return['hasConfirmCode'] = $hasConfirmCode;
-		$return['blurredEmail'] = $this->blurEmail($emailLowercase);
-		$return['hashOfEmail'] = md5($emailLowercase);
+		$return['blurredEmail'] = $emailLowercase ? $this->blurEmail($emailLowercase) : '';
+		$return['hashOfEmail'] = $emailLowercase ? md5($emailLowercase) : '';
 		return $return;
 	}
 


### PR DESCRIPTION
This funcion need to be only to convert the data of this class to array, validation here isn't good to have.