### PR TITLE
fix: update modal title to reflect edit vs add signer action

### DIFF
--- a/src/Components/RightSidebar/RequestSignatureTab.vue
+++ b/src/Components/RightSidebar/RequestSignatureTab.vue
@@ -117,9 +117,9 @@
 		<NcDialog v-if="filesStore.identifyingSigner"
 			id="request-signature-identify-signer"
 			:size="size"
-			:name="t('libresign', 'Add new signer')"
+			:name="modalTitle"
 			@closing="filesStore.disableIdentifySigner()">
-			<NcAppSidebar :name="t('libresign', 'Add new signer')">
+			<NcAppSidebar :name="modalTitle">
 				<NcAppSidebarTab v-for="method in enabledMethods()"
 					:id="`tab-${method.name}`"
 					:key="method.name"
@@ -313,6 +313,12 @@ export default {
 		},
 		size() {
 			return window.matchMedia('(max-width: 512px)').matches ? 'full' : 'normal'
+		},
+		modalTitle() {
+			if (Object.keys(this.signerToEdit).length > 0) {
+				return this.t('libresign', 'Edit signer')
+			}
+			return this.t('libresign', 'Add new signer')
 		},
 	},
 	watch: {


### PR DESCRIPTION
The modal dialog was displaying 'Add new signer' title when clicking an existing signer to edit, which was confusing. Added a computed property 'modalTitle' that dynamically returns 'Edit signer' when editing an existing signer or 'Add new signer' when adding a new one.

The logic checks if signerToEdit object has properties to determine the correct context.