### PR TITLE
chore: move tasks to the end of UI session

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -73,10 +73,6 @@ Feel free to remove this section when your PR only affects the backend/API code.
 - [ ] ... <!-- Describe the tasks performed here (e.g., layout adjustment, new feature X) -->
 - [ ] Screenshots before/after (add images or links)
 
-### 🚧 Tasks
-<!-- Add here the list of tasks that is necessary to do before merge this PR. As example: update the package X, merge the PR y. If isn't necessary, fell free to remove this block -->
-- [ ] ...
-
 🏚️ Before | 🏡 After
 --- | ---
 Screenshot before | Screenshot after
@@ -88,6 +84,10 @@ Screenshot before | Screenshot after
 - [ ] Accessibility verified (contrast, keyboard navigation, screen reader friendly) – *if applicable*
 - [ ] Design review approved – *optional, link to feedback if available*
 - [ ] Documentation updated (if applicable) – [docs repository](https://github.com/LibreSign/documentation/)
+
+### 🚧 Tasks
+<!-- Add here the list of tasks that is necessary to do before merge this PR. As example: update the package X, merge the PR y. If isn't necessary, fell free to remove this block -->
+- [ ] ...
 
 ## ⚙️ API / Back‑end changes
 


### PR DESCRIPTION
## 📝 Summary

Reorganized the pull request template by moving the tasks section from the middle to the end of the UI/Front-end changes section, improving the logical flow of the template. The tasks checklist now appears after the screenshots comparison table and testing checklist, making it more consistent with the API/Back-end changes section structure.

## 🧪 How to test

1. Open a new pull request
2. Verify the template renders correctly
3. Confirm the "🚧 Tasks" subsection now appears at the end of the UI/Front-end changes section
4. Confirm the checklist items and screenshots table remain intact

## 🎨 UI / Front‑end changes

- [x] Reorganized PR template structure for better readability
- [x] Moved Tasks subsection to the end of UI changes section

### 🚧 Tasks
- [x] Verify template syntax is valid Markdown
- [x] Ensure no broken checkboxes or formatting issues

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
