### PR TITLE
chore(release): changelog for 12.4.2 and 13.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,37 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 13.2.2 - 2026-04-08
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- Update translations
+- Bump dependencies [#7452](https://github.com/LibreSign/libresign/pull/7452) [#7453](https://github.com/LibreSign/libresign/pull/7453) [#7456](https://github.com/LibreSign/libresign/pull/7456) [#7459](https://github.com/LibreSign/libresign/pull/7459) [#7457](https://github.com/LibreSign/libresign/pull/7457) [#7461](https://github.com/LibreSign/libresign/pull/7461) [#7463](https://github.com/LibreSign/libresign/pull/7463) [#7469](https://github.com/LibreSign/libresign/pull/7469) [#7471](https://github.com/LibreSign/libresign/pull/7471)
+
+### Fixes
+- fix: improve TSA DNS/network error guidance [#7430](https://github.com/LibreSign/libresign/pull/7430)
+- fix: align signer and file UUID contracts [#7441](https://github.com/LibreSign/libresign/pull/7441)
+- fix(validation): harden unified files contract [#7445](https://github.com/LibreSign/libresign/pull/7445)
+- fix(Sign): submit each envelope file independently with its UUID [#7448](https://github.com/LibreSign/libresign/pull/7448)
+
+## 12.4.2 - 2026-04-08
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- Update translations
+- Bump dependencies [#7451](https://github.com/LibreSign/libresign/pull/7451) [#7454](https://github.com/LibreSign/libresign/pull/7454) [#7455](https://github.com/LibreSign/libresign/pull/7455) [#7460](https://github.com/LibreSign/libresign/pull/7460) [#7458](https://github.com/LibreSign/libresign/pull/7458) [#7462](https://github.com/LibreSign/libresign/pull/7462) [#7464](https://github.com/LibreSign/libresign/pull/7464) [#7472](https://github.com/LibreSign/libresign/pull/7472) [#7470](https://github.com/LibreSign/libresign/pull/7470)
+
+### Fixes
+- fix: align signer and file UUID contracts [#7440](https://github.com/LibreSign/libresign/pull/7440)
+- fix(validation): harden unified files contract [#7444](https://github.com/LibreSign/libresign/pull/7444)
+- fix(Sign): submit each envelope file independently with its UUID [#7447](https://github.com/LibreSign/libresign/pull/7447)
+
 ## 13.2.1 - 2026-04-05
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign


### PR DESCRIPTION
## Summary\n- prepare release changelog entries for v12.4.2 and v13.2.2\n- keep release PR strictly scoped to changelog updates\n\n## Notes\n- release order remains oldest stable first (stable32, then stable33)\n