### PR TITLE
[stable32] chore(deps): bump actions/github-script from 8.0.0 to 9.0.0

### DIFF
--- a/.github/workflows/update-stable-titles.yml
+++ b/.github/workflows/update-stable-titles.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get PR details and update title
         # Renovate already have target branch in the title
         if: github.event.pull_request.user.login != 'renovate[bot]'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Manual backport of #7497 to stable32 (automatic /backport failed due authentication on bot side).