### PR TITLE
Update field names in serializeVisibleElements to use producer & consumer names

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -867,10 +867,11 @@ const _filesStore = defineStore('files', () => {
 				}
 				const coordinates = element.coordinates && typeof element.coordinates === 'object'
 					? {
-						x: element.coordinates.x,
-						y: element.coordinates.y,
-						w: element.coordinates.w,
-						h: element.coordinates.h,
+						page: element.coordinates.page,
+						top: element.coordinates.top,
+						left: element.coordinates.left,
+						width: element.coordinates.width,
+						height: element.coordinates.height,
 					}
 					: undefined
 				return {


### PR DESCRIPTION
Resolves: https://github.com/LibreSign/libresign/issues/7316

EDIT: only tested on stable32

## 📝 Summary

In src/store/files.js:868-875, the serializeVisibleElements() function was mapping coordinate fields to the wrong names: x, y, w, h instead of the correct page, top, left, width, height.

The buildVisibleElements() function in VisibleElements.vue creates coordinates with { page, width, height, left, top }, matching what the backend's FileElementService::translateCoordinatesToInternalNotation() expects. But serializeVisibleElements() was looking for x/y/w/h properties that don't exist, so the API received undefined values for all coordinates. This caused the signature position to silently fail to save & no error because the request structure was valid, but the coordinates were empty.
  
## 🧪 How to test

- select a file
- add an account for signing
- place a signature somewhere
- check that the signature location just placed is correctly saved by re-opening the doc

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

