### PR TITLE
refactor: centralize file status translations in FileStatus enum

### DIFF
--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -250,20 +250,7 @@ class FileMapper extends QBMapper {
 		if (is_int($status)) {
 			$status = FileStatus::from($status);
 		}
-		return match ($status) {
-			// TRANSLATORS Name of the status when document is not a LibreSign file
-			FileStatus::NOT_LIBRESIGN_FILE => $this->l->t('not LibreSign file'),
-			// TRANSLATORS Name of the status that the document is still as a draft
-			FileStatus::DRAFT => $this->l->t('draft'),
-			// TRANSLATORS Name of the status that the document can be signed
-			FileStatus::ABLE_TO_SIGN => $this->l->t('available for signature'),
-			// TRANSLATORS Name of the status when the document has already been partially signed
-			FileStatus::PARTIAL_SIGNED => $this->l->t('partially signed'),
-			// TRANSLATORS Name of the status when the document has been completely signed
-			FileStatus::SIGNED => $this->l->t('signed'),
-			// TRANSLATORS Name of the status when the document was deleted
-			FileStatus::DELETED => $this->l->t('deleted'),
-		};
+		return $status->getLabel($this->l);
 	}
 
 	public function neutralizeDeletedUser(string $userId, string $displayName): void {

--- a/lib/Enum/FileStatus.php
+++ b/lib/Enum/FileStatus.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Enum;
 
+use OCP\IL10N;
+
 /**
  * File status enum
  *
@@ -21,4 +23,21 @@ enum FileStatus: int {
 	case PARTIAL_SIGNED = 2;
 	case SIGNED = 3;
 	case DELETED = 4;
+
+	public function getLabel(IL10N $l10n): string {
+		return match($this) {
+			// TRANSLATORS Name of the status when document is not a LibreSign file
+			self::NOT_LIBRESIGN_FILE => $l10n->t('not LibreSign file'),
+			// TRANSLATORS Name of the status that the document is still as a draft
+			self::DRAFT => $l10n->t('draft'),
+			// TRANSLATORS Name of the status that the document can be signed
+			self::ABLE_TO_SIGN => $l10n->t('available for signature'),
+			// TRANSLATORS Name of the status when the document has already been partially signed
+			self::PARTIAL_SIGNED => $l10n->t('partially signed'),
+			// TRANSLATORS Name of the status when the document has been completely signed
+			self::SIGNED => $l10n->t('signed'),
+			// TRANSLATORS Name of the status when the document was deleted
+			self::DELETED => $l10n->t('deleted'),
+		};
+	}
 }


### PR DESCRIPTION
- Add getLabel() method to FileStatus enum similar to DocMdpLevel and SignRequestStatus
- Simplify FileMapper::getTextOfStatus() to delegate to enum's getLabel()
- Improves maintainability by centralizing translations in a single place