### PR TITLE
[stable32] fix: files menu shortcut & icons

### DIFF
--- a/lib/Listener/LoadAdditionalListener.php
+++ b/lib/Listener/LoadAdditionalListener.php
@@ -12,6 +12,7 @@ use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
@@ -23,6 +24,7 @@ class LoadAdditionalListener implements IEventListener {
 	public function __construct(
 		private IAppManager $appManager,
 		private CertificateEngineFactory $certificateEngineFactory,
+		private IInitialState $initialState,
 	) {
 	}
 	#[\Override]
@@ -40,6 +42,7 @@ class LoadAdditionalListener implements IEventListener {
 		}
 
 		if (class_exists('\OCA\Files\App')) {
+			$this->initialState->provideInitialState('certificate_ok', true);
 			Util::addInitScript(Application::APP_ID, 'libresign-init');
 		}
 	}

--- a/src/actions/openInLibreSignAction.js
+++ b/src/actions/openInLibreSignAction.js
@@ -32,7 +32,7 @@ export const action = {
 	displayName: () => t('libresign', 'Open in LibreSign'),
 	iconSvgInline: () => SvgIcon,
 
-	enabled({ nodes }) {
+	enabled(nodes) {
 		const getNodeMime = (node) => node?.mime || node?.mimetype || ''
 
 		if (!loadState('libresign', 'certificate_ok', false)) {
@@ -62,8 +62,7 @@ export const action = {
 	/**
 	 * Single file or folder: open in sidebar
 	 */
-	async exec({ nodes }) {
-		const node = nodes[0]
+	async exec(node) {
 		await window.OCA.Files.Sidebar.open(node.path)
 		window.OCA.Files.Sidebar.setActiveTab('libresign')
 		return null
@@ -73,11 +72,11 @@ export const action = {
 	 * Multiple files: prepare envelope data and delegate to sidebar
 	 * Similar to exec, but passes multiple files to the sidebar for processing
 	 */
-	async execBatch({ nodes }) {
+	async execBatch(nodes) {
 		const getNodeFileId = (node) => node?.fileid ?? node?.id
 
 		if (nodes.length === 1) {
-			await this.exec({ nodes })
+			await this.exec(nodes[0])
 			return [null]
 		}
 

--- a/src/actions/showStatusInlineAction.js
+++ b/src/actions/showStatusInlineAction.js
@@ -15,7 +15,7 @@ const getNodeMime = (node) => node?.mime || node?.mimetype || ''
 const action = {
 	id: 'show-status-inline',
 	displayName: () => '',
-	title: ({ nodes }) => {
+	title: (nodes) => {
 		const node = nodes?.[0]
 		if (!node || !node.attributes) return ''
 
@@ -28,14 +28,13 @@ const action = {
 
 		return t('libresign', 'original file')
 	},
-	exec: async ({ nodes }) => {
-		const node = nodes?.[0]
+	exec: async (node) => {
 		if (!node) return null
 		window.OCA.Files.Sidebar.open(node.path)
 		window.OCA.Files.Sidebar.setActiveTab('libresign')
 		return null
 	},
-	iconSvgInline: ({ nodes }) => {
+	iconSvgInline: (nodes) => {
 		const node = nodes?.[0]
 		if (!node || !node.attributes) return ''
 
@@ -49,7 +48,7 @@ const action = {
 		return getStatusSvgInline(FILE_STATUS.DRAFT) || ''
 	},
 	inline: () => true,
-	enabled: ({ nodes }) => {
+	enabled: (nodes) => {
 		const certificateOk = loadState('libresign', 'certificate_ok')
 		const allHaveStatus = nodes?.every(node => node.attributes?.['libresign-signature-status'] !== undefined)
 

--- a/src/tests/actions/openInLibreSignAction.spec.ts
+++ b/src/tests/actions/openInLibreSignAction.spec.ts
@@ -95,9 +95,9 @@ describe('openInLibreSignAction rules', () => {
 		order: number
 		displayName: unknown
 		iconSvgInline: unknown
-		enabled: (context: { nodes: unknown }) => boolean
-		exec: (context: { nodes: unknown }) => Promise<unknown>
-		execBatch: (context: { nodes: unknown }) => Promise<unknown>
+		enabled: (nodes: unknown[]) => boolean
+		exec: (node: unknown) => Promise<unknown>
+		execBatch: (nodes: unknown[]) => Promise<unknown>
 	}
 	let loadState: { mockReturnValue: (value: unknown) => unknown }
 	let getCapabilities: { mockReturnValue: (value: unknown) => unknown }
@@ -151,9 +151,7 @@ describe('openInLibreSignAction rules', () => {
 		it('disables action when certificate not configured', () => {
 			loadState.mockReturnValue(false)
 
-			const enabled = action.enabled({
-				nodes: [{ type: 'file', mime: 'application/pdf' }],
-			})
+			const enabled = action.enabled([{ type: 'file', mime: 'application/pdf' }])
 
 			expect(enabled).toBe(false)
 		})
@@ -161,9 +159,7 @@ describe('openInLibreSignAction rules', () => {
 		it('enables action when certificate configured', () => {
 			loadState.mockReturnValue(true)
 
-			const enabled = action.enabled({
-				nodes: [{ type: 'file', mime: 'application/pdf' }],
-			})
+			const enabled = action.enabled([{ type: 'file', mime: 'application/pdf' }])
 
 			expect(enabled).toBe(true)
 		})
@@ -175,47 +171,37 @@ describe('openInLibreSignAction rules', () => {
 		})
 
 		it('enables for single PDF file', () => {
-			const enabled = action.enabled({
-				nodes: [{ type: 'file', mime: 'application/pdf' }],
-			})
+			const enabled = action.enabled([{ type: 'file', mime: 'application/pdf' }])
 
 			expect(enabled).toBe(true)
 		})
 
 		it('disables for single non-PDF file', () => {
-			const enabled = action.enabled({
-				nodes: [{ type: 'file', mime: 'image/png' }],
-			})
+			const enabled = action.enabled([{ type: 'file', mime: 'image/png' }])
 
 			expect(enabled).toBe(false)
 		})
 
 		it('enables for single PDF when only mimetype is provided', () => {
-			const enabled = action.enabled({
-				nodes: [{ type: 'file', mimetype: 'application/pdf' }],
-			})
+			const enabled = action.enabled([{ type: 'file', mimetype: 'application/pdf' }])
 
 			expect(enabled).toBe(true)
 		})
 
 		it('enables for folder with signature status', () => {
-			const enabled = action.enabled({
-				nodes: [{
-					type: 'folder',
-					attributes: { 'libresign-signature-status': 'signed' },
-				}],
-			})
+			const enabled = action.enabled([{
+				type: 'folder',
+				attributes: { 'libresign-signature-status': 'signed' },
+			}])
 
 			expect(enabled).toBe(true)
 		})
 
 		it('disables for folder without signature status', () => {
-			const enabled = action.enabled({
-				nodes: [{
-					type: 'folder',
-					attributes: {},
-				}],
-			})
+			const enabled = action.enabled([{
+				type: 'folder',
+				attributes: {},
+			}])
 
 			expect(enabled).toBe(false)
 		})
@@ -235,12 +221,10 @@ describe('openInLibreSignAction rules', () => {
 				},
 			})
 
-			const enabled = action.enabled({
-				nodes: [
-					{ type: 'file', mime: 'application/pdf' },
-					{ type: 'file', mime: 'application/pdf' },
-				],
-			})
+			const enabled = action.enabled([
+				{ type: 'file', mime: 'application/pdf' },
+				{ type: 'file', mime: 'application/pdf' },
+			])
 
 			expect(enabled).toBe(true)
 		})
@@ -254,12 +238,10 @@ describe('openInLibreSignAction rules', () => {
 				},
 			})
 
-			const enabled = action.enabled({
-				nodes: [
-					{ type: 'file', mime: 'application/pdf' },
-					{ type: 'file', mime: 'application/pdf' },
-				],
-			})
+			const enabled = action.enabled([
+				{ type: 'file', mime: 'application/pdf' },
+				{ type: 'file', mime: 'application/pdf' },
+			])
 
 			expect(enabled).toBe(false)
 		})
@@ -273,12 +255,10 @@ describe('openInLibreSignAction rules', () => {
 				},
 			})
 
-			const enabled = action.enabled({
-				nodes: [
-					{ type: 'file', mime: 'application/pdf' },
-					{ type: 'file', mime: 'image/png' },
-				],
-			})
+			const enabled = action.enabled([
+				{ type: 'file', mime: 'application/pdf' },
+				{ type: 'file', mime: 'image/png' },
+			])
 
 			expect(enabled).toBe(false)
 		})
@@ -291,7 +271,7 @@ describe('openInLibreSignAction rules', () => {
 
 			window.OCA.Libresign = {}
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.files[0].fileId).toBe(999)
@@ -305,17 +285,19 @@ describe('openInLibreSignAction rules', () => {
 		})
 
 		it('disables when nodes array is empty', () => {
-			const enabled = action.enabled({ nodes: [] })
+			const enabled = action.enabled([])
 			expect(enabled).toBe(false)
 		})
 
 		it('disables when nodes is null', () => {
-			const enabled = action.enabled({ nodes: null })
+			// @ts-expect-error Testing invalid input
+			const enabled = action.enabled(null)
 			expect(enabled).toBe(false)
 		})
 
 		it('disables when nodes is undefined', () => {
-			const enabled = action.enabled({ nodes: undefined })
+			// @ts-expect-error Testing invalid input
+			const enabled = action.enabled(undefined)
 			expect(enabled).toBe(false)
 		})
 	})
@@ -328,7 +310,7 @@ describe('openInLibreSignAction rules', () => {
 		it('opens sidebar with file', async () => {
 			const node = { type: 'file', mime: 'application/pdf', fileid: 123, path: '/test.pdf' }
 
-			await action.exec({ nodes: [node] })
+			await action.exec(node)
 
 			expect(mockSidebar.open).toHaveBeenCalledWith('/test.pdf')
 			expect(mockSidebar.setActiveTab).toHaveBeenCalledWith('libresign')
@@ -342,14 +324,14 @@ describe('openInLibreSignAction rules', () => {
 				path: '/Documents',
 			}
 
-			await action.exec({ nodes: [node] })
+			await action.exec(node)
 
 			expect(mockSidebar.open).toHaveBeenCalledWith('/Documents')
 		})
 
 		it('returns null after execution', async () => {
 			const node = { type: 'file', mime: 'application/pdf', path: '/test.pdf' }
-			const result = await action.exec({ nodes: [node] })
+			const result = await action.exec(node)
 
 			expect(result).toBeNull()
 		})
@@ -398,7 +380,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/Docs' },
 			]
 
-			const result = await action.execBatch({ nodes })
+			const result = await action.execBatch(nodes)
 
 			expect(result).toEqual([null, null])
 		})
@@ -411,7 +393,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			expect(mockSidebar.open).toHaveBeenCalled()
 			expect(mockSidebar.setActiveTab).toHaveBeenCalledWith('libresign')
@@ -425,7 +407,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.nodeType).toBe('envelope')
@@ -442,7 +424,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.settings.path).toBe('/Documents/Contracts/Test Envelope')
@@ -456,7 +438,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.settings.path).toBe('/Test Envelope')
@@ -470,7 +452,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.settings.path).toBe('/Docs/Test Envelope')
@@ -498,7 +480,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			window.OCA = { Libresign: {}, Files: { Sidebar: mockSidebar as OCAFilesSidebar } }
 
-			await action.execBatch({ nodes })
+			await action.execBatch(nodes)
 
 			const pending = getPendingEnvelope()
 			expect(pending.files[0].fileId).toBe(123)

--- a/src/tests/actions/showStatusInlineAction.spec.ts
+++ b/src/tests/actions/showStatusInlineAction.spec.ts
@@ -22,10 +22,10 @@ describe('showStatusInlineAction', () => {
 		displayName: () => string
 		inline: () => boolean
 		order: number
-		title: (context: { nodes: FileNode[] }) => string
-		iconSvgInline: (context: { nodes: FileNode[] }) => string
-		exec: (context: { nodes: FileNode[] }) => Promise<null> | null
-		enabled: (context: { nodes: FileNode[] }) => boolean
+		title: (nodes: FileNode[]) => string
+		iconSvgInline: (nodes: FileNode[]) => string
+		exec: (node: FileNode) => Promise<null> | null
+		enabled: (nodes: FileNode[]) => boolean
 	}
 
 	let action: FileAction
@@ -123,103 +123,89 @@ describe('showStatusInlineAction', () => {
 
 	describe('title', () => {
 		it('returns empty string when no nodes', () => {
-			const result = action.title({ nodes: [] })
+			const result = action.title([])
 			expect(result).toBe('')
 		})
 
 		it('returns status label for signed node', () => {
-			const result = action.title({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signed-node-id': 123,
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.title([{
+				fileid: 123,
+				attributes: {
+					'libresign-signed-node-id': 123,
+					'libresign-signature-status': 3,
+				},
+			}])
 			expect(result).toBe('Status 3')
 		})
 
 		it('returns status label when no signed node id', () => {
-			const result = action.title({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signature-status': 2,
-					},
-				}],
-			})
+			const result = action.title([{
+				fileid: 123,
+				attributes: {
+					'libresign-signature-status': 2,
+				},
+			}])
 			expect(result).toBe('Status 2')
 		})
 
 		it('returns "original file" for draft with different signed node id', () => {
-			const result = action.title({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signed-node-id': 456,
-						'libresign-signature-status': 0,
-					},
-				}],
-			})
+			const result = action.title([{
+				fileid: 123,
+				attributes: {
+					'libresign-signed-node-id': 456,
+					'libresign-signature-status': 0,
+				},
+			}])
 			expect(result).toBe('original file')
 		})
 
 		it('uses id fallback when fileid is unavailable', () => {
-			const result = action.title({
-				nodes: [{
-					id: 456,
-					attributes: {
-						'libresign-signed-node-id': 456,
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.title([{
+				id: 456,
+				attributes: {
+					'libresign-signed-node-id': 456,
+					'libresign-signature-status': 3,
+				},
+			}])
 			expect(result).toBe('Status 3')
 		})
 	})
 
 	describe('iconSvgInline', () => {
 		it('returns empty string when no nodes', () => {
-			const result = action.iconSvgInline({ nodes: [] })
+			const result = action.iconSvgInline([])
 			expect(result).toBe('')
 		})
 
 		it('returns status svg for signed node', () => {
-			const result = action.iconSvgInline({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signed-node-id': 123,
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.iconSvgInline([{
+				fileid: 123,
+				attributes: {
+					'libresign-signed-node-id': 123,
+					'libresign-signature-status': 3,
+				},
+			}])
 			expect(result).toBe('<svg>3</svg>')
 		})
 
 		it('returns status svg when no signed node id', () => {
-			const result = action.iconSvgInline({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signature-status': 2,
-					},
-				}],
-			})
+			const result = action.iconSvgInline([{
+				fileid: 123,
+				attributes: {
+					'libresign-signature-status': 2,
+				},
+			}])
 			expect(result).toBe('<svg>2</svg>')
 		})
 
 		it('returns draft svg for original file with different signed node id', () => {
-			const result = action.iconSvgInline({
-				nodes: [{
-					fileid: 123,
-					attributes: {
-						'libresign-signed-node-id': 456,
-						'libresign-signature-status': 0,
-					},
-				}],
-			})
+			const result = action.iconSvgInline([{
+				fileid: 123,
+				attributes: {
+					'libresign-signed-node-id': 456,
+					'libresign-signature-status': 0,
+				},
+			}])
 			expect(result).toBe('<svg>0</svg>')
 		})
 	})
@@ -227,7 +213,7 @@ describe('showStatusInlineAction', () => {
 	describe('exec', () => {
 		it('opens sidebar and sets active tab', async () => {
 			const node = { fileid: 123, name: 'test.pdf', path: '/test.pdf' }
-			const result = await action.exec({ nodes: [node] })
+			const result = await action.exec(node)
 
 			expect(global.window.OCA.Files!.Sidebar.open).toHaveBeenCalledWith('/test.pdf')
 			expect(global.window.OCA.Files!.Sidebar.setActiveTab).toHaveBeenCalledWith('libresign')
@@ -239,15 +225,13 @@ describe('showStatusInlineAction', () => {
 		it('returns false when certificate is not ok', () => {
 			mockLoadState.mockReturnValue(false)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					mime: 'application/pdf',
-					attributes: {
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				mime: 'application/pdf',
+				attributes: {
+					'libresign-signature-status': 3,
+				},
+			}])
 
 			expect(result).toBe(false)
 		})
@@ -255,13 +239,11 @@ describe('showStatusInlineAction', () => {
 		it('returns false when nodes do not have status', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					mime: 'application/pdf',
-					attributes: {},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				mime: 'application/pdf',
+				attributes: {},
+			}])
 
 			expect(result).toBe(false)
 		})
@@ -269,15 +251,13 @@ describe('showStatusInlineAction', () => {
 		it('returns true for PDF with status', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					mime: 'application/pdf',
-					attributes: {
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				mime: 'application/pdf',
+				attributes: {
+					'libresign-signature-status': 3,
+				},
+			}])
 
 			expect(result).toBe(true)
 		})
@@ -285,15 +265,13 @@ describe('showStatusInlineAction', () => {
 		it('returns true for PDF when only mimetype is available', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					mimetype: 'application/pdf',
-					attributes: {
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				mimetype: 'application/pdf',
+				attributes: {
+					'libresign-signature-status': 3,
+				},
+			}])
 
 			expect(result).toBe(true)
 		})
@@ -301,15 +279,13 @@ describe('showStatusInlineAction', () => {
 		it('returns true for folder with status', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					type: 'folder',
-					attributes: {
-						'libresign-signature-status': 2,
-					},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				type: 'folder',
+				attributes: {
+					'libresign-signature-status': 2,
+				},
+			}])
 
 			expect(result).toBe(true)
 		})
@@ -317,16 +293,14 @@ describe('showStatusInlineAction', () => {
 		it('returns false for non-PDF/non-folder', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [{
-					fileid: 1,
-					mime: 'text/plain',
-					type: 'file',
-					attributes: {
-						'libresign-signature-status': 3,
-					},
-				}],
-			})
+			const result = action.enabled([{
+				fileid: 1,
+				mime: 'text/plain',
+				type: 'file',
+				attributes: {
+					'libresign-signature-status': 3,
+				},
+			}])
 
 			expect(result).toBe(false)
 		})
@@ -334,24 +308,22 @@ describe('showStatusInlineAction', () => {
 		it('returns true for multiple PDFs with status', () => {
 			mockLoadState.mockReturnValue(true)
 
-			const result = action.enabled({
-				nodes: [
-					{
-						fileid: 1,
-						mime: 'application/pdf',
-						attributes: {
-							'libresign-signature-status': 3,
-						},
+			const result = action.enabled([
+				{
+					fileid: 1,
+					mime: 'application/pdf',
+					attributes: {
+						'libresign-signature-status': 3,
 					},
-					{
-						fileid: 2,
-						mime: 'application/pdf',
-						attributes: {
-							'libresign-signature-status': 2,
-						},
+				},
+				{
+					fileid: 2,
+					mime: 'application/pdf',
+					attributes: {
+						'libresign-signature-status': 2,
 					},
-				],
-			})
+				},
+			])
 
 			expect(result).toBe(true)
 		})


### PR DESCRIPTION
Nextcloud changed how the Files app calls file action callbacks between stable32 and master/stable33
Replaces https://github.com/LibreSign/libresign/pull/7318 for stable32 at least

Resolves: https://github.com/LibreSign/libresign/issues/7235

## 📝 Summary

LoadAdditionalListener loads libresign-init (which registers the file actions) but never provides the certificate_ok initial state. The enabled() check always returned false.

Also `enabled({ nodes })` destructuring works on master (it pulls `nodes` out of the context object), but on stable32 the first argument is already the array itself, destructuring it for a `nodes` property gives `undefined`.

## 🧪 How to test

1. Access your files
2. Click on a three-dot menu (on a pdf for example)
3. see that the shortcut is there (at the top)

Also, there is the libresign icon applied for signed documents.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).