### PR TITLE
feat: add dashboard pending signatures widget

### DIFF
--- a/lib/Dashboard/PendingSignaturesWidget.php
+++ b/lib/Dashboard/PendingSignaturesWidget.php
@@ -148,7 +148,7 @@ class PendingSignaturesWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget
 	#[Override]
 	public function getItems(string $userId, ?string $since = null, int $limit = 7): array {
 		$widgetItems = $this->getItemsV2($userId, $since, $limit);
-		return $widgetItems->getItems();
+		return array_values($widgetItems->getItems());
 	}
 
 	#[Override]

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -46,14 +46,6 @@
       <code><![CDATA[$storage]]></code>
     </UndefinedDocblockClass>
   </file>
-  <file src="lib/Dashboard/PendingSignaturesWidget.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$widgetItems->getItems()]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array]]></code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="lib/Dav/SignatureStatusPlugin.php">
     <UndefinedClass>
       <code><![CDATA[ServerPlugin]]></code>


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a new Dashboard widget that displays documents with pending signatures for the current user. The widget lists only files that are associated with the user and are still awaiting their signature, providing quick access directly from the Dashboard.

The implementation reuses existing LibreSign services and mappers to ensure consistent permission checks and filtering logic. Each item shows relevant document information and links directly to the signing page, improving visibility and usability for users who need to complete pending signatures.

### Pull Request Type
- Feature

<img width="1263" height="581" alt="image" src="https://github.com/user-attachments/assets/4bf4aeb9-e461-4bc7-90e1-a970a1f0e15e" />

