### PR TITLE
fix: include css assets in appstore package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ appstore:
 	cp -r \
 		appinfo \
 		composer \
+		css \
 		img \
 		js \
 		l10n \


### PR DESCRIPTION
Fix:
- https://github.com/LibreSign/libresign/issues/7180
- https://github.com/LibreSign/libresign/issues/7182