### PR TITLE
Fix LoadAdditionalListener

### DIFF
--- a/lib/Listener/LoadAdditionalListener.php
+++ b/lib/Listener/LoadAdditionalListener.php
@@ -12,6 +12,7 @@ use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
@@ -23,6 +24,7 @@ class LoadAdditionalListener implements IEventListener {
 	public function __construct(
 		private IAppManager $appManager,
 		private CertificateEngineFactory $certificateEngineFactory,
+		private IInitialState $initialState,
 	) {
 	}
 	#[\Override]
@@ -40,6 +42,7 @@ class LoadAdditionalListener implements IEventListener {
 		}
 
 		if (class_exists('\OCA\Files\App')) {
+			$this->initialState->provideInitialState('certificate_ok', true);
 			Util::addInitScript(Application::APP_ID, 'libresign-init');
 		}
 	}


### PR DESCRIPTION
Resolves: https://github.com/LibreSign/libresign/issues/7235

EDIT: only tested on stable32

## 📝 Summary

LoadAdditionalListener loads libresign-init (which registers the file actions) but never provides the certificate_ok initial state. The enabled() check always returned false.

During the Vue 3 migration, all file action callbacks were changed to use object destructuring ({ nodes }) but @nextcloud/files passes flat arguments (nodes, view) / (node, view, dir). So nodes was always undefined.

## 🧪 How to test

1. Access your files
2. Click on a three-dot menu (on a pdf for example)
3. see that the shortcut is there (at the top)

Also, there is the libresign icon applied for signed documents.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI -> used it to bisect the changes in releases (between 12.2.X / 12.3.X)
