### PR TITLE
[stable32] chore(release): remove duplicate autolabeler in stable32

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -93,26 +93,6 @@ autolabeler:
       - '/^chore:\s+bump\s+(js|php)\s+dependencies$/i'
       - '/^\[stable\d+\]\s+chore:\s+bump\s+(js|php)\s+dependencies$/i'
 
-autolabeler:
-  - label: 'fix'
-    title:
-      - '/^fix/i'
-  - label: 'feature'
-    title:
-      - '/^feat/i'
-  - label: 'chore'
-    title:
-      - '/^chore/i'
-  - label: 'docs'
-    title:
-      - '/^docs/i'
-  - label: 'refactor'
-    title:
-      - '/^refactor/i'
-  - label: 'test'
-    title:
-      - '/^test/i'
-
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
Follow-up fix for stable32 Release Drafter: remove remaining duplicate autolabeler key in .github/release-drafter.yml causing YAML parse failure.