### PR TITLE
fix: remove blue line from sidebar tab

### DIFF
--- a/src/Components/RightSidebar/RightSidebar.vue
+++ b/src/Components/RightSidebar/RightSidebar.vue
@@ -83,6 +83,9 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+.app-sidebar__tab  {
+	box-shadow: none !important;
+}
 
 @media (max-width: 512px) {
 	.app-sidebar {


### PR DESCRIPTION
Remove box-shadow from .app-sidebar__tab to eliminate the blue line that appeared above tab content when clicking on sidebar tabs.