### PR TITLE
fix(crl): enforce CRL metadata with scoped legacy backfill

### DIFF
--- a/lib/Migration/Version17004Date20260421000000.php
+++ b/lib/Migration/Version17004Date20260421000000.php
@@ -41,6 +41,10 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 		}
 
 		$metadata = $this->resolveMetadataDefaults();
+		if ($metadata === null) {
+			$output->warning('Skipped CRL metadata backfill because no deterministic metadata source was found.');
+			return;
+		}
 
 		$updatedInstance = $this->backfillInstanceId($metadata['instanceId']);
 		$updatedGeneration = $this->backfillGeneration($metadata['generation']);
@@ -65,39 +69,13 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
-		if (!$schema->hasTable('libresign_crl')) {
-			return $schema;
-		}
-
-		$metadata = $this->resolveMetadataDefaults();
-		$table = $schema->getTable('libresign_crl');
-
-		if ($table->hasColumn('instance_id')) {
-			$instanceColumn = $table->getColumn('instance_id');
-			$instanceColumn->setNotnull(true);
-			$instanceColumn->setDefault($metadata['instanceId']);
-		}
-
-		if ($table->hasColumn('generation')) {
-			$generationColumn = $table->getColumn('generation');
-			$generationColumn->setNotnull(true);
-			$generationColumn->setDefault($metadata['generation']);
-		}
-
-		if ($table->hasColumn('engine')) {
-			$engineColumn = $table->getColumn('engine');
-			$engineColumn->setNotnull(true);
-			$engineColumn->setDefault($metadata['engine']);
-		}
-
-		return $schema;
+		return $schemaClosure();
 	}
 
 	/**
-	 * @return array{instanceId: string, generation: int, engine: string}
+	 * @return array{instanceId: string, generation: int, engine: string}|null
 	 */
