### PR TITLE
chore(release): changelog for 13.2.1 and 12.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 13.2.1 - 2026-04-05
+
+### Changed
+- Update translations
+- Bump dependencies [#7382](https://github.com/LibreSign/libresign/pull/7382)
+
+### Fixes
+- fix: interpolate sign-request uuid into account create URL [#7388](https://github.com/LibreSign/libresign/pull/7388)
+- fix: handle visible signatures for envelope child files [#7385](https://github.com/LibreSign/libresign/pull/7385)
+- fix: extract file descriptor when items have nested `file` key [#7391](https://github.com/LibreSign/libresign/pull/7391)
+- fix: lazy load files sidebar tab [#7401](https://github.com/LibreSign/libresign/pull/7401)
+- fix: CRL disabled flow and signing error UX [#7404](https://github.com/LibreSign/libresign/pull/7404)
+- fix: prevent Imagick crash caused by invalid signature box dimensions [#7407](https://github.com/LibreSign/libresign/pull/7407)
+- fix: validate engine name in migration to prevent installation failures [#7413](https://github.com/LibreSign/libresign/pull/7413)
+- feat: mobile signature placement flow improvements [#7416](https://github.com/LibreSign/libresign/pull/7416)
+
+## 12.4.1 - 2026-04-05
+
+### Changed
+- Update translations
+- Bump dependencies [#7381](https://github.com/LibreSign/libresign/pull/7381)
+
+### Fixes
+- fix: files menu shortcut and icons [#7340](https://github.com/LibreSign/libresign/pull/7340)
+- fix: interpolate sign-request uuid into account create URL [#7387](https://github.com/LibreSign/libresign/pull/7387)
+- fix: handle visible signatures for envelope child files [#7386](https://github.com/LibreSign/libresign/pull/7386)
+- fix: extract file descriptor when items have nested `file` key [#7390](https://github.com/LibreSign/libresign/pull/7390)
+- fix: lazy load files sidebar tab [#7400](https://github.com/LibreSign/libresign/pull/7400)
+- fix: CRL disabled flow and signing error UX [#7403](https://github.com/LibreSign/libresign/pull/7403)
+- fix: prevent Imagick crash caused by invalid signature box dimensions [#7406](https://github.com/LibreSign/libresign/pull/7406)
+- fix: validate engine name in migration to prevent installation failures [#7412](https://github.com/LibreSign/libresign/pull/7412)
+
 ## 13.2.0 - 2026-03-17
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Types of changes:
 <!-- changelog-linker -->
 ## 13.2.1 - 2026-04-05
 
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
 ### Changed
 - Update translations
 - Bump dependencies [#7382](https://github.com/LibreSign/libresign/pull/7382)
@@ -35,6 +39,10 @@ Types of changes:
 - feat: mobile signature placement flow improvements [#7416](https://github.com/LibreSign/libresign/pull/7416)
 
 ## 12.4.1 - 2026-04-05
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
 
 ### Changed
 - Update translations


### PR DESCRIPTION
## Summary
- prepare changelog entries for bugfix releases 13.2.1 (stable33) and 12.4.1 (stable32)
- keep PR strictly scoped to release notes

## Notes
- no code changes
- release PR includes [skip ci] on last commit as per release process