### PR TITLE
fix: correct Signer component prop in VisibleElements

### DIFF
--- a/src/Components/Request/VisibleElements.vue
+++ b/src/Components/Request/VisibleElements.vue
@@ -32,9 +32,8 @@
 				</li>
 				<Signer v-for="(signer, key) in document.signers"
 					:key="key"
-					:current-signer="key"
+					:signer-index="key"
 					:class="{ disabled: signerSelected }"
-					:signer="signer"
 					event="libresign:visible-elements-select-signer">
 					<slot v-bind="{signer}" slot="actions" name="actions" />
 				</Signer>


### PR DESCRIPTION
The Signer component expects signerIndex prop but VisibleElements was passing current-signer instead. This caused Vue warnings about missing required prop and errors when trying to access signer data.

Changed :current-signer to :signer-index and removed obsolete :signer prop since the component now fetches signer data from the store using the signerIndex.