### PR TITLE
[stable32] chore(release): reduce stable32 release-drafter query limit

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 filter-by-commitish: true
-pull-request-limit: 100
+pull-request-limit: 50
 history-limit: 50
 sort-by: merged_at
 sort-direction: ascending


### PR DESCRIPTION
Reduce pull-request-limit in stable32 release-drafter config to avoid GitHub GraphQL node limit failures during release draft generation.