### PR TITLE
fix: hide account identifier from SignerCommonName

### DIFF
--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -948,7 +948,11 @@ class SignFileService {
 					$flattened[] = (string)$item;
 				}
 			});
-			return implode(', ', $flattened);
+			$displayValues = array_values(array_filter(
+				$flattened,
+				static fn (string $item) => !preg_match('/^account:\s*/i', $item),
+			));
+			return implode(', ', $displayValues);
 		}
 
 		return $value === null ? '' : (string)$value;

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -1246,6 +1246,22 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'',
 				'',
 			],
+			'legacy AD/LDAP cert with account: prefix in CN array' => [
+				[
+					'issuer' => ['CN' => 'LibreCode CA'],
+					'subject' => ['CN' => ['account:johndoe', 'John Doe']],
+				],
+				'LibreCode CA',
+				'John Doe',
+			],
+			'legacy AD/LDAP cert with spaced account: prefix in CN array' => [
+				[
+					'issuer' => ['CN' => 'LibreCode CA'],
+					'subject' => ['CN' => ['account: johndoe', 'John Doe']],
+				],
+				'LibreCode CA',
+				'John Doe',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary
- filter `account:`-prefixed CN entries when normalizing certificate CN values for signature params
- keep only human-readable CN values for `SignerCommonName`
- add unit coverage for legacy AD/LDAP CN arrays containing `account:` + display name
- remove unrealistic fallback scenario from test coverage

## Why
Issue #6989 reported `{{SignerCommonName}}` problems for AD users. The previous normalization fixed `Array` output but could still expose internal identifiers like `account:johndoe` alongside the display name.

## Validation
- `composer test:unit -- --filter testGetSignatureParamsCommonName` (inside container)
