### PR TITLE
fix(appstore): verify pdf worker in js/ instead of dist/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,8 @@ appstore:
 .PHONY: verify-appstore-package
 verify-appstore-package:
 	test -d $(appstore_sign_dir)/$(app_name)/css
+	test -d $(appstore_sign_dir)/$(app_name)/js
+	find $(appstore_sign_dir)/$(app_name)/js -maxdepth 1 -name 'pdf.worker.min-*.mjs' | grep -q .
 	if [ -d dist ]; then \
 		test -d $(appstore_sign_dir)/$(app_name)/dist; \
-		find $(appstore_sign_dir)/$(app_name)/dist -maxdepth 1 -name 'pdf.worker.min-*.mjs' | grep -q .; \
 	fi


### PR DESCRIPTION
## Problem

After updating `@libresign/pdf-elements`, the pdf worker is no longer output to `dist/` — Vite now bundles it to `js/` through the dynamic import in `pdf-elements`' `ensureWorkerReady()`.

The `verify-appstore-package` target was checking for `pdf.worker.min-*.mjs` inside `dist/` (conditionally), so the worker existence check was **always silently skipped** because `dist/` no longer exists in CI builds.

## Fix

- Assert `js/` directory exists in the sign dir (unconditional)
- Find `pdf.worker.min-*.mjs` in `js/` (where it now lives)
- Keep the `dist/` guard only to verify  the dir was copied when present (e.g. local env with stale build artifacts)

## Context

- PR #7423 / #7424 / #7425: made the `dist` copy conditional in `appstore` target
- Root cause: `@libresign/pdf-elements` update moved worker output from `dist/` → `js/` via Vite's handling of the relative dynamic import