### PR TITLE
fix: interpolate sign-request uuid into account create URL

### DIFF
--- a/src/tests/views/CreateAccount.spec.ts
+++ b/src/tests/views/CreateAccount.spec.ts
@@ -8,6 +8,8 @@ import { shallowMount } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
 import CreateAccount from '../../views/CreateAccount.vue'
 import md5 from 'blueimp-md5'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
 
 type ValidationField = {
 	$model: string
@@ -82,8 +84,12 @@ describe('CreateAccount.vue - Business Logic', () => {
 	}
 
 	let wrapper!: CreateAccountWrapper
+	const axiosPostMock = vi.mocked(axios.post)
+	const generateOcsUrlMock = vi.mocked(generateOcsUrl)
 
 	beforeEach(() => {
+		axiosPostMock.mockReset()
+		generateOcsUrlMock.mockClear()
 		wrapper = shallowMount(CreateAccount, {
 			global: {
 				mocks: {
@@ -485,6 +491,36 @@ describe('CreateAccount.vue - Business Logic', () => {
 			})
 
 			expect(wrapper.vm.canSave).toBe(false)
+		})
+
+		it('posts create-account request with interpolated sign request uuid', async () => {
+			axiosPostMock.mockRejectedValue({
+				response: {
+					data: {
+						ocs: {
+							data: {
+								message: 'Invalid UUID',
+							},
+						},
+					},
+				},
+			})
+
+			await wrapper.setData({
+				email: 'test@example.com',
+				password: 'validPassword123',
+				passwordConfirm: 'validPassword123',
+			})
+
+			await wrapper.vm.createAccount()
+
+			expect(generateOcsUrlMock).toHaveBeenCalledWith('/apps/libresign/api/v1/account/create/{uuid}', {
+				uuid: 'test-uuid',
+			})
+			expect(axiosPostMock).toHaveBeenCalledWith('/apps/libresign/api/v1/account/create/{uuid}', {
+				email: 'test@example.com',
+				password: 'validPassword123',
+			})
 		})
 	})
 })

--- a/src/views/CreateAccount.vue
+++ b/src/views/CreateAccount.vue
@@ -241,8 +241,9 @@ onBeforeMount(() => {
 async function createAccount() {
 	state.loading = true
 	try {
-		await axios.post(generateOcsUrl('/apps/libresign/api/v1/account/create/{uuid}'), {
+		await axios.post(generateOcsUrl('/apps/libresign/api/v1/account/create/{uuid}', {
 			uuid: route.value.params.uuid ?? '',
+		}), {
 			email: state.email,
 			password: state.password,
 		})


### PR DESCRIPTION
## Summary

When a signer with no Nextcloud account clicks the sign link received by email and fills in the **Create account** form, they get an _Invalid UUID_ error immediately instead of having the account created.

### Root cause

In `CreateAccount.vue`, `createAccount()` built the API URL with:

```ts
generateOcsUrl('/apps/libresign/api/v1/account/create/{uuid}')
// → POST /ocs/v2.php/apps/libresign/api/v1/account/create/{uuid}  ← literal
```

The placeholder `{uuid}` was never replaced because the params object was missing.  
The backend `AccountService::validateCreateToSign()` calls `UUIDUtil::validateUUID('{uuid}')` which returns `false` → throws `Invalid UUID`.

### Fix

Pass the route param as the second argument so `generateOcsUrl` interpolates it:

```ts
generateOcsUrl('/apps/libresign/api/v1/account/create/{uuid}', {
    uuid: route.value.params.uuid ?? '',
})
```

### Tests

Added a focused regression test in `CreateAccount.spec.ts` that asserts `generateOcsUrl` is called with the interpolated uuid, so this exact regression is caught at unit-test level.

Closes #7313