### PR TITLE
fix: return 404 when pdf node is missing

### DIFF
--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -342,7 +342,11 @@ class AccountService {
 
 		$userId = $this->fileMapper->getStorageUserIdByUuid($uuid);
 		$this->folderService->setUserId($userId);
-		return $this->folderService->getFileByNodeId($nodeId);
+		try {
+			return $this->folderService->getFileByNodeId($nodeId);
+		} catch (NotFoundException) {
+			throw new DoesNotExistException('Not found');
+		}
 	}
 
 	public function getFileByNodeId(int $nodeId): File {

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -307,6 +307,46 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertInstanceOf(\OCP\Files\File::class, $actual);
 	}
 
+	public function testGetPdfByUuidThrowsDoesNotExistWhenNodeNotFound(): void {
+		$libresignFile = $this->createMock(\OCA\Libresign\Db\File::class);
+		$libresignFile->method('__call')
+			->willReturnCallback(fn ($method)
+				=> match ($method) {
+					'getSignedNodeId' => null,
+					'getNodeId' => 123,
+					'getStatus' => \OCA\Libresign\Enum\FileStatus::DRAFT->value,
+				}
+			);
+
+		$this->fileMapper
+			->expects($this->once())
+			->method('getByUuid')
+			->with('uuid')
+			->willReturn($libresignFile);
+
+		$this->fileMapper
+			->expects($this->once())
+			->method('getStorageUserIdByUuid')
+			->with('uuid')
+			->willReturn('guest-user');
+
+		$this->folderService
+			->expects($this->once())
+			->method('setUserId')
+			->with('guest-user');
+
+		$this->folderService
+			->expects($this->once())
+			->method('getFileByNodeId')
+			->with(123)
+			->willThrowException(new NotFoundException('Invalid node'));
+
+		$this->expectException(DoesNotExistException::class);
+		$this->expectExceptionMessage('Not found');
+
+		$this->getService()->getPdfByUuid('uuid');
+	}
+
 	public function testCanRequestSignWithUnexistentUser():void {
 		$actual = $this->getService()->canRequestSign();
 		$this->assertFalse($actual);


### PR DESCRIPTION
## Summary
- fix issue #7494 where external signer identity/PDF validation could crash with `OCP\\Files\\NotFoundException: Invalid node`


Fixes #7494