### PR TITLE
fix(appstore): copy dist only if directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ appstore:
 		appinfo \
 		composer \
 		css \
-		dist \
 		img \
 		js \
 		l10n \
@@ -118,6 +117,9 @@ appstore:
 		CHANGELOG.md \
 		openapi*.json \
 		$(appstore_sign_dir)/$(app_name)
+	if [ -d dist ]; then \
+		cp -r dist $(appstore_sign_dir)/$(app_name)/; \
+	fi
 	rm -rf $(appstore_sign_dir)/$(app_name)/img/screenshot/
 	rm -rf $(appstore_sign_dir)/$(app_name)/3rdparty/.git
 	rm -rf $(appstore_sign_dir)/$(app_name)/3rdparty/.github


### PR DESCRIPTION
## Problem

The `appstore` Makefile target unconditionally copies the `dist/` directory:

```makefile
cp -r \
    appinfo \
    css \
    dist \   ← fails when absent
    js \
    ...
```

The GitHub Actions release workflow runs `npm run build` (via Vite + `@nextcloud/vite-config`), which outputs the pdf worker to `js/` — not `dist/`. Since `dist/` is not created by the build in CI, `make appstore` fails with:

```
cp: cannot stat 'dist': No such file or directory
```

This caused the v12.4.1 and v13.2.1 release workflows to fail (fixed on stable32/stable33 via PRs #7423 and #7424).

## Fix

Remove `dist` from the unconditional `cp -r` and add a conditional guard (identical to what `verify-appstore-package` already does):

```makefile
if [ -d dist ]; then \
    cp -r dist $(appstore_sign_dir)/$(app_name)/; \
fi
```

Consistent with the existing conditional in `verify-appstore-package`.