### PR TITLE
[stable32] chore(release): fix stable32 release-drafter yaml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,37 +20,6 @@ categories:
   - title: 'Added'
     labels:
       - 'feature'
-      - 'feat'
-      - 'enhancement'
-      - 'minor'
-
-  - title: 'Changed'
-    collapse-after: 4
-    labels:
-      - 'chore'
-      - 'refactor'
-      - 'improvement'
-
-  - title: 'Fixed'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-      - 'patch'
-
-  - title: 'Removed'
-    labels:
-      - 'removed'
-      - 'deprecated'
-
-  - title: 'Security'
-    labels:
-      - 'security'
-
-  - title: 'Tests'
-    collapse-after: 3
-    labels:
-      - 'test'
 
   - title: 'Dependencies'
     collapse-after: 2


### PR DESCRIPTION
Fix duplicate YAML key in .github/release-drafter.yml (duplicate autolabeler block) that causes Release Drafter workflow failure on stable32.