### PR TITLE
ci: refine release drafter release flow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,10 +89,7 @@ autolabeler:
     title:
       - '/^\[stable\d+\]\s+feat:/i'
       - '/^feat:/i'
-      - '/vue3 phase/i'
-      - '/migration to vue3/i'
-      - '/script setup ts/i'
-      - '/typescript/i'
+      - '/\b(migrate|migration)\b/i'
   - label: 'patch'
     title:
       - '/^\[stable\d+\]\s+fix:/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,9 +4,17 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 filter-by-commitish: true
+pull-request-limit: 100
+history-limit: 50
+sort-by: merged_at
+sort-direction: ascending
 exclude-contributors:
   - 'dependabot[bot]'
   - 'renovate[bot]'
+exclude-labels:
+  - 'skip-changelog'
+
+category-template: '### $TITLE'
 
 categories:
   - title: 'Added'
@@ -14,8 +22,10 @@ categories:
       - 'feature'
       - 'feat'
       - 'enhancement'
+      - 'minor'
 
   - title: 'Changed'
+    collapse-after: 4
     labels:
       - 'chore'
       - 'refactor'
@@ -26,6 +36,7 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+      - 'patch'
 
   - title: 'Removed'
     labels:
@@ -37,10 +48,12 @@ categories:
       - 'security'
 
   - title: 'Tests'
+    collapse-after: 3
     labels:
       - 'test'
 
   - title: 'Dependencies'
+    collapse-after: 2
     labels:
       - 'dependencies'
 
@@ -52,26 +65,67 @@ categories:
     labels: []
 
 change-template: '- $TITLE [#$NUMBER]($URL)'
+change-title-escapes: '#@'
+
+replacers:
+  - search: '/^\[stable\d+\]\s+/gm'
+    replace: ''
+  - search: '/^- hotfix:\s+v\d+\.\d+\.\d+.*$/gmi'
+    replace: ''
+  - search: '/^- fix:\s+pr\s+\d+\s+backport.*$/gmi'
+    replace: ''
+  - search: '/^- pr\s+\d+$/gmi'
+    replace: ''
 
 autolabeler:
+  - label: 'skip-changelog'
+    title:
+      - '/^\[stable\d+\]\s+fix:\s+release drafter process alignment$/i'
+      - '/^\[stable\d+\]\s+hotfix:\s+v\d+\.\d+\.\d+.*$/i'
+      - '/^hotfix:\s+v\d+\.\d+\.\d+.*$/i'
+      - '/^fix:\s+pr\s+\d+\s+backport$/i'
+      - '/^pr\s+\d+$/i'
+  - label: 'minor'
+    title:
+      - '/^\[stable\d+\]\s+feat:/i'
+      - '/^feat:/i'
+      - '/vue3 phase/i'
+      - '/migration to vue3/i'
+      - '/script setup ts/i'
+      - '/typescript/i'
+  - label: 'patch'
+    title:
+      - '/^\[stable\d+\]\s+fix:/i'
+      - '/^fix:/i'
   - label: 'fix'
     title:
       - '/^fix/i'
+      - '/^\[stable\d+\]\s+fix:/i'
   - label: 'feature'
     title:
       - '/^feat/i'
+      - '/^\[stable\d+\]\s+feat:/i'
   - label: 'chore'
     title:
       - '/^chore/i'
+      - '/^\[stable\d+\]\s+chore:/i'
   - label: 'docs'
     title:
       - '/^docs/i'
+      - '/^\[stable\d+\]\s+docs:/i'
   - label: 'refactor'
     title:
       - '/^refactor/i'
+      - '/^\[stable\d+\]\s+refactor/i'
   - label: 'test'
     title:
       - '/^test/i'
+      - '/^\[stable\d+\]\s+test:/i'
+  - label: 'dependencies'
+    title:
+      - '/deps/i'
+      - '/^chore:\s+bump\s+(js|php)\s+dependencies$/i'
+      - '/^\[stable\d+\]\s+chore:\s+bump\s+(js|php)\s+dependencies$/i'
 
 version-resolver:
   major:
@@ -80,9 +134,11 @@ version-resolver:
   minor:
     labels:
       - 'minor'
+      - 'feature'
   patch:
     labels:
       - 'patch'
+      - 'fix'
   default: patch
 
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,9 +33,47 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Resolve release draft version
+        id: resolve-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_REF_NAME: ${{ github.ref_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+
+          branch="$PUSH_REF_NAME"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            branch="$PR_BASE_REF"
+          fi
+
+          previous_tag=$(git describe --tags --abbrev=0 "origin/$branch")
+          current_version=${previous_tag#v}
+          major=${current_version%%.*}
+          version_tail=${current_version#*.}
+          minor=${version_tail%%.*}
+          patch=${version_tail##*.}
+
+          release_messages=$(git log --format='%s%n%b' "${previous_tag}..origin/${branch}")
+          if printf '%s\n' "$release_messages" | grep -Eiq '(^|\])\s*feat:|vue3 phase|migration to vue3|script setup ts|typescript'; then
+            minor=$((minor + 1))
+            patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          version="${major}.${minor}.${patch}"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=${previous_tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Draft release for this branch
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
+          commitish: ${{ steps.resolve-version.outputs.branch }}
+          version: ${{ steps.resolve-version.outputs.version }}
+          name: v${{ steps.resolve-version.outputs.version }}
+          tag: v${{ steps.resolve-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- refine Release Drafter changelog cleanup and categorization
- resolve draft version from stable branch history
- keep this work outside release PRs so release PRs stay limited to changelog and version bumps