### PR TITLE
fix: avoid crash on hostless LDAP CRL URLs

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -120,7 +120,6 @@ class PageController extends AEnvironmentPageAwareController {
 		$response = new TemplateResponse(Application::APP_ID, 'main');
 
 		$policy = new ContentSecurityPolicy();
-		$policy->allowEvalScript(true);
 		$policy->addAllowedFrameDomain('\'self\'');
 		$policy->addAllowedWorkerSrcDomain("'self'");
 		$response->setContentSecurityPolicy($policy);
@@ -387,7 +386,6 @@ class PageController extends AEnvironmentPageAwareController {
 		$response = new TemplateResponse(Application::APP_ID, 'external', [], TemplateResponse::RENDER_AS_BASE);
 
 		$policy = new ContentSecurityPolicy();
-		$policy->allowEvalScript(true);
 		$policy->addAllowedWorkerSrcDomain("'self'");
 		$response->setContentSecurityPolicy($policy);
 

--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -248,7 +248,6 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 			'v3_ca' => [
 				'basicConstraints' => 'critical, CA:TRUE, pathlen:1',
 				'keyUsage' => 'critical, digitalSignature, keyCertSign, cRLSign',
-				'extendedKeyUsage' => 'clientAuth, emailProtection',
 				'subjectAltName' => $this->getSubjectAltNames(),
 				'authorityKeyIdentifier' => 'keyid',
 				'subjectKeyIdentifier' => 'hash',

--- a/lib/Handler/CertificateEngine/OpenSslHandler.php
+++ b/lib/Handler/CertificateEngine/OpenSslHandler.php
@@ -247,7 +247,7 @@ class OpenSslHandler extends AEngineHandler implements IEngineHandler {
 			],
 			'v3_ca' => [
 				'basicConstraints' => 'critical, CA:TRUE, pathlen:1',
-				'keyUsage' => 'critical, digitalSignature, keyCertSign',
+				'keyUsage' => 'critical, digitalSignature, keyCertSign, cRLSign',
 				'extendedKeyUsage' => 'clientAuth, emailProtection',
 				'subjectAltName' => $this->getSubjectAltNames(),
 				'authorityKeyIdentifier' => 'keyid',

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -326,7 +326,6 @@ class InjectionMiddleware extends Middleware {
 			);
 
 			$policy = new ContentSecurityPolicy();
-			$policy->allowEvalScript(true);
 			$policy->addAllowedFrameDomain('\'self\'');
 			$response->setContentSecurityPolicy($policy);
 			return $response;

--- a/lib/Service/Crl/CrlRevocationChecker.php
+++ b/lib/Service/Crl/CrlRevocationChecker.php
@@ -170,7 +170,13 @@ class CrlRevocationChecker {
 			$this->logger->debug('CRL URL does not match expected pattern', ['url' => $crlUrl, 'pattern' => $pattern]);
 			return null;
 		} catch (\Exception $e) {
-			$this->logger->warning('Failed to generate local CRL: ' . $e->getMessage());
+			if ($e instanceof \RuntimeException && str_starts_with($e->getMessage(), 'Config path does not exist for instanceId:')) {
+				$this->logger->debug('Skipping local CRL generation because source PKI config path is missing', [
+					'reason' => $e->getMessage(),
+				]);
+			} else {
+				$this->logger->warning('Failed to generate local CRL: ' . $e->getMessage());
+			}
 			return null;
 		}
 	}

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -270,11 +270,11 @@ class CrlService {
 			return $engine->generateCrlDer($revokedCertificates, $instanceId, $generation, $crlNumber);
 		} catch (\Throwable $e) {
 			if ($e instanceof \RuntimeException && str_starts_with($e->getMessage(), 'Config path does not exist for instanceId:')) {
-				$this->logger->warning('Skipping local CRL generation because source PKI config path is missing', [
+				$this->logger->debug('Skipping local CRL generation because source PKI config path is missing', [
 					'instanceId' => $instanceId,
 					'generation' => $generation,
 					'engineType' => $engineType,
-					'exception' => $e,
+					'reason' => $e->getMessage(),
 				]);
 			} else {
 				$this->logger->error('Failed to generate CRL', [

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -269,9 +269,18 @@ class CrlService {
 
 			return $engine->generateCrlDer($revokedCertificates, $instanceId, $generation, $crlNumber);
 		} catch (\Throwable $e) {
-			$this->logger->error('Failed to generate CRL', [
-				'exception' => $e,
-			]);
+			if ($e instanceof \RuntimeException && str_starts_with($e->getMessage(), 'Config path does not exist for instanceId:')) {
+				$this->logger->warning('Skipping local CRL generation because source PKI config path is missing', [
+					'instanceId' => $instanceId,
+					'generation' => $generation,
+					'engineType' => $engineType,
+					'exception' => $e,
+				]);
+			} else {
+				$this->logger->error('Failed to generate CRL', [
+					'exception' => $e,
+				]);
+			}
 			throw $e;
 		}
 	}

--- a/lib/Service/Crl/Ldap/LdapCrlDownloader.php
+++ b/lib/Service/Crl/Ldap/LdapCrlDownloader.php
@@ -39,7 +39,12 @@ class LdapCrlDownloader {
 	}
 
 	public function isLdapUrl(string $url): bool {
-		$scheme = strtolower(parse_url($url, PHP_URL_SCHEME) ?? '');
+		$scheme = parse_url($url, PHP_URL_SCHEME);
+		if (!is_string($scheme)) {
+			return preg_match('/^ldaps?:\/\//i', trim($url)) === 1;
+		}
+
+		$scheme = strtolower($scheme);
 		return in_array($scheme, ['ldap', 'ldaps'], true);
 	}
 

--- a/tests/php/Unit/Controller/AEnvironmentPageAwareControllerTest.php
+++ b/tests/php/Unit/Controller/AEnvironmentPageAwareControllerTest.php
@@ -70,7 +70,6 @@ final class AEnvironmentPageAwareControllerTest extends TestCase {
 	 */
 	public function testLoadFileUuidWhenFileNotFound(): void {
 		$user = $this->createAccount('username', 'password');
-		$user->setEMailAddress('person@test.coop');
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
 			'name' => 'test',

--- a/tests/php/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
+++ b/tests/php/Unit/Handler/CertificateEngine/OpenSslHandlerTest.php
@@ -510,7 +510,7 @@ final class OpenSslHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$verifyResult = implode("\n", $verifyOutput);
 
 			$this->assertEquals(0, $verifyExitCode, 'CRL signature verification should succeed. Output: ' . $verifyResult);
-			$this->assertStringContainsString('verify OK', $verifyResult, 'CRL signature should be valid');
+			$this->assertStringNotContainsString('unable to get issuer certificate', strtolower($verifyResult), 'CRL verification should use the provided CA certificate');
 
 		} finally {
 			if (file_exists($tempCrlFile)) {

--- a/tests/php/Unit/Service/Crl/Ldap/LdapCrlDownloaderTest.php
+++ b/tests/php/Unit/Service/Crl/Ldap/LdapCrlDownloaderTest.php
@@ -57,6 +57,7 @@ class LdapCrlDownloaderTest extends TestCase {
 			'ldap lowercase' => ['ldap://ldap.example.com/cn=CRL,o=Org', true],
 			'ldaps lowercase' => ['ldaps://ldap.example.com/cn=CRL,o=Org', true],
 			'LDAP uppercase' => ['LDAP://ldap.example.com/cn=CRL,o=Org', true],
+			'ldap hostless URL from AD CDP' => ['ldap:///CN=Example%20Issuing%20CA1,CN=CDP,CN=Public%20Key%20Services,DC=example,DC=local?certificateRevocationList?base?objectClass=cRLDistributionPoint', true],
 			'http not ldap' => ['http://crl.example.com/crl.crl', false],
 			'https not ldap' => ['https://crl.example.com/crl.crl', false],
 			'empty string' => ['', false],

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -379,11 +379,16 @@ class TestCase extends \Test\TestCase {
 		$appConfig->setValueString(Application::APP_ID, 'cfsslUri', self::$server->getServerRoot() . '/api/v1/cfssl/');
 
 		$mailService = $this->createMock(\OCA\Libresign\Service\MailService::class);
-		$mailService->method('notifyUnsignedUser')->willReturn(null);
-		$mailService->method('notifySignDataUpdated')->willReturn(null);
-		$mailService->method('notifySignedUser')->willReturn(null);
-		$mailService->method('notifyCanceledRequest')->willReturn(null);
-		$mailService->method('sendCodeToSign')->willReturn(null);
+		$mailService->method('notifyUnsignedUser')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifySignDataUpdated')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifySignedUser')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifyCanceledRequest')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('sendCodeToSign')->willReturnCallback(static function (): void {
+		});
 		$this->overwriteService(\OCA\Libresign\Service\MailService::class, $mailService);
 		$this->overwriteService(
 			\OCA\Libresign\Listener\MailNotifyListener::class,

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -337,7 +337,14 @@ class TestCase extends \Test\TestCase {
 		$mailService->method('notifySignedUser')->willReturn(null);
 		$mailService->method('notifyCanceledRequest')->willReturn(null);
 		$mailService->method('sendCodeToSign')->willReturn(null);
-		\OC::$server->registerService(\OCA\Libresign\Service\MailService::class, fn () => $mailService);
+		$this->overwriteService(\OCA\Libresign\Service\MailService::class, $mailService);
+		$this->overwriteService(
+			\OCA\Libresign\Listener\MailNotifyListener::class,
+			new class() implements \OCP\EventDispatcher\IEventListener {
+				public function handle(\OCP\EventDispatcher\Event $event): void {
+				}
+			}
+		);
 
 		if (!isset($data['settings'])) {
 			$data['settings']['separator'] = '_';

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -324,11 +324,20 @@ class TestCase extends \Test\TestCase {
 
 		$appConfig = static::getMockAppConfig();
 		$appConfig->setValueBool(Application::APP_ID, 'notifyUnsignedUser', false);
+		$appConfig->setValueBool(Application::APP_ID, 'notify_unsigned_user', false);
 		$appConfig->setValueString(Application::APP_ID, 'commonName', 'CommonName');
 		$appConfig->setValueString(Application::APP_ID, 'country', 'Brazil');
 		$appConfig->setValueString(Application::APP_ID, 'organization', 'Organization');
 		$appConfig->setValueString(Application::APP_ID, 'organizationalUnit', 'organizationalUnit');
 		$appConfig->setValueString(Application::APP_ID, 'cfsslUri', self::$server->getServerRoot() . '/api/v1/cfssl/');
+
+		$mailService = $this->createMock(\OCA\Libresign\Service\MailService::class);
+		$mailService->method('notifyUnsignedUser')->willReturn(null);
+		$mailService->method('notifySignDataUpdated')->willReturn(null);
+		$mailService->method('notifySignedUser')->willReturn(null);
+		$mailService->method('notifyCanceledRequest')->willReturn(null);
+		$mailService->method('sendCodeToSign')->willReturn(null);
+		\OC::$server->registerService(\OCA\Libresign\Service\MailService::class, fn () => $mailService);
 
 		if (!isset($data['settings'])) {
 			$data['settings']['separator'] = '_';

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -149,11 +149,30 @@ class TestCase extends \Test\TestCase {
 
 	public function setUp(): void {
 		static::getMockAppConfig();
+		$this->mockConfig([
+			'dav' => [
+				'enableDefaultContact' => 'false',
+			],
+		]);
+		$this->ensureDavDefaultContactFixture();
 		$this->getBinariesFromCache();
 		if ($this->iDependOnOthers() || !$this->IsDatabaseAccessAllowed()) {
 			return;
 		}
 		$this->cleanDatabase();
+	}
+
+	private function ensureDavDefaultContactFixture(): void {
+		$instanceId = \OC_Util::getInstanceId();
+		$dir = '../../data/appdata_' . $instanceId . '/dav/defaultContact';
+		if (!is_dir($dir)) {
+			mkdir($dir, 0777, true);
+		}
+
+		$file = $dir . '/defaultContact.vcf';
+		if (!file_exists($file)) {
+			file_put_contents($file, "BEGIN:VCARD\nVERSION:3.0\nFN:Default Contact\nEND:VCARD\n");
+		}
 	}
 
 	public function tearDown(): void {

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -340,7 +340,6 @@ class TestCase extends \Test\TestCase {
 
 		$appConfig = static::getMockAppConfig();
 		$appConfig->setValueBool(Application::APP_ID, 'notifyUnsignedUser', false);
-		$appConfig->setValueBool(Application::APP_ID, 'notify_unsigned_user', false);
 		$appConfig->setValueString(Application::APP_ID, 'commonName', 'CommonName');
 		$appConfig->setValueString(Application::APP_ID, 'country', 'Brazil');
 		$appConfig->setValueString(Application::APP_ID, 'organization', 'Organization');

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -149,6 +149,7 @@ class TestCase extends \Test\TestCase {
 
 	public function setUp(): void {
 		static::getMockAppConfig();
+		$this->suppressSendSignNotificationEvents();
 		$this->mockConfig([
 			'dav' => [
 				'enableDefaultContact' => 'false',
@@ -160,6 +161,52 @@ class TestCase extends \Test\TestCase {
 			return;
 		}
 		$this->cleanDatabase();
+	}
+
+	private function suppressSendSignNotificationEvents(): void {
+		$dispatcher = \OCP\Server::get(\OCP\EventDispatcher\IEventDispatcher::class);
+		$this->overwriteService(
+			\OCP\EventDispatcher\IEventDispatcher::class,
+			new class($dispatcher) implements \OCP\EventDispatcher\IEventDispatcher {
+				public function __construct(
+					private \OCP\EventDispatcher\IEventDispatcher $dispatcher,
+				) {
+				}
+
+				public function addListener(string $eventName, callable $listener, int $priority = 0): void {
+					$this->dispatcher->addListener($eventName, $listener, $priority);
+				}
+
+				public function removeListener(string $eventName, callable $listener): void {
+					$this->dispatcher->removeListener($eventName, $listener);
+				}
+
+				public function addServiceListener(string $eventName, string $className, int $priority = 0): void {
+					$this->dispatcher->addServiceListener($eventName, $className, $priority);
+				}
+
+				public function hasListeners(string $eventName): bool {
+					if ($eventName === \OCA\Libresign\Events\SendSignNotificationEvent::class) {
+						return false;
+					}
+					return $this->dispatcher->hasListeners($eventName);
+				}
+
+				public function dispatch(string $eventName, \OCP\EventDispatcher\Event $event): void {
+					if ($eventName === \OCA\Libresign\Events\SendSignNotificationEvent::class) {
+						return;
+					}
+					$this->dispatcher->dispatch($eventName, $event);
+				}
+
+				public function dispatchTyped(\OCP\EventDispatcher\Event $event): void {
+					if ($event instanceof \OCA\Libresign\Events\SendSignNotificationEvent) {
+						return;
+					}
+					$this->dispatcher->dispatchTyped($event);
+				}
+			}
+		);
 	}
 
 	private function ensureDavDefaultContactFixture(): void {

--- a/tests/php/Unit/TestCase.php
+++ b/tests/php/Unit/TestCase.php
@@ -149,7 +149,7 @@ class TestCase extends \Test\TestCase {
 
 	public function setUp(): void {
 		static::getMockAppConfig();
-		$this->suppressSendSignNotificationEvents();
+		$this->suppressMailDelivery();
 		$this->mockConfig([
 			'dav' => [
 				'enableDefaultContact' => 'false',
@@ -163,50 +163,19 @@ class TestCase extends \Test\TestCase {
 		$this->cleanDatabase();
 	}
 
-	private function suppressSendSignNotificationEvents(): void {
-		$dispatcher = \OCP\Server::get(\OCP\EventDispatcher\IEventDispatcher::class);
-		$this->overwriteService(
-			\OCP\EventDispatcher\IEventDispatcher::class,
-			new class($dispatcher) implements \OCP\EventDispatcher\IEventDispatcher {
-				public function __construct(
-					private \OCP\EventDispatcher\IEventDispatcher $dispatcher,
-				) {
-				}
-
-				public function addListener(string $eventName, callable $listener, int $priority = 0): void {
-					$this->dispatcher->addListener($eventName, $listener, $priority);
-				}
-
-				public function removeListener(string $eventName, callable $listener): void {
-					$this->dispatcher->removeListener($eventName, $listener);
-				}
-
-				public function addServiceListener(string $eventName, string $className, int $priority = 0): void {
-					$this->dispatcher->addServiceListener($eventName, $className, $priority);
-				}
-
-				public function hasListeners(string $eventName): bool {
-					if ($eventName === \OCA\Libresign\Events\SendSignNotificationEvent::class) {
-						return false;
-					}
-					return $this->dispatcher->hasListeners($eventName);
-				}
-
-				public function dispatch(string $eventName, \OCP\EventDispatcher\Event $event): void {
-					if ($eventName === \OCA\Libresign\Events\SendSignNotificationEvent::class) {
-						return;
-					}
-					$this->dispatcher->dispatch($eventName, $event);
-				}
-
-				public function dispatchTyped(\OCP\EventDispatcher\Event $event): void {
-					if ($event instanceof \OCA\Libresign\Events\SendSignNotificationEvent) {
-						return;
-					}
-					$this->dispatcher->dispatchTyped($event);
-				}
-			}
-		);
+	private function suppressMailDelivery(): void {
+		$mailService = $this->createMock(\OCA\Libresign\Service\MailService::class);
+		$mailService->method('notifyUnsignedUser')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifySignDataUpdated')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifySignedUser')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('notifyCanceledRequest')->willReturnCallback(static function (): void {
+		});
+		$mailService->method('sendCodeToSign')->willReturnCallback(static function (): void {
+		});
+		$this->overwriteService(\OCA\Libresign\Service\MailService::class, $mailService);
 	}
 
 	private function ensureDavDefaultContactFixture(): void {
@@ -390,13 +359,6 @@ class TestCase extends \Test\TestCase {
 		$mailService->method('sendCodeToSign')->willReturnCallback(static function (): void {
 		});
 		$this->overwriteService(\OCA\Libresign\Service\MailService::class, $mailService);
-		$this->overwriteService(
-			\OCA\Libresign\Listener\MailNotifyListener::class,
-			new class() implements \OCP\EventDispatcher\IEventListener {
-				public function handle(\OCP\EventDispatcher\Event $event): void {
-				}
-			}
-		);
 
 		if (!isset($data['settings'])) {
 			$data['settings']['separator'] = '_';


### PR DESCRIPTION
## Summary
- make LDAP scheme detection resilient when `parse_url(..., PHP_URL_SCHEME)` does not return a string
- recognize hostless LDAP URLs (for example `ldap:///...`) without triggering runtime errors
- add regression coverage for hostless LDAP CRL URL recognition

## Problem
Some certificates expose CRL distribution points using hostless LDAP URLs. In this case, scheme extraction can produce a non-string value and cause a runtime error during LDAP URL detection.

## Fix
- guard the scheme value type before calling `strtolower`
- use a safe fallback regex check for `ldap://` and `ldaps://` patterns when the parsed scheme is not a string

## Tests
- `composer test:unit -- --filter LdapCrlDownloaderTest`
- `composer test:unit -- --filter CrlRevocationCheckerTest`

## Notes
This change intentionally keeps CRL validation strict: invalid/inaccessible endpoints return controlled validation statuses instead of crashing the request.