-	private function resolveMetadataDefaults(): array {
+	private function resolveMetadataDefaults(): ?array {
 		$engine = $this->appConfig->getValueString(Application::APP_ID, 'certificate_engine', 'openssl');
 		if ($engine === '' || $engine === 'none') {
 			$engine = 'openssl';
@@ -118,8 +96,8 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 			$instanceId = $this->config->getSystemValueString('instanceid', '');
 		}
 
-		if ($instanceId === '') {
-			$instanceId = 'legacy';
+		if ($instanceId === '' || !in_array($engine, ['openssl', 'cfssl'], true)) {
+			return null;
 		}
 
 		return [
@@ -134,7 +112,15 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 
 		return $qb->update('libresign_crl')
 			->set('instance_id', $qb->createNamedParameter($instanceId))
-			->where(
+			->where($qb->expr()->eq('status', $qb->createNamedParameter('issued')))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('generation'),
+					$qb->expr()->isNull('engine'),
+					$qb->expr()->eq('engine', $qb->createNamedParameter('')),
+				)
+			)
+			->andWhere(
 				$qb->expr()->orX(
 					$qb->expr()->isNull('instance_id'),
 					$qb->expr()->eq('instance_id', $qb->createNamedParameter('')),
@@ -148,7 +134,16 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 
 		return $qb->update('libresign_crl')
 			->set('generation', $qb->createNamedParameter($generation, IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->isNull('generation'))
+			->where($qb->expr()->eq('status', $qb->createNamedParameter('issued')))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('instance_id'),
+					$qb->expr()->eq('instance_id', $qb->createNamedParameter('')),
+					$qb->expr()->isNull('engine'),
+					$qb->expr()->eq('engine', $qb->createNamedParameter('')),
+				)
+			)
+			->andWhere($qb->expr()->isNull('generation'))
 			->executeStatement();
 	}
 
@@ -157,7 +152,15 @@ class Version17004Date20260421000000 extends SimpleMigrationStep {
 
 		return $qb->update('libresign_crl')
 			->set('engine', $qb->createNamedParameter($engine))
-			->where(
+			->where($qb->expr()->eq('status', $qb->createNamedParameter('issued')))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('instance_id'),
+					$qb->expr()->eq('instance_id', $qb->createNamedParameter('')),
+					$qb->expr()->isNull('generation'),
+				)
+			)
+			->andWhere(
 				$qb->expr()->orX(
 					$qb->expr()->isNull('engine'),
 					$qb->expr()->eq('engine', $qb->createNamedParameter('')),

--- a/lib/Migration/Version17004Date20260421000000.php
+++ b/lib/Migration/Version17004Date20260421000000.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Migration;
+
+use Closure;
+use OCA\Libresign\AppInfo\Application;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version17004Date20260421000000 extends SimpleMigrationStep {
+	public function __construct(
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[\Override]
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('libresign_crl')) {
+			return;
+		}
+
+		$metadata = $this->resolveMetadataDefaults();
+
+		$updatedInstance = $this->backfillInstanceId($metadata['instanceId']);
+		$updatedGeneration = $this->backfillGeneration($metadata['generation']);
+		$updatedEngine = $this->backfillEngine($metadata['engine']);
+
+		if ($updatedInstance > 0 || $updatedGeneration > 0 || $updatedEngine > 0) {
+			$output->warning(sprintf(
+				'Backfilled CRL metadata for legacy rows (instance_id=%d, generation=%d, engine=%d).',
+				$updatedInstance,
+				$updatedGeneration,
+				$updatedEngine,
+			));
+		}
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('libresign_crl')) {
+			return $schema;
+		}
+
+		$metadata = $this->resolveMetadataDefaults();
+		$table = $schema->getTable('libresign_crl');
+
+		if ($table->hasColumn('instance_id')) {
+			$instanceColumn = $table->getColumn('instance_id');
+			$instanceColumn->setNotnull(true);
+			$instanceColumn->setDefault($metadata['instanceId']);
+		}
+
+		if ($table->hasColumn('generation')) {
+			$generationColumn = $table->getColumn('generation');
+			$generationColumn->setNotnull(true);
+			$generationColumn->setDefault($metadata['generation']);
+		}
+
+		if ($table->hasColumn('engine')) {
+			$engineColumn = $table->getColumn('engine');
+			$engineColumn->setNotnull(true);
+			$engineColumn->setDefault($metadata['engine']);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @return array{instanceId: string, generation: int, engine: string}
+	 */
+	private function resolveMetadataDefaults(): array {
+		$engine = $this->appConfig->getValueString(Application::APP_ID, 'certificate_engine', 'openssl');
+		if ($engine === '' || $engine === 'none') {
+			$engine = 'openssl';
+		}
+
+		$instanceId = $this->appConfig->getValueString(Application::APP_ID, 'instance_id', '');
+		$generation = max(1, $this->appConfig->getValueInt(Application::APP_ID, 'ca_generation_counter', 1));
+		$caId = $this->appConfig->getValueString(Application::APP_ID, 'ca_id', '');
+
+		$pattern = '/^libresign-ca-id:(?P<instanceId>[a-z0-9]+)_g:(?P<generation>\d+)_e:(?P<engineType>[oc])$/';
+		if ($caId !== '' && preg_match($pattern, $caId, $matches)) {
+			$instanceId = $matches['instanceId'];
+			$generation = max(1, (int)$matches['generation']);
+			$engine = $matches['engineType'] === 'c' ? 'cfssl' : 'openssl';
+		}
+
+		if ($instanceId === '') {
+			$instanceId = $this->config->getSystemValueString('instanceid', '');
+		}
+
+		if ($instanceId === '') {
+			$instanceId = 'legacy';
+		}
+
+		return [
+			'instanceId' => $instanceId,
+			'generation' => $generation,
+			'engine' => $engine,
+		];
+	}
+
+	private function backfillInstanceId(string $instanceId): int {
+		$qb = $this->connection->getQueryBuilder();
+
+		return $qb->update('libresign_crl')
+			->set('instance_id', $qb->createNamedParameter($instanceId))
+			->where(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('instance_id'),
+					$qb->expr()->eq('instance_id', $qb->createNamedParameter('')),
+				)
+			)
+			->executeStatement();
+	}
+
+	private function backfillGeneration(int $generation): int {
+		$qb = $this->connection->getQueryBuilder();
+
+		return $qb->update('libresign_crl')
+			->set('generation', $qb->createNamedParameter($generation, IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->isNull('generation'))
+			->executeStatement();
+	}
+
+	private function backfillEngine(string $engine): int {
+		$qb = $this->connection->getQueryBuilder();
+
+		return $qb->update('libresign_crl')
+			->set('engine', $qb->createNamedParameter($engine))
+			->where(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('engine'),
+					$qb->expr()->eq('engine', $qb->createNamedParameter('')),
+				)
+			)
+			->executeStatement();
+	}
+}

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -64,7 +64,8 @@ class CrlService {
 
 		try {
 			$certificate = $this->crlMapper->findBySerialNumber($serialNumber);
-			$crlNumber = $this->resolveNextCrlNumber($certificate);
+			['instanceId' => $instanceId, 'generation' => $generation, 'engineType' => $engineType] = $this->getCrlMetadata($certificate);
+			$crlNumber = $this->getNextCrlNumber($instanceId, $generation, $engineType);
 
 			$this->crlMapper->revokeCertificateEntity(
 				$certificate,
@@ -130,8 +131,8 @@ class CrlService {
 		foreach ($certificates as $certificate) {
 			try {
 				$serialNumber = $certificate->getSerialNumber();
-
-				$crlNumber = $this->resolveNextCrlNumber($certificate);
+				['instanceId' => $instanceId, 'generation' => $generation, 'engineType' => $engineType] = $this->getCrlMetadata($certificate);
+				$crlNumber = $this->getNextCrlNumber($instanceId, $generation, $engineType);
 
 				$this->crlMapper->revokeCertificateEntity(
 					$certificate,
@@ -234,22 +235,23 @@ class CrlService {
 		return $result;
 	}
 
-	private function resolveNextCrlNumber(\OCA\Libresign\Db\Crl $certificate): ?int {
+	/**
+	 * @return array{instanceId: string, generation: int, engineType: string}
+	 */
+	private function getCrlMetadata(\OCA\Libresign\Db\Crl $certificate): array {
 		$instanceId = $certificate->getInstanceId();
 		$generation = $certificate->getGeneration();
 		$engineType = $certificate->getEngine();
 
 		if ($instanceId === null || $generation === null || $engineType === '') {
-			$this->logger->warning('Skipping CRL number generation for legacy certificate without CA metadata', [
-				'serial' => $certificate->getSerialNumber(),
-				'instanceId' => $instanceId,
-				'generation' => $generation,
-				'engineType' => $engineType,
-			]);
-			return null;
+			throw new \RuntimeException('Certificate missing CRL metadata: instance_id, generation or engine');
 		}
 
-		return $this->getNextCrlNumber($instanceId, $generation, $engineType);
+		return [
+			'instanceId' => $instanceId,
+			'generation' => $generation,
+			'engineType' => $engineType,
+		];
 	}
 
 	private function getNextCrlNumber(string $instanceId, int $generation, string $engineType): int {

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -64,11 +64,7 @@ class CrlService {
 
 		try {
 			$certificate = $this->crlMapper->findBySerialNumber($serialNumber);
-			$instanceId = $certificate->getInstanceId();
-			$generation = $certificate->getGeneration();
-			$engineType = $certificate->getEngine();
-
-			$crlNumber = $this->getNextCrlNumber($instanceId, $generation, $engineType);
+			$crlNumber = $this->resolveNextCrlNumber($certificate);
 
 			$this->crlMapper->revokeCertificateEntity(
 				$certificate,
@@ -80,7 +76,11 @@ class CrlService {
 			);
 
 			return true;
-		} catch (\Exception) {
+		} catch (\Throwable $exception) {
+			$this->logger->warning('Failed to revoke certificate {serial}', [
+				'serial' => $serialNumber,
+				'error' => $exception->getMessage(),
+			]);
 			return false;
 		}
 	}
@@ -129,12 +129,9 @@ class CrlService {
 
 		foreach ($certificates as $certificate) {
 			try {
-				$instanceId = $certificate->getInstanceId();
-				$generation = $certificate->getGeneration();
-				$engineType = $certificate->getEngine();
 				$serialNumber = $certificate->getSerialNumber();
 
-				$crlNumber = $this->getNextCrlNumber($instanceId, $generation, $engineType);
+				$crlNumber = $this->resolveNextCrlNumber($certificate);
 
 				$this->crlMapper->revokeCertificateEntity(
 					$certificate,
@@ -235,6 +232,24 @@ class CrlService {
 		}
 
 		return $result;
+	}
+
+	private function resolveNextCrlNumber(\OCA\Libresign\Db\Crl $certificate): ?int {
+		$instanceId = $certificate->getInstanceId();
+		$generation = $certificate->getGeneration();
+		$engineType = $certificate->getEngine();
+
+		if ($instanceId === null || $generation === null || $engineType === '') {
+			$this->logger->warning('Skipping CRL number generation for legacy certificate without CA metadata', [
+				'serial' => $certificate->getSerialNumber(),
+				'instanceId' => $instanceId,
+				'generation' => $generation,
+				'engineType' => $engineType,
+			]);
+			return null;
+		}
+
+		return $this->getNextCrlNumber($instanceId, $generation, $engineType);
 	}
 
 	private function getNextCrlNumber(string $instanceId, int $generation, string $engineType): int {

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -312,7 +312,8 @@ class CrlServiceTest extends TestCase {
 			->with(
 				'Failed to revoke certificate {serial}',
 				$this->callback(fn (array $context): bool => $context['serial'] === $serialNumber
-					&& str_contains($context['error'], 'missing CRL metadata'))
+					&& isset($context['error'])
+					&& $context['error'] !== '')
 			);
 
 		$result = $this->service->revokeCertificate($serialNumber);

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -290,6 +290,46 @@ class CrlServiceTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
+	public function testRevokeCertificateWithoutCrlMetadataStillRevokesLegacyCertificate(): void {
+		$serialNumber = '654321';
+		$certificate = new Crl();
+		$certificate->setSerialNumber($serialNumber);
+		$certificate->setEngine('openssl');
+
+		$this->crlMapper->expects($this->once())
+			->method('findBySerialNumber')
+			->with($serialNumber)
+			->willReturn($certificate);
+
+		$this->crlMapper->expects($this->never())
+			->method('getLastCrlNumber');
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				'Skipping CRL number generation for legacy certificate without CA metadata',
+				$this->callback(fn (array $context): bool => $context['serial'] === $serialNumber
+					&& $context['instanceId'] === null
+					&& $context['generation'] === null
+					&& $context['engineType'] === 'openssl')
+			);
+
+		$this->crlMapper->expects($this->once())
+			->method('revokeCertificateEntity')
+			->with(
+				$certificate,
+				CRLReason::UNSPECIFIED,
+				null,
+				null,
+				null,
+				null
+			);
+
+		$result = $this->service->revokeCertificate($serialNumber);
+
+		$this->assertTrue($result);
+	}
+
 	public function testGenerateCrlDerReturnsValidBinaryData(): void {
 		// Create revoked certificates data
 		$revokedCertificates = [

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -290,7 +290,7 @@ class CrlServiceTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testRevokeCertificateWithoutCrlMetadataStillRevokesLegacyCertificate(): void {
+	public function testRevokeCertificateWithoutCrlMetadataFails(): void {
 		$serialNumber = '654321';
 		$certificate = new Crl();
 		$certificate->setSerialNumber($serialNumber);
@@ -304,30 +304,20 @@ class CrlServiceTest extends TestCase {
 		$this->crlMapper->expects($this->never())
 			->method('getLastCrlNumber');
 
+		$this->crlMapper->expects($this->never())
+			->method('revokeCertificateEntity');
+
 		$this->logger->expects($this->once())
 			->method('warning')
 			->with(
-				'Skipping CRL number generation for legacy certificate without CA metadata',
+				'Failed to revoke certificate {serial}',
 				$this->callback(fn (array $context): bool => $context['serial'] === $serialNumber
-					&& $context['instanceId'] === null
-					&& $context['generation'] === null
-					&& $context['engineType'] === 'openssl')
-			);
-
-		$this->crlMapper->expects($this->once())
-			->method('revokeCertificateEntity')
-			->with(
-				$certificate,
-				CRLReason::UNSPECIFIED,
-				null,
-				null,
-				null,
-				null
+					&& str_contains($context['error'], 'missing CRL metadata'))
 			);
 
 		$result = $this->service->revokeCertificate($serialNumber);
 
-		$this->assertTrue($result);
+		$this->assertFalse($result);
 	}
 
 	public function testGenerateCrlDerReturnsValidBinaryData(): void {

--- a/tests/php/Unit/Service/SerialNumberServiceTest.php
+++ b/tests/php/Unit/Service/SerialNumberServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service;
+
+use DateTime;
+use OCA\Libresign\Db\CrlMapper;
+use OCA\Libresign\Service\SerialNumberService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SerialNumberServiceTest extends TestCase {
+	private CrlMapper&MockObject $crlMapper;
+	private SerialNumberService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->crlMapper = $this->createMock(CrlMapper::class);
+		$this->service = new SerialNumberService($this->crlMapper);
+	}
+
+	public function testGenerateUniqueSerialPersistsCrlMetadata(): void {
+		$expiresAt = new DateTime('2030-01-01 00:00:00');
+
+		$this->crlMapper->expects($this->once())
+			->method('createCertificate')
+			->with(
+				$this->isType('string'),
+				'test-owner',
+				'openssl',
+				'inst1234567',
+				4,
+				$this->isInstanceOf(DateTime::class),
+				$expiresAt,
+				null,
+				null,
+				'leaf'
+			);
+
+		$serial = $this->service->generateUniqueSerial(
+			'test-owner',
+			'inst1234567',
+			4,
+			$expiresAt,
+			'openssl',
+		);
+
+		$this->assertNotSame('', $serial);
+		$this->assertSame(1, preg_match('/^[0-9]+$/', $serial));
+	}
+}

--- a/tests/php/Unit/Service/SerialNumberServiceTest.php
+++ b/tests/php/Unit/Service/SerialNumberServiceTest.php
@@ -31,7 +31,7 @@ class SerialNumberServiceTest extends TestCase {
 		$this->crlMapper->expects($this->once())
 			->method('createCertificate')
 			->with(
-				$this->isType('string'),
+				$this->callback(static fn (mixed $value): bool => is_string($value) && $value !== ''),
 				'test-owner',
 				'openssl',
 				'inst1234567',


### PR DESCRIPTION
## Summary
- enforce strict CRL metadata handling in revocation flow: revocation now requires instance_id, generation and engine
- add migration Version17004Date20260421000000 to backfill only problematic legacy rows (status=issued with missing CRL metadata)
- keep migration fail-safe: if metadata source is not deterministic, it skips backfill instead of writing guessed values
- limit migration impact to the problematic subset; no file operations and no delete/drop/truncate behavior
- add regression test for SerialNumberService to guarantee new certificates persist CRL metadata
- make CRL test less brittle by avoiding assertion on internal error text

## Testing
- composer test:unit -- --filter CrlServiceTest
- composer test:unit -- --filter CrlApiControllerTest
- composer test:unit -- --filter SerialNumberServiceTest

Closes #7495