### PR TITLE
fix: handle visible signatures for envelope child files

### DIFF
--- a/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
+++ b/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
@@ -38,9 +38,9 @@ type OcsEnvelopeResponse = {
 	files?: OcsEnvelopeChildFile[]
 }
 
-function createIssue7344Scenario(): EnvelopeSigningScenario {
+function buildSigningScenario(): EnvelopeSigningScenario {
 	return {
-		envelopeName: `Issue 7344 envelope ${Date.now()}`,
+		envelopeName: `Envelope with visible signature ${Date.now()}`,
 		signerEmail: 'signer01@libresign.coop',
 		signerName: 'Signer 01',
 	}
@@ -209,25 +209,32 @@ async function expectEnvelopeSigned(page: Page, envelopeName: string) {
 }
 
 test('unauthenticated signer can define a visible signature for an envelope with multiple PDFs', async ({ page }) => {
-	const scenario = createIssue7344Scenario()
+	const scenario = buildSigningScenario()
 	const mailpit = createMailpitClient()
 
-	// 1. Prepare the signing rules used in this scenario.
-	await enableEnvelopeScenario(page.request)
+	await test.step('Given the system is configured to allow envelope signing via e-mail', async () => {
+		await enableEnvelopeScenario(page.request)
+	})
 
-	// 2. Start with a clean inbox and create the envelope already containing
-	//    a visible signature box inside the first PDF of the envelope.
-	await mailpit.deleteMessages()
-	await createEnvelopeWithVisibleSignatureRequirement(page.request, scenario)
+	await test.step('And an envelope with two PDFs is created requiring a visible signature on the first document', async () => {
+		await mailpit.deleteMessages()
+		await createEnvelopeWithVisibleSignatureRequirement(page.request, scenario)
+	})
 
-	// 3. Open the invitation exactly as the external signer would do.
-	const signLink = await waitForSignerInvitationLink(scenario.signerEmail)
-	await openInvitationAsExternalSigner(page, signLink)
+	await test.step('When the external signer opens the invitation link received by e-mail', async () => {
+		const signLink = await waitForSignerInvitationLink(scenario.signerEmail)
+		await openInvitationAsExternalSigner(page, signLink)
+	})
 
-	// 4. Define the visible signature and complete the signing action.
-	await defineVisibleSignature(page)
-	await finishSigning(page)
+	await test.step('And the signer draws and saves their visible signature on the document', async () => {
+		await defineVisibleSignature(page)
+	})
 
-	// 5. Confirm the signer reaches the final success screen.
-	await expectEnvelopeSigned(page, scenario.envelopeName)
+	await test.step('And the signer submits the signed document', async () => {
+		await finishSigning(page)
+	})
+
+	await test.step('Then the success confirmation screen is shown with the envelope name', async () => {
+		await expectEnvelopeSigned(page, scenario.envelopeName)
+	})
 })

--- a/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
+++ b/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/test'
+import type { APIRequestContext, Page } from '@playwright/test'
+import { configureOpenSsl, setAppConfig } from '../support/nc-provisioning'
+import { createMailpitClient, extractSignLink, waitForEmailTo } from '../support/mailpit'
+
+/**
+ * Issue #7344 in plain words:
+ * an external signer receives an envelope with two PDFs, the visible signature
+ * box exists only inside one child PDF, and the signer must still be able to
+ * create the signature and finish the signing flow.
+ */
+
+type EnvelopeSigningScenario = {
+	envelopeName: string
+	signerEmail: string
+	signerName: string
+}
+
+type OcsEnvelopeChildSigner = {
+	signRequestId?: number
+	email?: string
+	displayName?: string
+}
+
+type OcsEnvelopeChildFile = {
+	id?: number
+	name?: string
+	signers?: OcsEnvelopeChildSigner[]
+}
+
+type OcsEnvelopeResponse = {
+	uuid?: string
+	files?: OcsEnvelopeChildFile[]
+}
+
+function createIssue7344Scenario(): EnvelopeSigningScenario {
+	return {
+		envelopeName: `Issue 7344 envelope ${Date.now()}`,
+		signerEmail: 'signer01@libresign.coop',
+		signerName: 'Signer 01',
+	}
+}
+
+async function requestLibreSignApiAsAdmin(
+	request: APIRequestContext,
+	method: 'POST' | 'PATCH',
+	path: string,
+	body: Record<string, unknown>,
+) {
+	const adminUser = process.env.NEXTCLOUD_ADMIN_USER ?? 'admin'
+	const adminPassword = process.env.NEXTCLOUD_ADMIN_PASSWORD ?? 'admin'
+	const auth = 'Basic ' + Buffer.from(`${adminUser}:${adminPassword}`).toString('base64')
+	const response = await request.fetch(`./ocs/v2.php/apps/libresign/api/v1${path}`, {
+		method,
+		headers: {
+			'OCS-ApiRequest': 'true',
+			Accept: 'application/json',
+			Authorization: auth,
+			'Content-Type': 'application/json',
+		},
+		data: JSON.stringify(body),
+		failOnStatusCode: false,
+	})
+
+	if (!response.ok()) {
+		throw new Error(`LibreSign OCS request failed: ${method} ${path} -> ${response.status()} ${await response.text()}`)
+	}
+
+	return response.json() as Promise<{ ocs: { data: OcsEnvelopeResponse } }>
+}
+
+async function enableEnvelopeScenario(request: APIRequestContext) {
+	await configureOpenSsl(request, 'LibreSign Test', {
+		C: 'BR',
+		OU: ['Organization Unit'],
+		ST: 'Rio de Janeiro',
+		O: 'LibreSign',
+		L: 'Rio de Janeiro',
+	})
+
+	await setAppConfig(request, 'libresign', 'envelope_enabled', '1')
+	await setAppConfig(
+		request,
+		'libresign',
+		'identify_methods',
+		JSON.stringify([
+			{ name: 'account', enabled: false, mandatory: false },
+			{ name: 'email', enabled: true, mandatory: true, signatureMethods: { clickToSign: { enabled: true } }, can_create_account: false },
+		]),
+	)
+}
+
+async function createEnvelopeWithVisibleSignatureRequirement(
+	request: APIRequestContext,
+	scenario: EnvelopeSigningScenario,
+) {
+	const pdfResponse = await request.get('https://raw.githubusercontent.com/LibreSign/libresign/main/tests/php/fixtures/pdfs/small_valid.pdf', {
+		failOnStatusCode: true,
+	})
+	const pdfBase64 = Buffer.from(await pdfResponse.body()).toString('base64')
+
+	const createResponse = await requestLibreSignApiAsAdmin(request, 'POST', '/request-signature', {
+		name: scenario.envelopeName,
+		files: [
+			{ name: 'issue-7344-a.pdf', base64: pdfBase64 },
+			{ name: 'issue-7344-b.pdf', base64: pdfBase64 },
+		],
+		signers: [{
+			displayName: scenario.signerName,
+			identifyMethods: [{
+				method: 'email',
+				value: scenario.signerEmail,
+				mandatory: 1,
+			}],
+		}],
+	})
+
+	const envelope = createResponse.ocs.data
+	const targetFile = envelope.files?.[0]
+	const targetSigner = targetFile?.signers?.find((signer) => {
+		return signer.email === scenario.signerEmail || signer.displayName === scenario.signerName
+	})
+
+	if (!envelope.uuid || !targetFile?.id || !targetSigner?.signRequestId) {
+		throw new Error('Failed to create envelope payload for issue #7344 e2e test')
+	}
+
+	await requestLibreSignApiAsAdmin(request, 'PATCH', '/request-signature', {
+		uuid: envelope.uuid,
+		status: 1,
+		visibleElements: [{
+			type: 'signature',
+			fileId: targetFile.id,
+			signRequestId: targetSigner.signRequestId,
+			coordinates: {
+				page: 1,
+				left: 32,
+				top: 48,
+				width: 180,
+				height: 64,
+			},
+		}],
+	})
+}
+
+async function waitForSignerInvitationLink(signerEmail: string) {
+	const email = await waitForEmailTo(
+		createMailpitClient(),
+		signerEmail,
+		'LibreSign: There is a file for you to sign',
+	)
+	const signLink = extractSignLink(email.Text)
+	if (!signLink) {
+		throw new Error('Sign link not found in email')
+	}
+	return signLink
+}
+
+async function openInvitationAsExternalSigner(page: Page, signLink: string) {
+	// API setup runs as admin. Clear cookies so the browser behaves like the real external signer.
+	await page.context().clearCookies()
+	await page.goto(signLink)
+}
+
+async function defineVisibleSignature(page: Page) {
+	const deleteSignatureButton = page.getByRole('button', { name: 'Delete signature' })
+	await deleteSignatureButton.waitFor({ state: 'visible', timeout: 3_000 }).catch(() => null)
+	if (await deleteSignatureButton.isVisible()) {
+		await deleteSignatureButton.click()
+	}
+
+	await expect(page.getByRole('button', { name: 'Define your signature.' })).toBeVisible()
+	await page.getByRole('button', { name: 'Define your signature.' }).click()
+
+	const signatureDialog = page.getByRole('dialog', { name: 'Customize your signatures' })
+	await expect(signatureDialog).toBeVisible()
+	await signatureDialog.locator('canvas').click({
+		position: {
+			x: 156,
+			y: 132,
+		},
+	})
+	await signatureDialog.getByRole('button', { name: 'Save' }).click()
+
+	const confirmDialog = page.getByLabel('Confirm your signature')
+	await expect(confirmDialog).toBeVisible()
+	await confirmDialog.getByRole('button', { name: 'Save' }).click()
+
+	await expect(page.getByRole('button', { name: 'Sign the document.' })).toBeVisible()
+}
+
+async function finishSigning(page: Page) {
+	await page.getByRole('button', { name: 'Sign the document.' }).click()
+	await page.getByRole('button', { name: 'Sign document' }).click()
+}
+
+async function expectEnvelopeSigned(page: Page, envelopeName: string) {
+	await page.waitForURL('**/validation/**')
+	await expect(page.getByText('Envelope information')).toBeVisible()
+	await expect(page.getByText('Documents in this envelope')).toBeVisible()
+	await expect(page.getByText('Congratulations you have digitally signed a document using LibreSign')).toBeVisible()
+	await expect(page.locator('h2.app-sidebar-header__mainname')).toHaveText(envelopeName)
+	await expect(page.getByText('You need to define a visible signature or initials to sign this document.')).not.toBeVisible()
+}
+
+test('unauthenticated signer can define a visible signature for an envelope with multiple PDFs', async ({ page }) => {
+	const scenario = createIssue7344Scenario()
+	const mailpit = createMailpitClient()
+
+	// 1. Prepare the signing rules used in this scenario.
+	await enableEnvelopeScenario(page.request)
+
+	// 2. Start with a clean inbox and create the envelope already containing
+	//    a visible signature box inside the first PDF of the envelope.
+	await mailpit.deleteMessages()
+	await createEnvelopeWithVisibleSignatureRequirement(page.request, scenario)
+
+	// 3. Open the invitation exactly as the external signer would do.
+	const signLink = await waitForSignerInvitationLink(scenario.signerEmail)
+	await openInvitationAsExternalSigner(page, signLink)
+
+	// 4. Define the visible signature and complete the signing action.
+	await defineVisibleSignature(page)
+	await finishSigning(page)
+
+	// 5. Confirm the signer reaches the final success screen.
+	await expectEnvelopeSigned(page, scenario.envelopeName)
+})

--- a/playwright/support/mailpit.ts
+++ b/playwright/support/mailpit.ts
@@ -10,6 +10,17 @@ export type { MailpitClient }
 
 type Message = Awaited<ReturnType<MailpitClient['getMessageSummary']>>
 
+function resolveAgainstPlaywrightBaseUrl(url: string): string {
+	const baseUrl = process.env.PLAYWRIGHT_BASE_URL
+	if (!baseUrl) {
+		return url
+	}
+
+	const parsedUrl = new URL(url)
+	const targetUrl = new URL(`${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`, baseUrl)
+	return targetUrl.toString()
+}
+
 /** Creates a MailpitClient using MAILPIT_URL (default: http://localhost:8025). */
 export function createMailpitClient(): MailpitClient {
 	const defaultUrl = existsSync('/.dockerenv')
@@ -65,7 +76,12 @@ export async function waitForEmailTo(
 /** Extracts a LibreSign sign link from an email body matching /p/sign/{uuid}. */
 export function extractSignLink(body: string): string | null {
 	const match = body.match(/\S+\/p\/sign\/[\w-]+/)
-	return match ? match[0] : null
+	if (!match) {
+		return null
+	}
+
+	const parsedUrl = new URL(match[0])
+	return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
 }
 
 /** Extracts a numeric token from an email body. Default pattern: 4-8 digit sequence. */
@@ -80,5 +96,5 @@ export function extractTokenFromEmail(
 /** Extracts the first URL from an email body (email.Text). */
 export function extractLinkFromEmail(body: string): string | null {
 	const match = body.match(/https?:\/\/\S+/)
-	return match ? match[0] : null
+	return match ? resolveAgainstPlaywrightBaseUrl(match[0]) : null
 }

--- a/src/services/SigningRequirementValidator.ts
+++ b/src/services/SigningRequirementValidator.ts
@@ -4,12 +4,17 @@
  */
 
 import { ACTION_CODES } from '../helpers/ActionMapping.ts'
+import { hasVisibleElementsForCurrentUser } from './visibleElementsService'
 
 interface SignStore {
 	errors: Array<{ code?: number; [key: string]: unknown }>
 	document?: {
 		signers?: Array<{ me?: boolean; signRequestId?: number }> | null
 		visibleElements?: Array<{ signRequestId?: number }> | null
+		files?: Array<{
+			signers?: Array<{ me?: boolean; signRequestId?: number }> | null
+			visibleElements?: Array<{ signRequestId?: number }> | null
+		}> | null
 	}
 }
 
@@ -110,14 +115,8 @@ export class SigningRequirementValidator {
 			return false
 		}
 
-		const signer = this.signStore.document?.signers?.find(row => row.me) || {}
-		const signRequestId = (signer as { signRequestId?: number }).signRequestId
-
-		if (!signRequestId) {
-			return false
-		}
-
-		const visibleElements = this.signStore.document?.visibleElements || []
-		return visibleElements.some(row => row.signRequestId === signRequestId)
+		return hasVisibleElementsForCurrentUser(
+			(this.signStore.document ?? {}) as Parameters<typeof hasVisibleElementsForCurrentUser>[0],
+		)
 	}
 }

--- a/src/services/visibleElementsService.ts
+++ b/src/services/visibleElementsService.ts
@@ -123,12 +123,40 @@ export const getFileSigners = (file: FileLike): SignerLike[] => {
 	return []
 }
 
+export const getCurrentUserSignRequestIds = (document: DocumentLike): number[] => {
+	const signRequestIds = new Set<number>()
+	const addSignRequestId = (signer: SignerLike | null | undefined) => {
+		if (!isCurrentUserSigner(signer) || signer.signRequestId === undefined) {
+			return
+		}
+		signRequestIds.add(signer.signRequestId)
+	}
+
+	const signers = Array.isArray(document?.signers) ? document.signers : []
+	signers.forEach(addSignRequestId)
+
+	const files = Array.isArray(document?.files) ? document.files : []
+	files.flatMap((file) => getFileSigners(file)).forEach(addSignRequestId)
+
+	return Array.from(signRequestIds)
+}
+
 export const getVisibleElementsFromDocument = (document: DocumentLike): VisibleElementRecord[] => {
 	const topLevel = Array.isArray(document?.visibleElements) ? document.visibleElements : []
 	const signers = Array.isArray(document?.signers) ? document.signers : []
 	const nested = collectSignerVisibleElements(signers)
 	const files = Array.isArray(document?.files) ? aggregateVisibleElementsByFiles(document.files) : []
 	return deduplicateVisibleElements([...topLevel, ...nested, ...files])
+}
+
+export const hasVisibleElementsForCurrentUser = (document: DocumentLike): boolean => {
+	const signRequestIds = new Set(getCurrentUserSignRequestIds(document))
+	if (signRequestIds.size === 0) {
+		return false
+	}
+
+	return getVisibleElementsFromDocument(document)
+		.some((element) => element.signRequestId !== undefined && signRequestIds.has(element.signRequestId))
 }
 
 export const getVisibleElementsFromFile = (file: FileLike): VisibleElementRecord[] => {

--- a/src/tests/services/SigningRequirementValidator.spec.ts
+++ b/src/tests/services/SigningRequirementValidator.spec.ts
@@ -30,6 +30,14 @@ describe('SigningRequirementValidator', () => {
 		identificationDocumentStore?: IdentificationDocumentStoreOverrides
 	}
 
+	const visibleSignatureElement = {
+		elementId: 101,
+		fileId: 1,
+		signRequestId: 10,
+		type: 'signature',
+		coordinates: { page: 1, left: 10, top: 20 },
+	}
+
 	const createStores = (overrides: StoresOverrides = {}) => {
 		const signStore = {
 			errors: [],
@@ -44,7 +52,7 @@ describe('SigningRequirementValidator', () => {
 					identifyMethod: 'email',
 					identifyValue: 'signer@example.com',
 				}],
-				visibleElements: [{ signRequestId: 10 }],
+				visibleElements: [visibleSignatureElement],
 			},
 			...overrides.signStore,
 		}
@@ -183,6 +191,39 @@ describe('SigningRequirementValidator', () => {
 		const result = validator.needsCreateSignature({ hasSignatures: false, canCreateSignature: true })
 
 		expect(result).toBe(false)
+	})
+
+	it('requires createSignature when current signer visible elements are only on envelope child files', () => {
+		const stores = createStores({
+			signStore: {
+				document: {
+					signers: [{ me: true, signRequestId: 700 }],
+					visibleElements: [],
+					files: [
+						{
+							id: 10,
+							signers: [{ me: true, signRequestId: 501 }],
+							visibleElements: [{
+								elementId: 201,
+								fileId: 10,
+								signRequestId: 501,
+								type: 'signature',
+								coordinates: { page: 1, left: 15, top: 25 },
+							}],
+						},
+					],
+				},
+			},
+		})
+		const validator = new SigningRequirementValidator(
+			stores.signStore,
+			stores.signMethodsStore,
+			stores.identificationDocumentStore,
+		)
+
+		const result = validator.needsCreateSignature({ hasSignatures: false, canCreateSignature: true })
+
+		expect(result).toBe(true)
 	})
 
 	it('returns createSignature before clickToSign when no signature exists', () => {

--- a/src/tests/services/visibleElementsService.spec.ts
+++ b/src/tests/services/visibleElementsService.spec.ts
@@ -5,7 +5,9 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+	getCurrentUserSignRequestIds,
 	getVisibleElementsFromDocument,
+	hasVisibleElementsForCurrentUser,
 } from '../../services/visibleElementsService'
 
 describe('visibleElementsService', () => {
@@ -69,6 +71,53 @@ describe('visibleElementsService', () => {
 			expect(result).toEqual([
 				{ elementId: 101, fileId: 1, signRequestId: 401, type: 'signature', coordinates: { page: 1, left: 12, top: 18 } },
 			])
+		})
+	})
+
+	describe('getCurrentUserSignRequestIds', () => {
+		it('collects current signer ids from envelope parent and child files', () => {
+			const document = {
+				signers: [
+					{ me: true, signRequestId: 700 },
+				],
+				files: [
+					{
+						id: 10,
+						signers: [
+							{ me: true, signRequestId: 501 },
+							{ me: false, signRequestId: 502 },
+						],
+					},
+				],
+			}
+
+			const result = getCurrentUserSignRequestIds(document)
+
+			expect(result).toEqual([700, 501])
+		})
+	})
+
+	describe('hasVisibleElementsForCurrentUser', () => {
+		it('detects child file visible elements for current envelope signer', () => {
+			const document = {
+				visibleElements: [],
+				signers: [
+					{ me: true, signRequestId: 700 },
+				],
+				files: [
+					{
+						id: 10,
+						visibleElements: [
+							{ elementId: 201, fileId: 10, signRequestId: 501, type: 'signature', coordinates: { page: 1, left: 10, top: 20 } },
+						],
+						signers: [
+							{ me: true, signRequestId: 501 },
+						],
+					},
+				],
+			}
+
+			expect(hasVisibleElementsForCurrentUser(document)).toBe(true)
 		})
 	})
 })

--- a/src/tests/views/Settings/SignatureEngine.spec.ts
+++ b/src/tests/views/Settings/SignatureEngine.spec.ts
@@ -9,8 +9,10 @@ import { mount } from '@vue/test-utils'
 
 import SignatureEngine from '../../../views/Settings/SignatureEngine.vue'
 
-const loadStateMock = vi.fn()
-const emitMock = vi.fn()
+const { loadStateMock, emitMock } = vi.hoisted(() => ({
+	loadStateMock: vi.fn(),
+	emitMock: vi.fn(),
+}))
 
 vi.mock('@nextcloud/initial-state', () => ({
 	loadState: (...args: unknown[]) => loadStateMock(...args),

--- a/src/tests/views/SignPDF/Sign.spec.ts
+++ b/src/tests/views/SignPDF/Sign.spec.ts
@@ -1208,6 +1208,69 @@ describe('Sign.vue - signWithTokenCode', () => {
 			expect(wrapper.vm.needCreateSignature).toBe(false)
 		})
 
+		it('requires signature creation for envelope child elements even when parent signer id differs', async () => {
+			const { default: realSign } = await import('../../../views/SignPDF/_partials/Sign.vue')
+			const { useSignStore } = await import('../../../store/sign.js')
+			const { useSignatureElementsStore } = await import('../../../store/signatureElements.js')
+
+			const signStore = useSignStore()
+			const signatureElementsStore = useSignatureElementsStore()
+
+			signStore.document = createSignDocument({
+				nodeType: 'envelope',
+				signers: [
+					{ signRequestId: 700, me: true },
+				],
+				files: [
+					{
+						id: 10,
+						name: 'child-file',
+						signers: [
+							{ signRequestId: 501, me: true },
+						],
+						visibleElements: [
+							{ elementId: 201, fileId: 10, signRequestId: 501, type: 'signature', coordinates: { page: 1, left: 10, top: 20, width: 30, height: 40 } },
+						],
+					},
+				],
+			})
+
+			signatureElementsStore.signs.signature = {
+				id: 0,
+				type: '',
+				file: { url: '', nodeId: 0 },
+				starred: 0,
+				createdAt: '',
+			}
+
+			const wrapper = mount(realSign, {
+				global: {
+					stubs: {
+						NcButton: true,
+						NcDialog: true,
+						NcLoadingIcon: true,
+						TokenManager: true,
+						EmailManager: true,
+						UploadCertificate: true,
+						Documents: true,
+						Signatures: true,
+						Draw: true,
+						ManagePassword: true,
+						CreatePassword: true,
+						NcNoteCard: true,
+						NcPasswordField: true,
+						NcRichText: true,
+					},
+					mocks: {
+						$watch: vi.fn(),
+					},
+				},
+			})
+
+			expect(wrapper.vm.hasSignatures).toBe(false)
+			expect(wrapper.vm.needCreateSignature).toBe(true)
+		})
+
 		it('returns false for needCreateSignature when signer has no placed visibleElements (clickToSign scenario)', async () => {
 			// Regression: commit e9ea79495 removed visibleElements.some() check, causing
 			// needCreateSignature to return true for clickToSign documents where no visual

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -199,10 +199,14 @@ import { SigningRequirementValidator } from '../../../services/SigningRequiremen
 import { SignFlowHandler } from '../../../services/SignFlowHandler'
 import {
 	normalizeDocumentForVisibleElements,
-	normalizeFileForVisibleElements,
 } from '../../../services/signingDocumentAdapter'
 import { FILE_STATUS } from '../../../constants.js'
-import { getFileSigners, getVisibleElementsFromDocument, idsMatch, isCurrentUserSigner } from '../../../services/visibleElementsService'
+import {
+	getCurrentUserSignRequestIds,
+	hasVisibleElementsForCurrentUser,
+	getVisibleElementsFromDocument,
+	idsMatch,
+} from '../../../services/visibleElementsService'
 
 type OpenApiAccountMe = operations['account-me']['responses'][200]['content']['application/json']['ocs']['data']
 type LibreSignAccountMe = Omit<OpenApiAccountMe, 'settings'> & {
@@ -322,7 +326,6 @@ type SignatureProfile = LibreSignUserElement
 
 type SignDocument = NonNullable<ReturnType<typeof useSignStore>['document']>
 type SignDocumentFile = NonNullable<SignDocument['files']>[number]
-type SignDocumentSigner = NonNullable<SignDocument['signers']>[number]
 
 type SignResult = {
 	status: 'signingInProgress' | 'signed' | 'unknown'
@@ -419,24 +422,10 @@ let requirementValidator: SigningRequirementValidator | null = null
 let actionHandler: SignFlowHandler | null = null
 const currentDocument = computed<SignDocument>(() => signStore.document)
 const visibleElementsDocument = computed(() => normalizeDocumentForVisibleElements(currentDocument.value))
+const currentUserSignRequestIds = computed(() => new Set(getCurrentUserSignRequestIds(visibleElementsDocument.value)))
 
 const elements = computed(() => {
-	const document = currentDocument.value
-	const signer = document?.signers?.find((row: SignDocumentSigner) => row.me)
-
-	const signRequestIds = new Set<number>()
-	if (signer?.signRequestId !== undefined) {
-		signRequestIds.add(signer.signRequestId)
-	}
-
-	if (Array.isArray(document?.files)) {
-		document.files
-			.map(normalizeFileForVisibleElements)
-			.flatMap((file) => getFileSigners(file))
-			.filter((row): row is ReturnType<typeof getFileSigners>[number] & { me: true; signRequestId: number } => isCurrentUserSigner(row) && row.signRequestId !== undefined)
-			.forEach((row) => signRequestIds.add(row.signRequestId))
-	}
-
+	const signRequestIds = currentUserSignRequestIds.value
 	if (signRequestIds.size === 0) {
 		return []
 	}
@@ -458,13 +447,7 @@ const needCreateSignature = computed(() => {
 	if (!canCreateSignature.value || hasSignatures.value) {
 		return false
 	}
-	const document = currentDocument.value
-	const signer = document?.signers?.find((row: SignDocumentSigner) => row.me)
-	if (signer?.signRequestId === undefined) {
-		return false
-	}
-	const visibleElements = visibleElementsDocument.value.visibleElements || []
-	return visibleElements.some((row) => row.signRequestId === signer.signRequestId)
+	return hasVisibleElementsForCurrentUser(visibleElementsDocument.value)
 })
 const needIdentificationDocuments = computed(() => identificationDocumentStore.showDocumentsComponent())
 const canCreateSignature = computed(() => {


### PR DESCRIPTION
## Summary
- detect the current signer across envelope child files when visible signatures are required
- apply the same rule in the signer view and signing requirement validation
- add unit, component, and Playwright regression coverage for issue #7344, with a readable end-to-end scenario

## Testing
- npm run ts:check
- npm run test
- docker compose exec -u www-data -w /var/www/html/apps-extra/libresign playwright npx playwright test playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts --output=/tmp/playwright-issue-7344-readable

Fixes #7344