### PR TITLE
fix: remove mobile orientation signing hint

### DIFF
--- a/src/tests/views/SignPDF/Sign.spec.ts
+++ b/src/tests/views/SignPDF/Sign.spec.ts
@@ -1687,54 +1687,6 @@ describe('Sign.vue - signWithTokenCode', () => {
 			expect(wrapper.vm.hasSignatures).toBe(false)
 			expect(wrapper.vm.needCreateSignature).toBe(false)
 		})
-
-		it('shows a mobile orientation hint when signature setup is required on portrait phones', async () => {
-			const { default: realSign } = await import('../../../views/SignPDF/_partials/Sign.vue')
-			const { useSignStore } = await import('../../../store/sign.js')
-			const signStore = useSignStore()
-
-			signStore.document = createSignDocument({
-				nodeType: 'file',
-				signers: [
-					{ signRequestId: 501, me: true },
-				],
-				visibleElements: [
-					{ elementId: 201, fileId: 1, signRequestId: 501, type: 'signature', coordinates: { page: 1, left: 10, top: 20, width: 30, height: 40 } },
-				],
-			})
-
-			Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390, writable: true })
-			Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844, writable: true })
-
-			const wrapper = mount(realSign, {
-				global: {
-					stubs: {
-						NcButton: true,
-						NcDialog: true,
-						NcLoadingIcon: true,
-						TokenManager: true,
-						EmailManager: true,
-						UploadCertificate: true,
-						Documents: true,
-						Signatures: true,
-						Draw: true,
-						ManagePassword: true,
-						CreatePassword: true,
-						NcNoteCard: false,
-						NcPasswordField: true,
-						NcRichText: true,
-					},
-					mocks: {
-						$watch: vi.fn(),
-					},
-				},
-			})
-
-			await flushPromises()
-
-			expect(wrapper.vm.needCreateSignature).toBe(true)
-			expect(wrapper.text()).toContain('For a better signing experience on mobile, rotate your phone to landscape mode.')
-		})
 	})
 
 	describe('Sign.vue - create signature modal', () => {

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -8,9 +8,6 @@
 			<Signatures v-if="hasSignatures" />
 		</div>
 		<div v-if="!loading" class="button-wrapper">
-			<NcNoteCard v-if="showMobileOrientationHint" type="warning">
-				{{ t('libresign', 'For a better signing experience on mobile, rotate your phone to landscape mode.') }}
-			</NcNoteCard>
 			<NcNoteCard v-for="(error, index) in signStore.errors"
 				:key="index"
 				:heading="error.title || ''"
@@ -436,7 +433,6 @@ const sidebarStore = useSidebarStore() as SidebarStoreContract
 const identificationDocumentStore = useIdentificationDocumentStore() as IdentificationDocumentStoreContract
 
 const loading = ref(true)
-const isMobilePortrait = ref(false)
 const user = ref<UserInfo>({
 	account: { uid: '', emailAddress: '', displayName: '' },
 	settings: { canRequestSign: false, hasSignatureFile: false, phoneNumber: '' },
@@ -476,7 +472,6 @@ const needCreateSignature = computed(() => {
 	}
 	return hasVisibleElementsForCurrentUser(visibleElementsDocument.value)
 })
-const showMobileOrientationHint = computed(() => needCreateSignature.value && isMobilePortrait.value)
 const needIdentificationDocuments = computed(() => identificationDocumentStore.showDocumentsComponent())
 const canCreateSignature = computed(() => {
 	const capabilities = getCapabilities() as LibresignCapabilities
@@ -546,19 +541,6 @@ function onSignatureFileCreated() {
 
 function clearBlockingSignError() {
 	signStore.clearSigningErrors()
-}
-
-function updateOrientationHint() {
-	if (typeof window === 'undefined') {
-		isMobilePortrait.value = false
-		return
-	}
-
-	const isMobileViewport = window.innerWidth <= 512
-	const isPortrait = window.matchMedia?.('(orientation: portrait)').matches
-		?? window.innerHeight > window.innerWidth
-
-	isMobilePortrait.value = isMobileViewport && isPortrait
 }
 
 function saveSignature() {
@@ -746,10 +728,6 @@ function executeSigningAction(action: string) {
 }
 
 onMounted(async () => {
-	updateOrientationHint()
-	window.addEventListener('resize', updateOrientationHint, { passive: true })
-	window.addEventListener('orientationchange', updateOrientationHint)
-
 	loading.value = true
 	signatureElementsStore.signRequestUuid = signRequestUuid.value
 	signatureElementsStore.loadSignatures()
@@ -797,8 +775,6 @@ watch(signRequestUuid, (newUuid, oldUuid) => {
 })
 
 onBeforeUnmount(() => {
-	window.removeEventListener('resize', updateOrientationHint)
-	window.removeEventListener('orientationchange', updateOrientationHint)
 	resetSignMethodsState()
 	if (unwatchPendingAction) {
 		unwatchPendingAction()


### PR DESCRIPTION
## Summary
- remove the mobile orientation warning from the signing sidebar
- delete the related orientation tracking logic from Sign.vue
- drop the obsolete test that expected the removed warning
