### PR TITLE
fix: allow signer thumbnail access and prefer file_id preview URLs

### DIFF
--- a/.github/workflows/behat-mariadb.yml
+++ b/.github/workflows/behat-mariadb.yml
@@ -108,7 +108,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql, imagick
           coverage: none
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/behat-mysql.yml
+++ b/.github/workflows/behat-mysql.yml
@@ -112,7 +112,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, imagick
           coverage: none
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/behat-pgsql.yml
+++ b/.github/workflows/behat-pgsql.yml
@@ -111,7 +111,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql, imagick
           coverage: none
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -102,7 +102,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, imagick
           coverage: none
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql, imagick
           coverage: xdebug
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql, imagick
           coverage: xdebug
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql, imagick
           coverage: xdebug
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, imagick
           coverage: xdebug
           ini-file: development
           # Temporary workaround for missing pcntl_* in PHP 8.3

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -18,6 +18,7 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\JSActions;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\PrivateValidation;
+use OCA\Libresign\Middleware\Attribute\RequireFileAccess;
 use OCA\Libresign\Middleware\Attribute\RequireManager;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\File\FileListService;
@@ -353,6 +354,7 @@ class FileController extends AEnvironmentAwareController {
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
+	#[RequireFileAccess('nodeId')]
 	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/file/thumbnail/{nodeId}', requirements: ['apiVersion' => '(v1)'])]
 	public function getThumbnail(
 		int $nodeId = -1,
@@ -369,9 +371,6 @@ class FileController extends AEnvironmentAwareController {
 
 		try {
 			$libreSignFile = $this->fileMapper->getByNodeId($nodeId);
-			if ($libreSignFile->getUserId() !== $this->userSession->getUser()->getUID()) {
-				return new DataResponse([], Http::STATUS_FORBIDDEN);
-			}
 
 			if ($libreSignFile->getNodeType() === 'envelope') {
 				if ($mimeFallback) {
@@ -411,6 +410,7 @@ class FileController extends AEnvironmentAwareController {
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
+	#[RequireFileAccess('fileId')]
 	#[ApiRoute(verb: 'GET', url: '/api/{apiVersion}/file/thumbnail/file_id/{fileId}', requirements: ['apiVersion' => '(v1)'])]
 	public function getThumbnailByFileId(
 		int $fileId = -1,
@@ -427,9 +427,6 @@ class FileController extends AEnvironmentAwareController {
 
 		try {
 			$libreSignFile = $this->fileMapper->getById($fileId);
-			if ($libreSignFile->getUserId() !== $this->userSession->getUser()->getUID()) {
-				return new DataResponse([], Http::STATUS_FORBIDDEN);
-			}
 
 			if ($libreSignFile->getNodeType() === 'envelope') {
 				if ($mimeFallback) {

--- a/lib/Middleware/Attribute/RequireFileAccess.php
+++ b/lib/Middleware/Attribute/RequireFileAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Middleware\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RequireFileAccess {
+	public function __construct(
+		private string $identifier = 'fileId',
+	) {
+	}
+
+	public function getIdentifier(): string {
+		return $this->identifier;
+	}
+}

--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -22,11 +22,13 @@ use OCA\Libresign\Helper\JSActions;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\CanSignRequestUuid;
 use OCA\Libresign\Middleware\Attribute\PrivateValidation;
+use OCA\Libresign\Middleware\Attribute\RequireFileAccess;
 use OCA\Libresign\Middleware\Attribute\RequireManager;
 use OCA\Libresign\Middleware\Attribute\RequireSetupOk;
 use OCA\Libresign\Middleware\Attribute\RequireSigner;
 use OCA\Libresign\Middleware\Attribute\RequireSignerUuid;
 use OCA\Libresign\Middleware\Attribute\RequireSignRequestUuid;
+use OCA\Libresign\Service\FileAccessService;
 use OCA\Libresign\Service\SignFileService;
 use OCA\Libresign\Service\UuidResolverService;
 use OCP\AppFramework\Controller;
@@ -58,6 +60,7 @@ class InjectionMiddleware extends Middleware {
 		private CertificateEngineFactory $certificateEngineFactory,
 		private FileMapper $fileMapper,
 		private IInitialState $initialState,
+		private FileAccessService $fileAccessService,
 		private SignFileService $signFileService,
 		private UuidResolverService $uuidResolverService,
 		private IL10N $l10n,
@@ -92,6 +95,9 @@ class InjectionMiddleware extends Middleware {
 		}
 		if (!empty($reflectionMethod->getAttributes(RequireSignerUuid::class))) {
 			$this->requireSignerUuid();
+		}
+		if (!empty($reflectionMethod->getAttributes(RequireFileAccess::class))) {
+			$this->requireFileAccess($reflectionMethod);
 		}
 
 		$this->requireSetupOk($reflectionMethod);
@@ -230,6 +236,26 @@ class InjectionMiddleware extends Middleware {
 		} catch (LibresignException $e) {
 			throw new LibresignException($e->getMessage());
 		}
+	}
+
+	private function requireFileAccess(\ReflectionMethod $reflectionMethod): void {
+		$attributes = $reflectionMethod->getAttributes(RequireFileAccess::class);
+		$attribute = current($attributes);
+		/** @var RequireFileAccess $requirement */
+		$requirement = $attribute->newInstance();
+
+		$identifier = $requirement->getIdentifier();
+		$hasAccess = match ($identifier) {
+			'nodeId' => $this->fileAccessService->userCanAccessFileByNodeId((int)$this->request->getParam('nodeId', -1)),
+			'fileId' => $this->fileAccessService->userCanAccessFileById((int)$this->request->getParam('fileId', -1)),
+			default => throw new \InvalidArgumentException('Unsupported file access identifier: ' . $identifier),
+		};
+
+		if ($hasAccess) {
+			return;
+		}
+
+		throw new LibresignException(json_encode([]), Http::STATUS_FORBIDDEN);
 	}
 
 	private function redirectSignedToValidationIfNeeded(RequireSignRequestUuid $requirement): void {

--- a/lib/Search/FileSearchProvider.php
+++ b/lib/Search/FileSearchProvider.php
@@ -92,11 +92,12 @@ class FileSearchProvider implements IProvider {
 				$icon = $this->mimeTypeDetector->mimeTypeIcon($node->getMimetype());
 
 				$thumbnailUrl = $this->urlGenerator->linkToRouteAbsolute(
-					'core.Preview.getPreviewByFileId',
+					'ocs.libresign.File.getThumbnailByFileId',
 					[
+						'apiVersion' => 'v1',
 						'x' => 32,
 						'y' => 32,
-						'fileId' => $node->getId()
+						'fileId' => $file->getId()
 					]
 				);
 

--- a/lib/Service/FileAccessService.php
+++ b/lib/Service/FileAccessService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Service;
+
+use OCA\Libresign\Db\File as FileEntity;
+use OCA\Libresign\Db\FileMapper;
+use OCP\IUser;
+use OCP\IUserSession;
+
+class FileAccessService {
+	public function __construct(
+		private FileMapper $fileMapper,
+		private SignFileService $signFileService,
+		private IUserSession $userSession,
+	) {
+	}
+
+	public function userCanAccessFileById(int $fileId, ?IUser $user = null): bool {
+		$user = $this->resolveUser($user);
+		if (!$user) {
+			return false;
+		}
+
+		return $this->userCanAccessFile($this->fileMapper->getById($fileId), $user);
+	}
+
+	public function userCanAccessFileByNodeId(int $nodeId, ?IUser $user = null): bool {
+		$user = $this->resolveUser($user);
+		if (!$user) {
+			return false;
+		}
+
+		return $this->userCanAccessFile($this->fileMapper->getByNodeId($nodeId), $user);
+	}
+
+	private function resolveUser(?IUser $user): ?IUser {
+		return $user ?? $this->userSession->getUser();
+	}
+
+	private function userCanAccessFile(FileEntity $file, IUser $user): bool {
+		if ($file->getUserId() === $user->getUID()) {
+			return true;
+		}
+
+		return $this->userCanSignFile($file, $user);
+	}
+
+	private function userCanSignFile(FileEntity $file, IUser $user): bool {
+		try {
+			$this->signFileService->getSignRequestToSign($file, null, $user);
+			return true;
+		} catch (\Exception) {
+			return false;
+		}
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -45,5 +45,6 @@
     </issueHandlers>
     <stubs>
         <file name="tests/stubs/oc_hooks_emitter.php" />
+        <file name="tests/stubs/psr_http_client.php" />
     </stubs>
 </psalm>

--- a/src/components/File/File.vue
+++ b/src/components/File/File.vue
@@ -61,13 +61,13 @@ const previewUrl = computed(() => {
 	}
 
 	let filePreviewUrl = ''
-	if (currentFile.value.nodeId) {
-		filePreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
-			nodeId: currentFile.value.nodeId,
-		})
-	} else if (currentFile.value.id) {
+	if (currentFile.value.id) {
 		filePreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/file_id/{fileId}', {
 			fileId: currentFile.value.id,
+		})
+	} else if (currentFile.value.nodeId) {
+		filePreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
+			nodeId: currentFile.value.nodeId,
 		})
 	} else {
 		filePreviewUrl = window.location.origin + generateUrl('/core/preview?fileId={fileid}', {

--- a/src/components/RightSidebar/EnvelopeFilesList.vue
+++ b/src/components/RightSidebar/EnvelopeFilesList.vue
@@ -412,11 +412,17 @@ function validateMaxFileUploads(filesCount: number) {
 	return true
 }
 
-function getPreviewUrl(file: Partial<EnvelopeFile> & { nodeId?: number }) {
-	if (!file.nodeId) return null
-	const url = new URL(generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
-		nodeId: file.nodeId,
-	}))
+function getPreviewUrl(file: Partial<EnvelopeFile> & { id?: number; nodeId?: number }) {
+	if (!file.id && !file.nodeId) return null
+
+	const previewUrl = file.id
+		? generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/file_id/{fileId}', {
+			fileId: file.id,
+		})
+		: generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
+			nodeId: file.nodeId,
+		})
+	const url = new URL(previewUrl)
 	url.searchParams.set('x', '32')
 	url.searchParams.set('y', '32')
 	url.searchParams.set('mimeFallback', 'true')

--- a/src/tests/components/File/File.spec.ts
+++ b/src/tests/components/File/File.spec.ts
@@ -9,7 +9,7 @@ import { mount } from '@vue/test-utils'
 import File from '../../../components/File/File.vue'
 
 type FileEntry = {
-	id: number
+	id?: number
 	nodeId?: number
 	name: string
 	status: number
@@ -83,23 +83,23 @@ describe('File.vue', () => {
 		sidebarStoreMock.activeRequestSignatureTab.mockReset()
 	})
 
-	it('renders the selected file preview using the node id thumbnail endpoint', () => {
+	it('renders the selected file preview using the file id thumbnail endpoint', () => {
 		const wrapper = createWrapper()
 
 		const image = wrapper.find('img')
 
 		expect(image.exists()).toBe(true)
 		expect(wrapper.find('h1').text()).toBe('contract.pdf')
-		expect(image.attributes('src')).toContain('/apps/libresign/api/v1/file/thumbnail/99')
+		expect(image.attributes('src')).toContain('/apps/libresign/api/v1/file/thumbnail/file_id/13')
 		expect(image.attributes('src')).toContain('x=128')
 		expect(image.attributes('src')).toContain('y=128')
 		expect(image.attributes('src')).toContain('mimeFallback=true')
 		expect(image.attributes('src')).toContain('a=0')
 	})
 
-	it('falls back to the file id thumbnail endpoint when node id is absent', () => {
+	it('falls back to the node id thumbnail endpoint when the file id is absent', () => {
 		filesStoreMock.files[7] = {
-			id: 13,
+			nodeId: 99,
 			name: 'fallback.pdf',
 			status: 1,
 			statusText: 'Pending',
@@ -107,7 +107,7 @@ describe('File.vue', () => {
 
 		const wrapper = createWrapper()
 
-		expect(wrapper.find('img').attributes('src')).toContain('/apps/libresign/api/v1/file/thumbnail/file_id/13')
+		expect(wrapper.find('img').attributes('src')).toContain('/apps/libresign/api/v1/file/thumbnail/99')
 	})
 
 	it('selects the file and opens the request signature sidebar on click', async () => {

--- a/src/tests/components/RightSidebar/EnvelopeFilesList.spec.ts
+++ b/src/tests/components/RightSidebar/EnvelopeFilesList.spec.ts
@@ -26,7 +26,7 @@ vi.mock('@nextcloud/l10n', () => globalThis.mockNextcloudL10n())
 
 vi.mock('@nextcloud/capabilities')
 vi.mock('@nextcloud/router', () => ({
-	generateOcsUrl: vi.fn((url) => `https://example.com${url}`),
+	generateOcsUrl: vi.fn((url, params) => `https://example.com${url.replace('{fileId}', String(params?.fileId ?? '')).replace('{nodeId}', String(params?.nodeId ?? ''))}`),
 	generateUrl: vi.fn((url, params) => url.replace('{uuid}', params.uuid).replace('{nodeId}', params.nodeId)),
 }))
 vi.mock('../../../utils/viewer.js', () => ({
@@ -364,16 +364,24 @@ describe('EnvelopeFilesList', () => {
 	})
 
 	describe('RULE: getPreviewUrl constructs thumbnail URL with parameters', () => {
-		it('builds URL with nodeId and parameters', () => {
+		it('prefers file id URLs and appends preview parameters', () => {
 			wrapper = createWrapper()
 
-			const url = wrapper.vm.getPreviewUrl({ nodeId: 123 })
+			const url = wrapper.vm.getPreviewUrl({ id: 123, nodeId: 456 })
 
-			expect(url).toContain('nodeId')
+			expect(url).toContain('/apps/libresign/api/v1/file/thumbnail/file_id/123')
 			expect(url).toContain('x=32')
 			expect(url).toContain('y=32')
 			expect(url).toContain('mimeFallback=true')
 			expect(url).toContain('a=1')
+		})
+
+		it('falls back to node id URLs when file id is absent', () => {
+			wrapper = createWrapper()
+
+			const url = wrapper.vm.getPreviewUrl({ nodeId: 123 })
+
+			expect(url).toContain('/apps/libresign/api/v1/file/thumbnail/123')
 		})
 
 		it('returns null when no nodeId', () => {

--- a/src/tests/views/FilesList/FileEntryPreview.spec.ts
+++ b/src/tests/views/FilesList/FileEntryPreview.spec.ts
@@ -56,14 +56,21 @@ describe('FileEntryPreview.vue', () => {
 		expect(wrapper.vm.isEnvelope).toBe(true)
 	})
 
-	it('builds a thumbnail URL from the node id with list-size previews', () => {
+	it('prefers the file id thumbnail URL with list-size previews', () => {
+		const wrapper = createWrapper({ id: 7, nodeId: 42 })
+		const url = wrapper.vm.previewUrl as URL
+
+		expect(url.toString()).toContain('/apps/libresign/api/v1/file/thumbnail/file_id/7')
+		expect(url.searchParams.get('x')).toBe('32')
+		expect(url.searchParams.get('y')).toBe('32')
+		expect(url.searchParams.get('a')).toBe('1')
+	})
+
+	it('falls back to the node id thumbnail URL when the file id is absent', () => {
 		const wrapper = createWrapper({ nodeId: 42 })
 		const url = wrapper.vm.previewUrl as URL
 
 		expect(url.toString()).toContain('/apps/libresign/api/v1/file/thumbnail/42')
-		expect(url.searchParams.get('x')).toBe('32')
-		expect(url.searchParams.get('y')).toBe('32')
-		expect(url.searchParams.get('a')).toBe('1')
 	})
 
 	it('uses grid preview sizes when the user config enables grid mode', () => {

--- a/src/views/FilesList/FileEntry/FileEntryPreview.vue
+++ b/src/views/FilesList/FileEntry/FileEntryPreview.vue
@@ -65,13 +65,13 @@ const previewUrl = computed(() => {
 	}
 
 	let nextPreviewUrl = ''
-	if (props.source?.nodeId) {
-		nextPreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
-			nodeId: props.source.nodeId,
-		})
-	} else if (props.source?.id) {
+	if (props.source?.id) {
 		nextPreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/file_id/{fileId}', {
 			fileId: props.source.id,
+		})
+	} else if (props.source?.nodeId) {
+		nextPreviewUrl = generateOcsUrl('/apps/libresign/api/v1/file/thumbnail/{nodeId}', {
+			nodeId: props.source.nodeId,
 		})
 	} else {
 		nextPreviewUrl = window.location.origin + generateUrl('/core/preview?fileId={fileid}', {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -39,6 +39,23 @@ class FeatureContext extends NextcloudApiContext implements OpenedEmailStorageAw
 		$this->openedEmailStorage = $storage;
 	}
 
+	#[Given('the response should have one of these status codes :statusCodes')]
+	public function theResponseShouldHaveOneOfTheseStatusCodes(string $statusCodes): void {
+		$allowedStatusCodes = array_map(
+			'intval',
+			array_filter(
+				array_map('trim', explode(',', $statusCodes)),
+				fn (string $value): bool => $value !== ''
+			)
+		);
+		Assert::assertNotEmpty($allowedStatusCodes, 'Expected at least one allowed status code.');
+		Assert::assertContains(
+			$this->response->getStatusCode(),
+			$allowedStatusCodes,
+			'Unexpected response status code.'
+		);
+	}
+
 	protected function beforeRequest(string $fullUrl, array $options): array {
 		[$fullUrl, $options] = parent::beforeRequest($fullUrl, $options);
 		$options = $this->parseFormParams($options);
@@ -185,6 +202,14 @@ class FeatureContext extends NextcloudApiContext implements OpenedEmailStorageAw
 			</d:propfind>
 			XML;
 		$this->davRequest($user, 'PROPFIND', $path, $body, ['Depth' => '0']);
+	}
+
+	#[Given('user :user sends WebDAV :method to :path')]
+	public function userSendsWebDavRequest(string $user, string $method, string $path): void {
+		$this->setCurrentUser($user);
+		$normalizedMethod = strtoupper(trim($method));
+		Assert::assertContains($normalizedMethod, ['DELETE', 'PUT', 'PROPFIND', 'GET', 'HEAD', 'MOVE', 'COPY', 'MKCOL'], 'Unsupported WebDAV method');
+		$this->davRequest($user, $normalizedMethod, $path);
 	}
 
 	#[Given('the WebDAV response should contain property :property with value :value')]

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -39,23 +39,6 @@ class FeatureContext extends NextcloudApiContext implements OpenedEmailStorageAw
 		$this->openedEmailStorage = $storage;
 	}
 
-	#[Given('the response should have one of these status codes :statusCodes')]
-	public function theResponseShouldHaveOneOfTheseStatusCodes(string $statusCodes): void {
-		$allowedStatusCodes = array_map(
-			'intval',
-			array_filter(
-				array_map('trim', explode(',', $statusCodes)),
-				fn (string $value): bool => $value !== ''
-			)
-		);
-		Assert::assertNotEmpty($allowedStatusCodes, 'Expected at least one allowed status code.');
-		Assert::assertContains(
-			$this->response->getStatusCode(),
-			$allowedStatusCodes,
-			'Unexpected response status code.'
-		);
-	}
-
 	protected function beforeRequest(string $fullUrl, array $options): array {
 		[$fullUrl, $options] = parent::beforeRequest($fullUrl, $options);
 		$options = $this->parseFormParams($options);

--- a/tests/integration/features/file/thumbnail.feature
+++ b/tests/integration/features/file/thumbnail.feature
@@ -12,6 +12,12 @@ Feature: file-thumbnail
     And the response should have a status code 200
     And sending "get" to ocs "/apps/libresign/api/v1/file/list?details=1"
     And fetch field "(FILE_ID)ocs.data.data.0.id" from previous JSON response
+    And as user "admin"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>"
+    Then the response should have a status code 200
+    And as user "signer1"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>"
+    Then the response should have a status code 200
     # x=0 triggers a deterministic 400 in controller for authorized users,
     # while unauthorized users are blocked earlier by middleware with 403.
     And as user "admin"

--- a/tests/integration/features/file/thumbnail.feature
+++ b/tests/integration/features/file/thumbnail.feature
@@ -1,5 +1,5 @@
 Feature: file-thumbnail
-  Scenario: Thumbnail endpoint access by file_id should enforce signer authorization
+  Scenario Outline: Thumbnail endpoint access by file_id should enforce signer authorization
     Given as user "admin"
     And user "signer1" exists
     And user "nonsigner" exists
@@ -12,12 +12,14 @@ Feature: file-thumbnail
     And the response should have a status code 200
     And sending "get" to ocs "/apps/libresign/api/v1/file/list?details=1"
     And fetch field "(FILE_ID)ocs.data.data.0.id" from previous JSON response
-    And as user "admin"
-    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
-    Then the response should have one of these status codes "200,303"
-    And as user "signer1"
-    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
-    Then the response should have one of these status codes "200,303"
-    And as user "nonsigner"
-    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
-    Then the response should have a status code 403
+    And as user "<user>"
+    # x=0 triggers a deterministic 400 in controller for authorized users,
+    # while unauthorized users are blocked earlier by middleware with 403.
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?x=0"
+    Then the response should have a status code <statusCode>
+
+    Examples:
+      | user      | statusCode |
+      | admin     | 400        |
+      | signer1   | 400        |
+      | nonsigner | 403        |

--- a/tests/integration/features/file/thumbnail.feature
+++ b/tests/integration/features/file/thumbnail.feature
@@ -12,12 +12,9 @@ Feature: file-thumbnail
     And the response should have a status code 200
     And sending "get" to ocs "/apps/libresign/api/v1/file/list?details=1"
     And fetch field "(FILE_ID)ocs.data.data.0.id" from previous JSON response
-    And as user "admin"
+    And as user "nonsigner"
     When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>"
-    Then the response should have a status code 200
-    And as user "signer1"
-    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>"
-    Then the response should have a status code 200
+    Then the response should have a status code 403
     # x=0 triggers a deterministic 400 in controller for authorized users,
     # while unauthorized users are blocked earlier by middleware with 403.
     And as user "admin"

--- a/tests/integration/features/file/thumbnail.feature
+++ b/tests/integration/features/file/thumbnail.feature
@@ -1,5 +1,5 @@
 Feature: file-thumbnail
-  Scenario Outline: Thumbnail endpoint access by file_id should enforce signer authorization
+  Scenario: Thumbnail endpoint access by file_id should enforce signer authorization
     Given as user "admin"
     And user "signer1" exists
     And user "nonsigner" exists
@@ -12,14 +12,14 @@ Feature: file-thumbnail
     And the response should have a status code 200
     And sending "get" to ocs "/apps/libresign/api/v1/file/list?details=1"
     And fetch field "(FILE_ID)ocs.data.data.0.id" from previous JSON response
-    And as user "<user>"
     # x=0 triggers a deterministic 400 in controller for authorized users,
     # while unauthorized users are blocked earlier by middleware with 403.
+    And as user "admin"
     When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?x=0"
-    Then the response should have a status code <statusCode>
-
-    Examples:
-      | user      | statusCode |
-      | admin     | 400        |
-      | signer1   | 400        |
-      | nonsigner | 403        |
+    Then the response should have a status code 400
+    And as user "signer1"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?x=0"
+    Then the response should have a status code 400
+    And as user "nonsigner"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?x=0"
+    Then the response should have a status code 403

--- a/tests/integration/features/file/thumbnail.feature
+++ b/tests/integration/features/file/thumbnail.feature
@@ -1,0 +1,23 @@
+Feature: file-thumbnail
+  Scenario: Thumbnail endpoint access by file_id should enforce signer authorization
+    Given as user "admin"
+    And user "signer1" exists
+    And user "nonsigner" exists
+    And sending "post" to ocs "/apps/provisioning_api/api/v1/config/apps/libresign/identify_methods"
+      | value | (string)[{"name":"account","enabled":true,"mandatory":true}] |
+    And sending "post" to ocs "/apps/libresign/api/v1/request-signature"
+      | file | {"url":"<BASE_URL>/apps/libresign/develop/pdf"} |
+      | signers | [{"identifyMethods":[{"method":"account","value":"signer1"}]}] |
+      | name | document |
+    And the response should have a status code 200
+    And sending "get" to ocs "/apps/libresign/api/v1/file/list?details=1"
+    And fetch field "(FILE_ID)ocs.data.data.0.id" from previous JSON response
+    And as user "admin"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
+    Then the response should have one of these status codes "200,303"
+    And as user "signer1"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
+    Then the response should have one of these status codes "200,303"
+    And as user "nonsigner"
+    When sending "get" to ocs "/apps/libresign/api/v1/file/thumbnail/file_id/<FILE_ID>?mimeFallback=1"
+    Then the response should have a status code 403

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Api\Controller;
 
 use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Db\File as FileEntity;
+use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Tests\Api\ApiTestCase;
 
 /**
@@ -16,6 +18,17 @@ use OCA\Libresign\Tests\Api\ApiTestCase;
  * @group DB
  */
 final class FileControllerTest extends ApiTestCase {
+	private function getDocumentFileFromResult(FileEntity $file): FileEntity {
+		if ($file->getNodeType() !== 'envelope') {
+			return $file;
+		}
+
+		$children = \OCP\Server::get(FileMapper::class)->getChildrenFiles($file->getId());
+		$this->assertNotEmpty($children, 'Expected envelope to have at least one child file.');
+
+		return $children[0];
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 */
@@ -180,6 +193,7 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
@@ -216,6 +230,7 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
@@ -252,6 +267,7 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Api\Controller;
 
 use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Db\File as FileEntity;
+use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Tests\Api\ApiTestCase;
 
 /**
@@ -16,6 +18,17 @@ use OCA\Libresign\Tests\Api\ApiTestCase;
  * @group DB
  */
 final class FileControllerTest extends ApiTestCase {
+	private function getDocumentFileFromResult(FileEntity $file): FileEntity {
+		if ($file->getNodeType() !== 'envelope') {
+			return $file;
+		}
+
+		$children = \OCP\Server::get(FileMapper::class)->getChildrenFiles($file->getId());
+		$this->assertNotEmpty($children, 'Expected envelope to have at least one child file.');
+
+		return $children[0];
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 */
@@ -180,13 +193,14 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('owner:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?x=0')
-			->assertResponseCode(400);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
+			->assertResponseCode(200);
 
 		$this->assertRequest();
 	}
@@ -216,13 +230,14 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?x=0')
-			->assertResponseCode(400);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
+			->assertResponseCode(200);
 
 		$this->assertRequest();
 	}
@@ -252,13 +267,14 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
+		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId() . '?x=0')
-			->assertResponseCode(400);
+			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId())
+			->assertResponseCode(200);
 
 		$this->assertRequest();
 	}

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Api\Controller;
 
 use OCA\Libresign\AppInfo\Application;
-use OCA\Libresign\Db\File as FileEntity;
-use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Tests\Api\ApiTestCase;
 
 /**
@@ -18,17 +16,6 @@ use OCA\Libresign\Tests\Api\ApiTestCase;
  * @group DB
  */
 final class FileControllerTest extends ApiTestCase {
-	private function getDocumentFileFromResult(FileEntity $file): FileEntity {
-		if ($file->getNodeType() !== 'envelope') {
-			return $file;
-		}
-
-		$children = \OCP\Server::get(FileMapper::class)->getChildrenFiles($file->getId());
-		$this->assertNotEmpty($children, 'Expected envelope to have at least one child file.');
-
-		return $children[0];
-	}
-
 	/**
 	 * @runInSeparateProcess
 	 */
@@ -183,7 +170,7 @@ final class FileControllerTest extends ApiTestCase {
 
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test',
+			'name' => 'test.pdf',
 			'signers' => [[
 				'identifyMethods' => [[
 					'method' => 'account',
@@ -193,14 +180,13 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
-		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('owner:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?x=0')
+			->assertResponseCode(400);
 
 		$this->assertRequest();
 	}
@@ -220,7 +206,7 @@ final class FileControllerTest extends ApiTestCase {
 
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test',
+			'name' => 'test.pdf',
 			'signers' => [[
 				'identifyMethods' => [[
 					'method' => 'account',
@@ -230,14 +216,13 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
-		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?x=0')
+			->assertResponseCode(400);
 
 		$this->assertRequest();
 	}
@@ -257,7 +242,7 @@ final class FileControllerTest extends ApiTestCase {
 
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test',
+			'name' => 'test.pdf',
 			'signers' => [[
 				'identifyMethods' => [[
 					'method' => 'account',
@@ -267,14 +252,13 @@ final class FileControllerTest extends ApiTestCase {
 			]],
 			'userManager' => $owner,
 		]);
-		$file = $this->getDocumentFileFromResult($file);
 
 		$this->request
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId() . '?x=0')
+			->assertResponseCode(400);
 
 		$this->assertRequest();
 	}
@@ -290,7 +274,7 @@ final class FileControllerTest extends ApiTestCase {
 
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test',
+			'name' => 'test.pdf',
 			'signers' => [[
 				'identifyMethods' => [[
 					'method' => 'account',
@@ -322,7 +306,7 @@ final class FileControllerTest extends ApiTestCase {
 
 		$file = $this->requestSignFile([
 			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test',
+			'name' => 'test.pdf',
 			'signers' => [[
 				'identifyMethods' => [[
 					'method' => 'account',

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -159,4 +159,171 @@ final class FileControllerTest extends ApiTestCase {
 
 		$this->assertRequest();
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetThumbnailByOwner(): void {
+		$owner = $this->createAccount('owner', 'password');
+		$this->createAccount('signer', 'password');
+		$this->getMockAppConfig();
+
+		$file = $this->requestSignFile([
+			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
+			'name' => 'test',
+			'signers' => [[
+				'identifyMethods' => [[
+					'method' => 'account',
+					'mandatory' => 0,
+					'value' => 'signer',
+				]],
+			]],
+			'userManager' => $owner,
+		]);
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode('owner:password'),
+			])
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
+			->assertResponseCode(200);
+
+		$this->assertRequest();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetThumbnailBySigner(): void {
+		$owner = $this->createAccount('owner', 'password');
+		$signer = $this->createAccount('signer', 'password');
+		$signer->setEMailAddress('signer@test.coop');
+
+		$this->getMockAppConfig()->setValueArray(Application::APP_ID, 'identify_methods', [[
+			'name' => 'account',
+			'enabled' => 1,
+		]]);
+
+		$file = $this->requestSignFile([
+			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
+			'name' => 'test',
+			'signers' => [[
+				'identifyMethods' => [[
+					'method' => 'account',
+					'mandatory' => 0,
+					'value' => 'signer',
+				]],
+			]],
+			'userManager' => $owner,
+		]);
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode('signer:password'),
+			])
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
+			->assertResponseCode(200);
+
+		$this->assertRequest();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetThumbnailByNodeIdForSigner(): void {
+		$owner = $this->createAccount('owner', 'password');
+		$signer = $this->createAccount('signer', 'password');
+		$signer->setEMailAddress('signer@test.coop');
+
+		$this->getMockAppConfig()->setValueArray(Application::APP_ID, 'identify_methods', [[
+			'name' => 'account',
+			'enabled' => 1,
+		]]);
+
+		$file = $this->requestSignFile([
+			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
+			'name' => 'test',
+			'signers' => [[
+				'identifyMethods' => [[
+					'method' => 'account',
+					'mandatory' => 0,
+					'value' => 'signer',
+				]],
+			]],
+			'userManager' => $owner,
+		]);
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode('signer:password'),
+			])
+			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId())
+			->assertResponseCode(200);
+
+		$this->assertRequest();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetThumbnailByNonSigner(): void {
+		$owner = $this->createAccount('owner', 'password');
+		$this->createAccount('signer', 'password');
+		$this->createAccount('nonsigner', 'password');
+		$this->getMockAppConfig();
+
+		$file = $this->requestSignFile([
+			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
+			'name' => 'test',
+			'signers' => [[
+				'identifyMethods' => [[
+					'method' => 'account',
+					'mandatory' => 0,
+					'value' => 'signer',
+				]],
+			]],
+			'userManager' => $owner,
+		]);
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode('nonsigner:password'),
+			])
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
+			->assertResponseCode(403);
+
+		$this->assertRequest();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testGetThumbnailByNodeIdForNonSigner(): void {
+		$owner = $this->createAccount('owner', 'password');
+		$this->createAccount('signer', 'password');
+		$this->createAccount('nonsigner', 'password');
+		$this->getMockAppConfig();
+
+		$file = $this->requestSignFile([
+			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
+			'name' => 'test',
+			'signers' => [[
+				'identifyMethods' => [[
+					'method' => 'account',
+					'mandatory' => 0,
+					'value' => 'signer',
+				]],
+			]],
+			'userManager' => $owner,
+		]);
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode('nonsigner:password'),
+			])
+			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId())
+			->assertResponseCode(403);
+
+		$this->assertRequest();
+	}
 }

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Api\Controller;
 
+use ByJG\ApiTools\Exception\StatusCodeNotMatchedException;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Db\File as FileEntity;
 use OCA\Libresign\Db\FileMapper;
@@ -27,6 +28,33 @@ final class FileControllerTest extends ApiTestCase {
 		$this->assertNotEmpty($children, 'Expected envelope to have at least one child file.');
 
 		return $children[0];
+	}
+
+	private function assertAuthorizedThumbnailRequest(string $username, string $path): void {
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode($username . ':password'),
+			])
+			->withPath($path)
+			->assertResponseCode(200);
+
+		try {
+			$this->assertRequest();
+			return;
+		} catch (StatusCodeNotMatchedException $exception) {
+			if (!str_contains($exception->getMessage(), 'Expected 200, got 303')) {
+				throw $exception;
+			}
+		}
+
+		$this->request
+			->withRequestHeader([
+				'Authorization' => 'Basic ' . base64_encode($username . ':password'),
+			])
+			->withPath($path)
+			->assertResponseCode(303);
+
+		$this->assertRequest();
 	}
 
 	/**
@@ -194,15 +222,7 @@ final class FileControllerTest extends ApiTestCase {
 			'userManager' => $owner,
 		]);
 		$file = $this->getDocumentFileFromResult($file);
-
-		$this->request
-			->withRequestHeader([
-				'Authorization' => 'Basic ' . base64_encode('owner:password'),
-			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1')
-			->assertResponseCode(303);
-
-		$this->assertRequest();
+		$this->assertAuthorizedThumbnailRequest('owner', '/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1');
 	}
 
 	/**
@@ -231,15 +251,7 @@ final class FileControllerTest extends ApiTestCase {
 			'userManager' => $owner,
 		]);
 		$file = $this->getDocumentFileFromResult($file);
-
-		$this->request
-			->withRequestHeader([
-				'Authorization' => 'Basic ' . base64_encode('signer:password'),
-			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1')
-			->assertResponseCode(303);
-
-		$this->assertRequest();
+		$this->assertAuthorizedThumbnailRequest('signer', '/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1');
 	}
 
 	/**
@@ -268,15 +280,7 @@ final class FileControllerTest extends ApiTestCase {
 			'userManager' => $owner,
 		]);
 		$file = $this->getDocumentFileFromResult($file);
-
-		$this->request
-			->withRequestHeader([
-				'Authorization' => 'Basic ' . base64_encode('signer:password'),
-			])
-			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId() . '?mimeFallback=1')
-			->assertResponseCode(303);
-
-		$this->assertRequest();
+		$this->assertAuthorizedThumbnailRequest('signer', '/api/v1/file/thumbnail/' . $file->getNodeId() . '?mimeFallback=1');
 	}
 
 	/**

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -8,10 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Api\Controller;
 
-use ByJG\ApiTools\Exception\StatusCodeNotMatchedException;
 use OCA\Libresign\AppInfo\Application;
-use OCA\Libresign\Db\File as FileEntity;
-use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Tests\Api\ApiTestCase;
 
 /**
@@ -19,43 +16,6 @@ use OCA\Libresign\Tests\Api\ApiTestCase;
  * @group DB
  */
 final class FileControllerTest extends ApiTestCase {
-	private function getDocumentFileFromResult(FileEntity $file): FileEntity {
-		if ($file->getNodeType() !== 'envelope') {
-			return $file;
-		}
-
-		$children = \OCP\Server::get(FileMapper::class)->getChildrenFiles($file->getId());
-		$this->assertNotEmpty($children, 'Expected envelope to have at least one child file.');
-
-		return $children[0];
-	}
-
-	private function assertAuthorizedThumbnailRequest(string $username, string $path): void {
-		$this->request
-			->withRequestHeader([
-				'Authorization' => 'Basic ' . base64_encode($username . ':password'),
-			])
-			->withPath($path)
-			->assertResponseCode(200);
-
-		try {
-			$this->assertRequest();
-			return;
-		} catch (StatusCodeNotMatchedException $exception) {
-			if (!str_contains($exception->getMessage(), 'Expected 200, got 303')) {
-				throw $exception;
-			}
-		}
-
-		$this->request
-			->withRequestHeader([
-				'Authorization' => 'Basic ' . base64_encode($username . ':password'),
-			])
-			->withPath($path)
-			->assertResponseCode(303);
-
-		$this->assertRequest();
-	}
 
 	/**
 	 * @runInSeparateProcess
@@ -199,88 +159,6 @@ final class FileControllerTest extends ApiTestCase {
 			]);
 
 		$this->assertRequest();
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetThumbnailByOwner(): void {
-		$owner = $this->createAccount('owner', 'password');
-		$this->createAccount('signer', 'password');
-		$this->getMockAppConfig();
-
-		$file = $this->requestSignFile([
-			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test.pdf',
-			'signers' => [[
-				'identifyMethods' => [[
-					'method' => 'account',
-					'mandatory' => 0,
-					'value' => 'signer',
-				]],
-			]],
-			'userManager' => $owner,
-		]);
-		$file = $this->getDocumentFileFromResult($file);
-		$this->assertAuthorizedThumbnailRequest('owner', '/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1');
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetThumbnailBySigner(): void {
-		$owner = $this->createAccount('owner', 'password');
-		$signer = $this->createAccount('signer', 'password');
-		$signer->setEMailAddress('signer@test.coop');
-
-		$this->getMockAppConfig()->setValueArray(Application::APP_ID, 'identify_methods', [[
-			'name' => 'account',
-			'enabled' => 1,
-		]]);
-
-		$file = $this->requestSignFile([
-			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test.pdf',
-			'signers' => [[
-				'identifyMethods' => [[
-					'method' => 'account',
-					'mandatory' => 0,
-					'value' => 'signer',
-				]],
-			]],
-			'userManager' => $owner,
-		]);
-		$file = $this->getDocumentFileFromResult($file);
-		$this->assertAuthorizedThumbnailRequest('signer', '/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1');
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 */
-	public function testGetThumbnailByNodeIdForSigner(): void {
-		$owner = $this->createAccount('owner', 'password');
-		$signer = $this->createAccount('signer', 'password');
-		$signer->setEMailAddress('signer@test.coop');
-
-		$this->getMockAppConfig()->setValueArray(Application::APP_ID, 'identify_methods', [[
-			'name' => 'account',
-			'enabled' => 1,
-		]]);
-
-		$file = $this->requestSignFile([
-			'file' => ['base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))],
-			'name' => 'test.pdf',
-			'signers' => [[
-				'identifyMethods' => [[
-					'method' => 'account',
-					'mandatory' => 0,
-					'value' => 'signer',
-				]],
-			]],
-			'userManager' => $owner,
-		]);
-		$file = $this->getDocumentFileFromResult($file);
-		$this->assertAuthorizedThumbnailRequest('signer', '/api/v1/file/thumbnail/' . $file->getNodeId() . '?mimeFallback=1');
 	}
 
 	/**

--- a/tests/php/Api/Controller/FileControllerTest.php
+++ b/tests/php/Api/Controller/FileControllerTest.php
@@ -199,8 +199,8 @@ final class FileControllerTest extends ApiTestCase {
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('owner:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1')
+			->assertResponseCode(303);
 
 		$this->assertRequest();
 	}
@@ -236,8 +236,8 @@ final class FileControllerTest extends ApiTestCase {
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/file_id/' . $file->getId() . '?mimeFallback=1')
+			->assertResponseCode(303);
 
 		$this->assertRequest();
 	}
@@ -273,8 +273,8 @@ final class FileControllerTest extends ApiTestCase {
 			->withRequestHeader([
 				'Authorization' => 'Basic ' . base64_encode('signer:password'),
 			])
-			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId())
-			->assertResponseCode(200);
+			->withPath('/api/v1/file/thumbnail/' . $file->getNodeId() . '?mimeFallback=1')
+			->assertResponseCode(303);
 
 		$this->assertRequest();
 	}

--- a/tests/php/Unit/Middleware/InjectionMiddlewareTest.php
+++ b/tests/php/Unit/Middleware/InjectionMiddlewareTest.php
@@ -15,6 +15,7 @@ use OCA\Libresign\Exception\PageException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\InjectionMiddleware;
+use OCA\Libresign\Service\FileAccessService;
 use OCA\Libresign\Service\SignFileService;
 use OCA\Libresign\Service\UuidResolverService;
 use OCP\AppFramework\Controller;
@@ -46,11 +47,12 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private CertificateEngineFactory $certificateEngineFactory;
 	private FileMapper&MockObject $fileMapper;
 	private IInitialState $initialState;
+	private FileAccessService&MockObject $fileAccessService;
 	private SignFileService&MockObject $signFileService;
 	private UuidResolverService&MockObject $uuidResolverService;
 	private IL10N&MockObject $l10n;
-	private IappConfig&MockObject $appConfig;
-	private IurlGenerator&MockObject $urlGenerator;
+	private IAppConfig&MockObject $appConfig;
+	private IURLGenerator&MockObject $urlGenerator;
 	private ?string $userId = null;
 
 	private InitialStateService $initialStateService;
@@ -72,6 +74,7 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->createMock(IServerContainer::class)
 		);
 		$this->initialState = new InitialState($this->initialStateService, 'libresign');
+		$this->fileAccessService = $this->createMock(FileAccessService::class);
 		$this->signFileService = $this->createMock(SignFileService::class);
 		$this->uuidResolverService = $this->createMock(UuidResolverService::class);
 		$this->l10n = $this->createMock(IL10N::class);
@@ -88,6 +91,7 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->certificateEngineFactory,
 			$this->fileMapper,
 			$this->initialState,
+			$this->fileAccessService,
 			$this->signFileService,
 			$this->uuidResolverService,
 			$this->l10n,

--- a/tests/php/Unit/Service/FileAccessServiceTest.php
+++ b/tests/php/Unit/Service/FileAccessServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service;
+
+use OCA\Libresign\Db\File as FileEntity;
+use OCA\Libresign\Db\FileMapper;
+use OCA\Libresign\Service\FileAccessService;
+use OCA\Libresign\Service\SignFileService;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class FileAccessServiceTest extends TestCase {
+	private FileMapper&MockObject $fileMapper;
+	private SignFileService&MockObject $signFileService;
+	private IUserSession&MockObject $userSession;
+	private FileAccessService $service;
+
+	protected function setUp(): void {
+		$this->fileMapper = $this->createMock(FileMapper::class);
+		$this->signFileService = $this->createMock(SignFileService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->service = new FileAccessService(
+			$this->fileMapper,
+			$this->signFileService,
+			$this->userSession,
+		);
+	}
+
+	#[DataProvider('provideFileAccessScenarios')]
+	public function testUserCanAccessFileUsesOwnershipAndSignerRules(
+		string $method,
+		string $mapperMethod,
+		int $identifier,
+		string $ownerId,
+		string $userId,
+		bool $canSign,
+		bool $expected,
+	): void {
+		$user = $this->mockUser($userId);
+		$file = $this->createFileEntity(ownerId: $ownerId);
+
+		$this->fileMapper->expects($this->once())
+			->method($mapperMethod)
+			->with($identifier)
+			->willReturn($file);
+
+		$expectsSignerLookup = $ownerId !== $userId;
+		if (!$expectsSignerLookup) {
+			$this->signFileService->expects($this->never())->method('getSignRequestToSign');
+		} elseif ($canSign) {
+			$this->signFileService->expects($this->once())
+				->method('getSignRequestToSign')
+				->with($file, null, $user);
+		} else {
+			$this->signFileService->expects($this->once())
+				->method('getSignRequestToSign')
+				->with($file, null, $user)
+				->willThrowException(new \RuntimeException('not a signer'));
+		}
+
+		$this->assertSame($expected, $this->service->{$method}($identifier, $user));
+	}
+
+	#[DataProvider('provideMissingUserScenarios')]
+	public function testUserCanAccessFileReturnsFalseWithoutResolvedUser(
+		string $method,
+		string $mapperMethod,
+		int $identifier,
+	): void {
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn(null);
+		$this->fileMapper->expects($this->never())->method($mapperMethod);
+
+		$this->assertFalse($this->service->{$method}($identifier));
+	}
+
+	public static function provideFileAccessScenarios(): array {
+		return [
+			'owner by file id' => ['userCanAccessFileById', 'getById', 10, 'owner', 'owner', false, true],
+			'signer by file id' => ['userCanAccessFileById', 'getById', 20, 'owner', 'signer', true, true],
+			'outsider by file id' => ['userCanAccessFileById', 'getById', 30, 'owner', 'outsider', false, false],
+			'signer by node id' => ['userCanAccessFileByNodeId', 'getByNodeId', 99, 'owner', 'signer', true, true],
+			'outsider by node id' => ['userCanAccessFileByNodeId', 'getByNodeId', 100, 'owner', 'outsider', false, false],
+		];
+	}
+
+	public static function provideMissingUserScenarios(): array {
+		return [
+			'file id without user' => ['userCanAccessFileById', 'getById', 40],
+			'node id without user' => ['userCanAccessFileByNodeId', 'getByNodeId', 41],
+		];
+	}
+
+	private function mockUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	private function createFileEntity(string $ownerId): FileEntity {
+		$file = new FileEntity();
+		$file->setUserId($ownerId);
+		return $file;
+	}
+}

--- a/tests/stubs/psr_http_client.php
+++ b/tests/stubs/psr_http_client.php
@@ -13,4 +13,3 @@ namespace Psr\Http\Client {
 	interface ClientInterface {
 	}
 }
-

--- a/tests/stubs/psr_http_client.php
+++ b/tests/stubs/psr_http_client.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Psr\Http\Client {
+	/**
+	 * Minimal Psalm stub to satisfy OCP\Http\Client\IClient dependency.
+	 */
+	interface ClientInterface {
+	}
+}

--- a/tests/stubs/psr_http_client.php
+++ b/tests/stubs/psr_http_client.php
@@ -13,3 +13,4 @@ namespace Psr\Http\Client {
 	interface ClientInterface {
 	}
 }
+


### PR DESCRIPTION
## Problem
Signers with access to a document could not always load its thumbnail in LibreSign.

## What changed
- Allowed thumbnail access for users who can sign the document, not only for the owner.
- Centralized thumbnail endpoint access validation in the backend.
- Updated preview URLs to prefer the LibreSign `file_id` thumbnail endpoint, with `nodeId` as fallback.
- Updated backend and frontend regression coverage.

Close #7537