### PR TITLE
[stable32] chore(ci): harden app certificate download

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -171,7 +171,10 @@ jobs:
           cd ../../../
           # Setting up keys
           echo '${{ secrets.APP_PRIVATE_KEY }}' > ${{ env.APP_NAME }}.key
-          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt"
+          curl --fail --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --output ${{ env.APP_NAME }}.crt \
+            "https://raw.githubusercontent.com/nextcloud/app-certificate-requests/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt"
           # Signing
           php nextcloud/occ integrity:sign-app --privateKey=../${{ env.APP_NAME }}.key --certificate=../${{ env.APP_NAME }}.crt --path=../${{ env.APP_NAME }}/build/artifacts/${{ env.APP_NAME }}
           # Rebuilding archive


### PR DESCRIPTION
## Summary
- replace the certificate download in the release workflow with a direct raw URL
- fail loudly on HTTP errors and follow redirects explicitly
- add retries to reduce transient GitHub download failures during app signing

## Context
The `v13.2.0` appstore publish rerun succeeded, but the original failure was consistent with a transient certificate download error in the `Sign app` step. This keeps the workflow behavior the same while making that download path more robust.
