### PR TITLE
refactor: signer TSA component and simplify CRL validation messaging

### DIFF
--- a/lib/Db/CrlMapper.php
+++ b/lib/Db/CrlMapper.php
@@ -90,6 +90,7 @@ class CrlMapper extends QBMapper {
 		?string $revokedBy = null,
 		?DateTime $invalidityDate = null,
 		?int $crlNumber = null,
+		?DateTime $revokedAt = null,
 	): Crl {
 		$certificate = $this->findBySerialNumber($serialNumber);
 		return $this->revokeCertificateEntity(
@@ -98,7 +99,8 @@ class CrlMapper extends QBMapper {
 			$comment,
 			$revokedBy,
 			$invalidityDate,
-			$crlNumber
+			$crlNumber,
+			$revokedAt,
 		);
 	}
 
@@ -109,6 +111,7 @@ class CrlMapper extends QBMapper {
 		?string $revokedBy = null,
 		?DateTime $invalidityDate = null,
 		?int $crlNumber = null,
+		?DateTime $revokedAt = null,
 	): Crl {
 		if (CRLStatus::from($certificate->getStatus()) !== CRLStatus::ISSUED) {
 			throw new \InvalidArgumentException('Certificate is not in issued status');
@@ -118,7 +121,7 @@ class CrlMapper extends QBMapper {
 		$certificate->setReasonCode($reason->value);
 		$certificate->setComment($comment !== '' ? $comment : null);
 		$certificate->setRevokedBy($revokedBy);
-		$certificate->setRevokedAt(new DateTime());
+		$certificate->setRevokedAt($revokedAt ?? new DateTime());
 		$certificate->setInvalidityDate($invalidityDate);
 		$certificate->setCrlNumber($crlNumber);
 

--- a/lib/Listener/RevokeClickToSignCertificateListener.php
+++ b/lib/Listener/RevokeClickToSignCertificateListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Listener;
 
+use DateTime;
 use OCA\Libresign\Enum\CRLReason;
 use OCA\Libresign\Events\SignedEvent;
 use OCA\Libresign\Service\Crl\CrlService;
@@ -47,7 +48,9 @@ class RevokeClickToSignCertificateListener implements IEventListener {
 			$serialNumber,
 			CRLReason::SUPERSEDED,
 			'Temporary certificate issued for click-to-sign. Automatically revoked after document signing.',
-			'system'
+			'system',
+			null,
+			new DateTime('+1 second'),
 		);
 
 		if ($success) {

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -60,6 +60,7 @@ class CrlService {
 		?string $reasonText = null,
 		?string $revokedBy = null,
 		?DateTime $invalidityDate = null,
+		?DateTime $revokedAt = null,
 	): bool {
 
 		try {
@@ -73,7 +74,8 @@ class CrlService {
 				$reasonText,
 				$revokedBy,
 				$invalidityDate,
-				$crlNumber
+				$crlNumber,
+				$revokedAt,
 			);
 
 			return true;

--- a/lib/Service/File/CertificateSignersMergeService.php
+++ b/lib/Service/File/CertificateSignersMergeService.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Service\File;
+
+use DateTime;
+use DateTimeInterface;
+
+class CertificateSignersMergeService {
+	/**
+	 * @param callable(array, string): (?string) $resolveUid
+	 * @param callable(string, string): string $buildIdentifier
+	 * @param callable(string): (?string) $lookupAccountDisplayName
+	 */
+	public function merge(
+		\stdClass $fileData,
+		array $certData,
+		string $host,
+		string $signedStatusText,
+		callable $resolveUid,
+		callable $buildIdentifier,
+		callable $lookupAccountDisplayName,
+	): void {
+		$existingSigners = $fileData->signers ?? [];
+		$hasContractSigners = $this->hasContractSigners($existingSigners);
+		$indexMap = $this->buildSignerIndexMap($existingSigners, $buildIdentifier);
+		$usedIndexes = [];
+		$lastMatchedSignerIndex = null;
+		$singleContractSignerIndex = $this->getSingleContractSignerIndex($existingSigners);
+
+		foreach ($certData as $index => $signer) {
+			$resolvedUid = $this->resolveCertSignerUid($signer, $existingSigners, $host, $resolveUid);
+			$matchedIndex = $this->findMatchingSignerIndex($indexMap, $resolvedUid, $signer);
+			$targetIndex = $this->resolveTargetIndex(
+				$matchedIndex,
+				$existingSigners,
+				$usedIndexes,
+				$hasContractSigners,
+				$index,
+			);
+			if ($targetIndex === null) {
+				$timestampTargetIndex = $lastMatchedSignerIndex ?? $singleContractSignerIndex;
+				if ($timestampTargetIndex !== null
+					&& isset($fileData->signers[$timestampTargetIndex])
+					&& $this->isTechnicalTimestampEntry($signer)
+				) {
+					$this->hydrateTimestampOnly($fileData->signers[$timestampTargetIndex], $signer);
+				}
+				continue;
+			}
+
+			$isLibreSignMatch = $matchedIndex !== null && isset($existingSigners[$matchedIndex]->signRequestId);
+			$usedIndexes[$targetIndex] = true;
+
+			$this->ensureSignerSlotExists($fileData, $targetIndex);
+			$this->hydrateSignerFromCertData(
+				$fileData->signers[$targetIndex],
+				$signer,
+				$resolvedUid,
+				$isLibreSignMatch,
+				$host,
+				$signedStatusText,
+				$resolveUid,
+				$lookupAccountDisplayName,
+			);
+
+			if (isset($fileData->signers[$targetIndex]->uid)) {
+				$indexMap[strtolower((string)$fileData->signers[$targetIndex]->uid)] = $targetIndex;
+			}
+
+			$lastMatchedSignerIndex = $targetIndex;
+		}
+	}
+
+	private function isTechnicalTimestampEntry(array $signer): bool {
+		if (!isset($signer['timestamp']) || !is_array($signer['timestamp'])) {
+			return false;
+		}
+
+		if (isset($signer['uid']) && is_string($signer['uid']) && $signer['uid'] !== '') {
+			return false;
+		}
+
+		$subjectUid = $signer['chain'][0]['subject']['UID'] ?? null;
+		if (is_string($subjectUid) && $subjectUid !== '') {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function getSingleContractSignerIndex(array $signers): ?int {
+		$contractIndexes = [];
+		foreach ($signers as $index => $signer) {
+			if (is_object($signer) && isset($signer->signRequestId) && is_numeric($signer->signRequestId)) {
+				$contractIndexes[] = $index;
+			}
+		}
+
+		if (count($contractIndexes) === 1) {
+			return $contractIndexes[0];
+		}
+
+		return null;
+	}
+
+	private function hydrateTimestampOnly(\stdClass $targetSigner, array $signer): void {
+		$targetSigner->timestamp = $signer['timestamp'];
+		if (isset($signer['timestamp']['genTime']) && $signer['timestamp']['genTime'] instanceof DateTimeInterface) {
+			$targetSigner->timestamp['genTime'] = $signer['timestamp']['genTime']->format(DateTimeInterface::ATOM);
+		}
+	}
+
+	/**
+	 * @param callable(array, string): (?string) $resolveUid
+	 */
+	private function resolveCertSignerUid(array $signer, array $existingSigners, string $host, callable $resolveUid): ?string {
+		if (!isset($signer['chain'][0]) || !is_array($signer['chain'][0])) {
+			return is_string($signer['uid'] ?? null) ? $signer['uid'] : null;
+		}
+
+		$resolvedUid = $this->tryMatchWithExistingSigners($signer['chain'][0], $existingSigners, $host, $resolveUid);
+		if ($resolvedUid) {
+			return $resolvedUid;
+		}
+
+		$isLibreSignCert = isset($signer['chain'][0]['isLibreSignRootCA'])
+			&& $signer['chain'][0]['isLibreSignRootCA'] === true;
+		if ($isLibreSignCert) {
+			$certUid = $signer['chain'][0]['subject']['UID'] ?? null;
+			if (!is_string($certUid) || $certUid === '') {
+				return null;
+			}
+			return str_contains($certUid, ':') ? $certUid : 'account:' . $certUid;
+		}
+
+		if (is_string($signer['uid'] ?? null) && $signer['uid'] !== '') {
+			return $signer['uid'];
+		}
+
+		return $resolveUid($signer['chain'][0], $host);
+	}
+
+	private function resolveTargetIndex(
+		?int $matchedIndex,
+		array $existingSigners,
+		array $usedIndexes,
+		bool $hasContractSigners,
+		int $defaultIndex,
+	): ?int {
+		if ($matchedIndex !== null) {
+			return $matchedIndex;
+		}
+
+		if ($hasContractSigners) {
+			return null;
+		}
+
+		if (empty($existingSigners)) {
+			return $defaultIndex;
+		}
+
+		return $this->nextAvailableSignerIndex($existingSigners, $usedIndexes);
+	}
+
+	private function ensureSignerSlotExists(\stdClass $fileData, int $targetIndex): void {
+		if (!isset($fileData->signers[$targetIndex])) {
+			$fileData->signers[$targetIndex] = new \stdClass();
+		}
+	}
+
+	/**
+	 * @param callable(array, string): (?string) $resolveUid
+	 * @param callable(string): (?string) $lookupAccountDisplayName
+	 */
+	private function hydrateSignerFromCertData(
+		\stdClass $targetSigner,
+		array $signer,
+		?string $resolvedUid,
+		bool $isLibreSignMatch,
+		string $host,
+		string $signedStatusText,
+		callable $resolveUid,
+		callable $lookupAccountDisplayName,
+	): void {
+		$preservedDisplayName = $isLibreSignMatch && isset($targetSigner->displayName)
+			? $targetSigner->displayName
+			: null;
+
+		$targetSigner->status = 2;
+		$targetSigner->statusText = $signedStatusText;
+
+		if (isset($signer['timestamp'])) {
+			$targetSigner->timestamp = $signer['timestamp'];
+			if (isset($signer['timestamp']['genTime']) && $signer['timestamp']['genTime'] instanceof DateTimeInterface) {
+				$targetSigner->timestamp['genTime'] = $signer['timestamp']['genTime']->format(DateTimeInterface::ATOM);
+			}
+		}
+		if (isset($signer['signingTime']) && $signer['signingTime'] instanceof DateTimeInterface) {
+			$targetSigner->signingTime = $signer['signingTime'];
+			$targetSigner->signed = $signer['signingTime']->format(DateTimeInterface::ATOM);
+		}
+		if (isset($signer['docmdp'])) {
+			$targetSigner->docmdp = $signer['docmdp'];
+		}
+		if (isset($signer['docmdp_validation'])) {
+			$targetSigner->docmdp_validation = $signer['docmdp_validation'];
+		}
+		if (isset($signer['modifications'])) {
+			$targetSigner->modifications = $signer['modifications'];
+		}
+		if (isset($signer['modification_validation'])) {
+			$targetSigner->modification_validation = $signer['modification_validation'];
+		}
+
+		if (isset($signer['chain']) && is_array($signer['chain'])) {
+			$this->processChainData($targetSigner, $signer['chain']);
+		}
+
+		$this->assignSignerUid($targetSigner, $signer, $resolvedUid, $host, $resolveUid);
+
+		if (isset($signer['signDate'])) {
+			$targetSigner->signDate = $signer['signDate'];
+		}
+		if (isset($signer['type'])) {
+			$targetSigner->type = $signer['type'];
+		}
+
+		$this->assignSignerDisplayName($targetSigner, $signer, $preservedDisplayName, $lookupAccountDisplayName);
+	}
+
+	/**
+	 * @param callable(array, string): (?string) $resolveUid
+	 */
+	private function assignSignerUid(\stdClass $targetSigner, array $signer, ?string $resolvedUid, string $host, callable $resolveUid): void {
+		if (isset($signer['uid'])) {
+			$targetSigner->uid = $signer['uid'];
+			return;
+		}
+
+		if ($resolvedUid) {
+			$targetSigner->uid = $resolvedUid;
+			return;
+		}
+
+		if (isset($signer['chain'][0]) && is_array($signer['chain'][0])) {
+			$targetSigner->uid = $resolveUid($signer['chain'][0], $host);
+		}
+	}
+
+	/**
+	 * @param callable(string): (?string) $lookupAccountDisplayName
+	 */
+	private function assignSignerDisplayName(\stdClass $targetSigner, array $signer, ?string $preservedDisplayName, callable $lookupAccountDisplayName): void {
+		if ($preservedDisplayName) {
+			$targetSigner->displayName = $preservedDisplayName;
+			return;
+		}
+
+		if (isset($targetSigner->uid) && str_starts_with($targetSigner->uid, 'account:')) {
+			$accountId = substr($targetSigner->uid, strlen('account:'));
+			$displayName = $lookupAccountDisplayName($accountId);
+			$targetSigner->displayName = $displayName ?: $accountId;
+			return;
+		}
+
+		if (!isset($targetSigner->displayName) && isset($signer['chain'][0])) {
+			$targetSigner->displayName = $signer['chain'][0]['name'] ?? ($signer['chain'][0]['subject']['CN'] ?? '');
+		}
+	}
+
+	private function hasContractSigners(array $signers): bool {
+		foreach ($signers as $signer) {
+			if (is_object($signer) && isset($signer->signRequestId) && is_numeric($signer->signRequestId)) {
+				return true;
+			}
+			if (is_array($signer) && isset($signer['signRequestId']) && is_numeric($signer['signRequestId'])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param callable(string, string): string $buildIdentifier
+	 */
+	private function buildSignerIndexMap(array $signers, callable $buildIdentifier): array {
+		$map = [];
+		foreach ($signers as $index => $signer) {
+			if (isset($signer->uid)) {
+				$map[strtolower((string)$signer->uid)] = $index;
+			}
+			if (!empty($signer->identifyMethods)) {
+				foreach ($signer->identifyMethods as $identifyMethod) {
+					if (isset($identifyMethod['method']) && isset($identifyMethod['value'])) {
+						$identifier = $buildIdentifier($identifyMethod['method'], $identifyMethod['value']);
+						$map[strtolower($identifier)] = $index;
+					}
+				}
+			}
+		}
+		return $map;
+	}
+
+	private function findMatchingSignerIndex(array $indexMap, ?string $resolvedUid, array $certSigner): ?int {
+		$identifiers = [];
+		if ($resolvedUid) {
+			$identifiers[] = strtolower($resolvedUid);
+		}
+		if (!empty($certSigner['uid'])) {
+			$identifiers[] = strtolower((string)$certSigner['uid']);
+		}
+		foreach ($identifiers as $identifier) {
+			if (isset($indexMap[$identifier])) {
+				return $indexMap[$identifier];
+			}
+		}
+		return null;
+	}
+
+	private function nextAvailableSignerIndex(array $existingSigners, array $usedIndexes): int {
+		$index = count($existingSigners);
+		while (isset($existingSigners[$index]) || isset($usedIndexes[$index])) {
+			$index++;
+		}
+		return $index;
+	}
+
+	private function processChainData(\stdClass $signer, array $chain): void {
+		$signer->chain = [];
+
+		foreach ($chain as $chainIndex => $chainItem) {
+			$chainArr = $chainItem;
+
+			if (isset($chainItem['validFrom_time_t']) && is_numeric($chainItem['validFrom_time_t'])) {
+				$chainArr['valid_from'] = (new DateTime('@' . $chainItem['validFrom_time_t'], new \DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
+			}
+			if (isset($chainItem['validTo_time_t']) && is_numeric($chainItem['validTo_time_t'])) {
+				$chainArr['valid_to'] = (new DateTime('@' . $chainItem['validTo_time_t'], new \DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
+			}
+
+			$chainArr['displayName'] = $chainArr['name'] ?? ($chainArr['subject']['CN'] ?? '');
+			$signer->chain[$chainIndex] = $chainArr;
+		}
+
+		if (isset($chain[0])) {
+			$this->enrichSignerWithCertificateValidation($signer, $chain[0]);
+		}
+	}
+
+	private function enrichSignerWithCertificateValidation(\stdClass $signer, array $endEntityCert): void {
+		if (isset($endEntityCert['name']) && !isset($signer->name)) {
+			$signer->name = $endEntityCert['name'];
+		}
+		if (isset($endEntityCert['hash']) && !isset($signer->hash)) {
+			$signer->hash = $endEntityCert['hash'];
+		}
+		if (isset($endEntityCert['serialNumber']) && !isset($signer->serialNumber)) {
+			$signer->serialNumber = $endEntityCert['serialNumber'];
+		}
+		if (isset($endEntityCert['serialNumberHex']) && !isset($signer->serialNumberHex)) {
+			$signer->serialNumberHex = $endEntityCert['serialNumberHex'];
+		}
+		if (isset($endEntityCert['signatureTypeSN']) && !isset($signer->signatureTypeSN)) {
+			$signer->signatureTypeSN = $endEntityCert['signatureTypeSN'];
+		}
+
+		if (isset($endEntityCert['subject']) && !isset($signer->subject)) {
+			$signer->subject = $endEntityCert['subject'];
+		}
+
+		if (isset($endEntityCert['crl_urls']) && !isset($signer->crl_urls)) {
+			$signer->crl_urls = $endEntityCert['crl_urls'];
+		}
+		if (isset($endEntityCert['crl_validation']) && !isset($signer->crl_validation)) {
+			$signer->crl_validation = $endEntityCert['crl_validation'];
+		}
+		if (isset($endEntityCert['crl_revoked_at']) && !isset($signer->crl_revoked_at)) {
+			$signer->crl_revoked_at = $endEntityCert['crl_revoked_at'];
+		}
+
+		if (isset($endEntityCert['signature_validation']) && !isset($signer->signature_validation)) {
+			$signer->signature_validation = $endEntityCert['signature_validation'];
+		}
+
+		if (isset($endEntityCert['isLibreSignRootCA']) && !isset($signer->isLibreSignRootCA)) {
+			$signer->isLibreSignRootCA = $endEntityCert['isLibreSignRootCA'];
+		}
+	}
+
+	/**
+	 * @param callable(array, string): (?string) $resolveUid
+	 */
+	private function tryMatchWithExistingSigners(array $certData, array $existingSigners, string $host, callable $resolveUid): ?string {
+		if (empty($existingSigners)) {
+			return null;
+		}
+
+		$certSerialNumber = $certData['serialNumber'] ?? null;
+		$certSerialNumberHex = $certData['serialNumberHex'] ?? null;
+		$certHash = $certData['hash'] ?? null;
+
+		if (!$certSerialNumber && !$certSerialNumberHex && !$certHash) {
+			return null;
+		}
+
+		foreach ($existingSigners as $signer) {
+			if (!isset($signer->metadata) || !is_array($signer->metadata)) {
+				continue;
+			}
+
+			$certInfo = $signer->metadata['certificate_info'] ?? null;
+			if (!is_array($certInfo)) {
+				continue;
+			}
+
+			if ($certSerialNumber && isset($certInfo['serialNumber']) && $certSerialNumber === $certInfo['serialNumber']) {
+				return $signer->uid ?? $resolveUid($certData, $host);
+			}
+
+			if ($certSerialNumberHex && isset($certInfo['serialNumberHex']) && $certSerialNumberHex === $certInfo['serialNumberHex']) {
+				return $signer->uid ?? $resolveUid($certData, $host);
+			}
+
+			if ($certHash && isset($certInfo['hash']) && $certHash === $certInfo['hash']) {
+				return $signer->uid ?? $resolveUid($certData, $host);
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Service/File/SignersLoader.php
+++ b/lib/Service/File/SignersLoader.php
@@ -11,7 +11,6 @@ namespace OCA\Libresign\Service\File;
 use DateTimeInterface;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\SignRequestMapper;
-use OCA\Libresign\Service\File\CertificateSignersMergeService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SubjectAlternativeNameService;
 use OCP\Accounts\IAccountManager;

--- a/lib/Service/File/SignersLoader.php
+++ b/lib/Service/File/SignersLoader.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Service\File;
 
-use DateTime;
 use DateTimeInterface;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\SignRequestMapper;
+use OCA\Libresign\Service\File\CertificateSignersMergeService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SubjectAlternativeNameService;
 use OCP\Accounts\IAccountManager;
 use OCP\IUserManager;
-use stdClass;
 
 /**
  * Handles loading signer data for files
  */
 class SignersLoader {
 	private bool $signersLibreSignLoaded = false;
+	private CertificateSignersMergeService $certificateSignersMergeService;
 
 	public function __construct(
 		private SignRequestMapper $signRequestMapper,
@@ -31,11 +31,12 @@ class SignersLoader {
 		private IAccountManager $accountManager,
 		private IUserManager $userManager,
 	) {
+		$this->certificateSignersMergeService = new CertificateSignersMergeService();
 	}
 
 	public function loadLibreSignSigners(
 		?File $file,
-		stdClass $fileData,
+		\stdClass $fileData,
 		FileResponseOptions $options,
 		array $certData = [],
 	): void {
@@ -54,7 +55,7 @@ class SignersLoader {
 		foreach ($signers as $signer) {
 			$identifyMethods = $identifyMethodsBatch[$signer->getId()] ?? [];
 			if (!empty($fileData->signers)) {
-				$found = array_filter($fileData->signers, function (stdClass $found) use ($identifyMethods) {
+				$found = array_filter($fileData->signers, function (\stdClass $found) use ($identifyMethods) {
 					if (!isset($found->uid)) {
 						return false;
 					}
@@ -78,7 +79,7 @@ class SignersLoader {
 				$index = 0;
 			}
 			if (!isset($fileData->signers[$index])) {
-				$fileData->signers[$index] = new stdClass();
+				$fileData->signers[$index] = new \stdClass();
 			}
 			$fileData->signers[$index]->signRequestId = $signer->getId();
 			$fileData->signers[$index]->signed = $signer->getSigned()?->format(DateTimeInterface::ATOM);
@@ -160,7 +161,7 @@ class SignersLoader {
 			}
 			$fileData->signers[$index]->me = false;
 			if ($options->getMe() || $options->getIdentifyMethodId()) {
-				$currentUserData = new stdClass();
+				$currentUserData = new \stdClass();
 				$currentUserData->me = false;
 				foreach ($identifyMethods as $methods) {
 					foreach ($methods as $identifyMethod) {
@@ -209,269 +210,23 @@ class SignersLoader {
 		$this->signersLibreSignLoaded = true;
 	}
 
-	public function loadSignersFromCertData(stdClass $fileData, array $certData, string $host): void {
-		$existingSigners = $fileData->signers ?? [];
-		$indexMap = $this->buildSignerIndexMap($existingSigners);
-		$usedIndexes = [];
-
-		foreach ($certData as $index => $signer) {
-			$targetIndex = $index;
-			$isLibreSignMatch = false;
-
-			$resolvedUid = $this->tryMatchWithExistingSigners($signer['chain'][0], $existingSigners, $host);
-			if (!$resolvedUid) {
-				$isLibreSignCert = isset($signer['chain'][0]['isLibreSignRootCA'])
-					&& $signer['chain'][0]['isLibreSignRootCA'] === true;
-				if ($isLibreSignCert) {
-					$certUid = $signer['chain'][0]['subject']['UID'] ?? null;
-					if ($certUid) {
-						$resolvedUid = str_contains($certUid, ':') ? $certUid : 'account:' . $certUid;
-					} else {
-						$resolvedUid = null;
-					}
-				} else {
-					$resolvedUid = $signer['uid'] ?? null;
-					if (!$resolvedUid && isset($signer['chain'][0])) {
-						$resolvedUid = $this->identifyMethodService->resolveUid($signer['chain'][0], $host);
-					}
-				}
-			}
-
-			$matchedIndex = $this->findMatchingSignerIndex($indexMap, $resolvedUid, $signer);
-			if ($matchedIndex !== null) {
-				$targetIndex = $matchedIndex;
-				$isLibreSignMatch = isset($existingSigners[$matchedIndex]->signRequestId);
-			} else {
-				if (!empty($existingSigners)) {
-					$targetIndex = $this->nextAvailableSignerIndex($existingSigners, $usedIndexes);
-				}
-			}
-			$usedIndexes[$targetIndex] = true;
-
-			if (!isset($fileData->signers[$targetIndex])) {
-				$fileData->signers[$targetIndex] = new stdClass();
-			}
-
-			$preservedDisplayName = $isLibreSignMatch && isset($fileData->signers[$targetIndex]->displayName)
-				? $fileData->signers[$targetIndex]->displayName
-				: null;
-
-			$fileData->signers[$targetIndex]->status = 2;
-			$fileData->signers[$targetIndex]->statusText = $this->signRequestMapper->getTextOfSignerStatus(2);
-
-			if (isset($signer['timestamp'])) {
-				$fileData->signers[$targetIndex]->timestamp = $signer['timestamp'];
-				if (isset($signer['timestamp']['genTime']) && $signer['timestamp']['genTime'] instanceof DateTimeInterface) {
-					$fileData->signers[$targetIndex]->timestamp['genTime'] = $signer['timestamp']['genTime']->format(DateTimeInterface::ATOM);
-				}
-			}
-			if (isset($signer['signingTime']) && $signer['signingTime'] instanceof DateTimeInterface) {
-				$fileData->signers[$targetIndex]->signingTime = $signer['signingTime'];
-				$fileData->signers[$targetIndex]->signed = $signer['signingTime']->format(DateTimeInterface::ATOM);
-			}
-			if (isset($signer['docmdp'])) {
-				$fileData->signers[$targetIndex]->docmdp = $signer['docmdp'];
-			}
-			if (isset($signer['docmdp_validation'])) {
-				$fileData->signers[$targetIndex]->docmdp_validation = $signer['docmdp_validation'];
-			}
-			if (isset($signer['modifications'])) {
-				$fileData->signers[$targetIndex]->modifications = $signer['modifications'];
-			}
-			if (isset($signer['modification_validation'])) {
-				$fileData->signers[$targetIndex]->modification_validation = $signer['modification_validation'];
-			}
-
-			if (isset($signer['chain'])) {
-				$this->processChainData($fileData->signers[$targetIndex], $signer['chain']);
-			}
-
-			if (isset($signer['uid'])) {
-				$fileData->signers[$targetIndex]->uid = $signer['uid'];
-			} elseif ($resolvedUid) {
-				$fileData->signers[$targetIndex]->uid = $resolvedUid;
-			} elseif (isset($signer['chain'][0])) {
-				$fileData->signers[$targetIndex]->uid = $this->identifyMethodService->resolveUid($signer['chain'][0], $host);
-			}
-
-			if (isset($signer['signDate'])) {
-				$fileData->signers[$targetIndex]->signDate = $signer['signDate'];
-			}
-			if (isset($signer['type'])) {
-				$fileData->signers[$targetIndex]->type = $signer['type'];
-			}
-
-			if ($preservedDisplayName) {
-				$fileData->signers[$targetIndex]->displayName = $preservedDisplayName;
-			} elseif (isset($fileData->signers[$targetIndex]->uid) && str_starts_with($fileData->signers[$targetIndex]->uid, 'account:')) {
-				$accountId = substr($fileData->signers[$targetIndex]->uid, strlen('account:'));
+	public function loadSignersFromCertData(\stdClass $fileData, array $certData, string $host): void {
+		$this->certificateSignersMergeService->merge(
+			$fileData,
+			$certData,
+			$host,
+			$this->signRequestMapper->getTextOfSignerStatus(2),
+			fn (array $certData, string $currentHost): ?string => $this->identifyMethodService->resolveUid($certData, $currentHost),
+			fn (string $method, string $value): string => $this->subjectAlternativeNameService->build($method, $value),
+			function (string $accountId): ?string {
 				$user = $this->userManager->get($accountId);
-				if ($user) {
-					$fileData->signers[$targetIndex]->displayName = $user->getDisplayName();
-				} else {
-					$fileData->signers[$targetIndex]->displayName = $accountId;
-				}
-			} elseif (!isset($fileData->signers[$targetIndex]->displayName) && isset($signer['chain'][0])) {
-				$fileData->signers[$targetIndex]->displayName = $signer['chain'][0]['name'] ?? ($signer['chain'][0]['subject']['CN'] ?? '');
-			}
-
-			if (isset($fileData->signers[$targetIndex]->uid)) {
-				$indexMap[strtolower((string)$fileData->signers[$targetIndex]->uid)] = $targetIndex;
-			}
-		}
-	}
-
-	private function buildSignerIndexMap(array $signers): array {
-		$map = [];
-		foreach ($signers as $index => $signer) {
-			if (isset($signer->uid)) {
-				$map[strtolower((string)$signer->uid)] = $index;
-			}
-			if (!empty($signer->identifyMethods)) {
-				foreach ($signer->identifyMethods as $identifyMethod) {
-					if (isset($identifyMethod['method']) && isset($identifyMethod['value'])) {
-						$identifier = $this->subjectAlternativeNameService->build($identifyMethod['method'], $identifyMethod['value']);
-						$map[strtolower($identifier)] = $index;
-					}
-				}
-			}
-		}
-		return $map;
-	}
-
-	private function findMatchingSignerIndex(array $indexMap, ?string $resolvedUid, array $certSigner): ?int {
-		$identifiers = [];
-		if ($resolvedUid) {
-			$identifiers[] = strtolower($resolvedUid);
-		}
-		if (!empty($certSigner['uid'])) {
-			$identifiers[] = strtolower((string)$certSigner['uid']);
-		}
-		foreach ($identifiers as $identifier) {
-			if (isset($indexMap[$identifier])) {
-				return $indexMap[$identifier];
-			}
-		}
-		return null;
-	}
-
-	private function nextAvailableSignerIndex(array $existingSigners, array $usedIndexes): int {
-		$index = count($existingSigners);
-		while (isset($existingSigners[$index]) || isset($usedIndexes[$index])) {
-			$index++;
-		}
-		return $index;
+				return $user ? $user->getDisplayName() : null;
+			},
+		);
 	}
 
 	public function reset(): void {
 		$this->signersLibreSignLoaded = false;
-	}
-
-	private function processChainData(stdClass $signer, array $chain): void {
-		$signer->chain = [];
-
-		foreach ($chain as $chainIndex => $chainItem) {
-			$chainArr = $chainItem;
-
-			if (isset($chainItem['validFrom_time_t']) && is_numeric($chainItem['validFrom_time_t'])) {
-				$chainArr['valid_from'] = (new DateTime('@' . $chainItem['validFrom_time_t'], new \DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
-			}
-			if (isset($chainItem['validTo_time_t']) && is_numeric($chainItem['validTo_time_t'])) {
-				$chainArr['valid_to'] = (new DateTime('@' . $chainItem['validTo_time_t'], new \DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
-			}
-
-			$chainArr['displayName'] = $chainArr['name'] ?? ($chainArr['subject']['CN'] ?? '');
-			$signer->chain[$chainIndex] = $chainArr;
-		}
-
-		if (isset($chain[0])) {
-			$this->enrichSignerWithCertificateValidation($signer, $chain[0]);
-		}
-	}
-
-	private function enrichSignerWithCertificateValidation(stdClass $signer, array $endEntityCert): void {
-		if (isset($endEntityCert['name']) && !isset($signer->name)) {
-			$signer->name = $endEntityCert['name'];
-		}
-		if (isset($endEntityCert['hash']) && !isset($signer->hash)) {
-			$signer->hash = $endEntityCert['hash'];
-		}
-		if (isset($endEntityCert['serialNumber']) && !isset($signer->serialNumber)) {
-			$signer->serialNumber = $endEntityCert['serialNumber'];
-		}
-		if (isset($endEntityCert['serialNumberHex']) && !isset($signer->serialNumberHex)) {
-			$signer->serialNumberHex = $endEntityCert['serialNumberHex'];
-		}
-		if (isset($endEntityCert['signatureTypeSN']) && !isset($signer->signatureTypeSN)) {
-			$signer->signatureTypeSN = $endEntityCert['signatureTypeSN'];
-		}
-
-		if (isset($endEntityCert['subject']) && !isset($signer->subject)) {
-			$signer->subject = $endEntityCert['subject'];
-		}
-
-		if (isset($endEntityCert['crl_urls']) && !isset($signer->crl_urls)) {
-			$signer->crl_urls = $endEntityCert['crl_urls'];
-		}
-		if (isset($endEntityCert['crl_validation']) && !isset($signer->crl_validation)) {
-			$signer->crl_validation = $endEntityCert['crl_validation'];
-		}
-		if (isset($endEntityCert['crl_revoked_at']) && !isset($signer->crl_revoked_at)) {
-			$signer->crl_revoked_at = $endEntityCert['crl_revoked_at'];
-		}
-
-		if (isset($endEntityCert['signature_validation']) && !isset($signer->signature_validation)) {
-			$signer->signature_validation = $endEntityCert['signature_validation'];
-		}
-
-		if (isset($endEntityCert['isLibreSignRootCA']) && !isset($signer->isLibreSignRootCA)) {
-			$signer->isLibreSignRootCA = $endEntityCert['isLibreSignRootCA'];
-		}
-	}
-
-	private function tryMatchWithExistingSigners(array $certData, array $existingSigners, string $host): ?string {
-		if (empty($existingSigners)) {
-			return null;
-		}
-
-		$certSerialNumber = $certData['serialNumber'] ?? null;
-		$certSerialNumberHex = $certData['serialNumberHex'] ?? null;
-		$certHash = $certData['hash'] ?? null;
-
-		if (!$certSerialNumber && !$certSerialNumberHex && !$certHash) {
-			return null;
-		}
-
-		foreach ($existingSigners as $signer) {
-			if (!isset($signer->metadata) || !is_array($signer->metadata)) {
-				continue;
-			}
-
-			$certInfo = $signer->metadata['certificate_info'] ?? null;
-			if (!is_array($certInfo)) {
-				continue;
-			}
-
-			if ($certSerialNumber && isset($certInfo['serialNumber'])) {
-				if ($certSerialNumber === $certInfo['serialNumber']) {
-					return $signer->uid ?? $this->identifyMethodService->resolveUid($certData, $host);
-				}
-			}
-
-			if ($certSerialNumberHex && isset($certInfo['serialNumberHex'])) {
-				if ($certSerialNumberHex === $certInfo['serialNumberHex']) {
-					return $signer->uid ?? $this->identifyMethodService->resolveUid($certData, $host);
-				}
-			}
-
-			if ($certHash && isset($certInfo['hash'])) {
-				if ($certHash === $certInfo['hash']) {
-					return $signer->uid ?? $this->identifyMethodService->resolveUid($certData, $host);
-				}
-			}
-		}
-
-		return null;
 	}
 
 }

--- a/src/components/validation/SignerDetails.vue
+++ b/src/components/validation/SignerDetails.vue
@@ -59,6 +59,9 @@
 			</template>
 		</NcListItem>
 
+		<!-- Timestamp Authority (TSA) -->
+		<SignerTimestamp v-if="isOpen" :timestamp="signer.timestamp" />
+
 		<!-- Validation Status Section -->
 		<NcListItem v-if="isOpen && hasValidationStatus(signer)"
 			class="extra"
@@ -115,7 +118,7 @@
 			</NcListItem>
 			<NcListItem v-if="signer.crl_validation" class="extra-chain" compact>
 				<template #icon>
-					<NcIconSvgWrapper :path="crlStatusMap[signer.crl_validation]?.icon || mdiHelpCircle"
+					<NcIconSvgWrapper :path="getCrlValidationIconPath(signer)"
 						:class="getCrlValidationIconClass(signer)" />
 				</template>
 				<template #name>
@@ -242,6 +245,7 @@ import Moment from '@nextcloud/moment'
 import { computed, ref } from 'vue'
 
 import CertificateChain from './CertificateChain.vue'
+import SignerTimestamp from './SignerTimestamp.vue'
 
 import {
 	mdiAlertCircle,
@@ -282,6 +286,20 @@ type SignerModifications = {
 	revisionCount?: number
 }
 
+type SignerTimestamp = {
+	genTime?: string
+	policy?: string
+	policyName?: string
+	hash?: string
+	hashAlgorithm?: string
+	serialNumber?: string | number
+	authority?: string
+	tsaName?: string
+	cnHints?: {
+		commonName?: string
+	}
+}
+
 type SignerModel = {
 	displayName?: string
 	email?: string | null
@@ -299,6 +317,7 @@ type SignerModel = {
 	docmdp_validation?: { message?: string }
 	modification_validation?: SignerModificationValidation
 	modifications?: SignerModifications
+	timestamp?: SignerTimestamp
 	signatureTypeSN?: string
 	hash?: string
 	chain?: Record<string, unknown>[]
@@ -364,13 +383,13 @@ function isRevokedBeforeSigning(signer: SignerModel) {
 		return true
 	}
 
-	const revokedDate = new Date(revokedAt)
-	const signedDate = new Date(signedAt)
-	if (Number.isNaN(revokedDate.getTime()) || Number.isNaN(signedDate.getTime())) {
+	const revokedTime = new Date(revokedAt).getTime()
+	const signedTime = new Date(signedAt).getTime()
+	if (Number.isNaN(revokedTime) || Number.isNaN(signedTime)) {
 		return true
 	}
 
-	return revokedDate <= signedDate
+	return revokedTime <= signedTime
 }
 
 function hasValidationIssues(signer: SignerModel) {
@@ -435,9 +454,21 @@ function getCrlValidationIconClass(signer: SignerModel) {
 	return crlStatusMap[signer.crl_validation ?? '']?.class || 'icon-warning'
 }
 
+function getCrlValidationIconPath(signer: SignerModel) {
+	if (isRevokedStatus(signer.crl_validation)) {
+		return isRevokedBeforeSigning(signer) ? mdiCloseCircle : mdiCheckCircle
+	}
+	return crlStatusMap[signer.crl_validation ?? '']?.icon || mdiHelpCircle
+}
+
 function dateFromSqlAnsi(date?: string | number | null) {
 	if (!date) return ''
 	return Moment(String(date)).format('LLL')
+}
+
+function dateFromSqlAnsiWithSeconds(date?: string | number | null) {
+	if (!date) return ''
+	return Moment(String(date)).format('L LTS')
 }
 
 function getCrlStatusText(signer: SignerModel) {
@@ -447,12 +478,16 @@ function getCrlStatusText(signer: SignerModel) {
 	}
 
 	if (isRevokedBeforeSigning(signer)) {
+		if (signer.crl_revoked_at) {
+			const revokedAt = dateFromSqlAnsiWithSeconds(signer.crl_revoked_at)
+			return t('libresign', 'CRL: Certificate revoked before signing (revocation date: {revokedAt})', { revokedAt })
+		}
 		return t('libresign', 'CRL: Certificate revoked before signing')
 	}
 
 	if (signer.crl_revoked_at) {
-		const formattedDate = dateFromSqlAnsi(signer.crl_revoked_at)
-		return t('libresign', 'CRL: Valid at signing time (revoked on {date})', { date: formattedDate })
+		const revokedAt = dateFromSqlAnsiWithSeconds(signer.crl_revoked_at)
+		return t('libresign', 'CRL: Valid at signing time (revocation date: {revokedAt})', { revokedAt })
 	}
 	return t('libresign', 'CRL: Valid at signing time')
 }
@@ -516,12 +551,14 @@ defineExpose({
 	getSignatureValidationMessage,
 	getCertificateTrustMessage,
 	getValidityStatusAtSigning,
+	getCrlValidationIconPath,
 	getCrlValidationIconClass,
 	getCrlStatusText,
 	hasDocMdpInfo,
 	getModificationStatusIcon,
 	getModificationStatusClass,
 	dateFromSqlAnsi,
+	dateFromSqlAnsiWithSeconds,
 	formatTimestamp,
 })
 </script>

--- a/src/components/validation/SignerTimestamp.vue
+++ b/src/components/validation/SignerTimestamp.vue
@@ -1,0 +1,216 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 LibreCode coop and LibreCode contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<template v-if="hasContent">
+		<NcListItem class="extra"
+			compact
+			:name="t('libresign', 'Timestamp Authority (TSA)')"
+			:aria-expanded="open ? 'true' : 'false'"
+			role="button"
+			@click="open = !open">
+			<template #name>
+				<strong>{{ t('libresign', 'Timestamp Authority (TSA)') }}</strong>
+			</template>
+			<template #extra-actions>
+				<NcButton variant="tertiary"
+					:aria-label="toggleAriaLabel"
+					@click.stop="open = !open">
+					<template #icon>
+						<NcIconSvgWrapper v-if="open"
+							:path="mdiUnfoldLessHorizontal"
+							:size="20" />
+						<NcIconSvgWrapper v-else
+							:path="mdiUnfoldMoreHorizontal"
+							:size="20" />
+					</template>
+				</NcButton>
+			</template>
+		</NcListItem>
+		<div v-if="open" class="timestamp-wrapper" role="region" :aria-label="t('libresign', 'Timestamp authority details')">
+			<div class="extra-chain timestamp-item">
+				<dl class="timestamp-details">
+					<div v-if="authority" class="timestamp-field">
+						<dt>{{ t('libresign', 'Authority:') }}</dt>
+						<dd>{{ authority }}</dd>
+					</div>
+					<div v-if="timestamp?.genTime" class="timestamp-field">
+						<dt>{{ t('libresign', 'Generated at:') }}</dt>
+						<dd>{{ dateFromSqlAnsi(timestamp.genTime) }}</dd>
+					</div>
+					<div v-if="policy" class="timestamp-field">
+						<dt>{{ t('libresign', 'Policy:') }}</dt>
+						<dd>{{ policy }}</dd>
+					</div>
+					<div v-if="hashAlgorithm" class="timestamp-field">
+						<dt>{{ t('libresign', 'Hash algorithm:') }}</dt>
+						<dd>{{ hashAlgorithm }}</dd>
+					</div>
+					<div v-if="serialNumber" class="timestamp-field">
+						<dt>{{ t('libresign', 'Serial number:') }}</dt>
+						<dd>{{ serialNumber }}</dd>
+					</div>
+				</dl>
+			</div>
+		</div>
+	</template>
+</template>
+
+<script setup lang="ts">
+import { t } from '@nextcloud/l10n'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcListItem from '@nextcloud/vue/components/NcListItem'
+import Moment from '@nextcloud/moment'
+import { computed, ref } from 'vue'
+
+import {
+	mdiUnfoldLessHorizontal,
+	mdiUnfoldMoreHorizontal,
+} from '@mdi/js'
+
+type SignerTimestampData = {
+	genTime?: string
+	policy?: string
+	policyName?: string
+	hash?: string
+	hashAlgorithm?: string
+	serialNumber?: string | number
+	authority?: string
+	tsaName?: string
+	cnHints?: {
+		commonName?: string
+	}
+}
+
+defineOptions({
+	name: 'SignerTimestamp',
+})
+
+const props = defineProps<{
+	timestamp?: SignerTimestampData
+}>()
+
+const open = ref(false)
+
+const authority = computed(() =>
+	props.timestamp?.cnHints?.commonName
+	|| props.timestamp?.authority
+	|| props.timestamp?.tsaName
+	|| '',
+)
+
+const policy = computed(() =>
+	props.timestamp?.policyName || props.timestamp?.policy || '',
+)
+
+const hashAlgorithm = computed(() =>
+	props.timestamp?.hashAlgorithm || props.timestamp?.hash || '',
+)
+
+const serialNumber = computed(() => {
+	const serial = props.timestamp?.serialNumber
+	if (typeof serial === 'number') {
+		return String(serial)
+	}
+	return serial || ''
+})
+
+const hasContent = computed(() =>
+	!!(authority.value
+	|| props.timestamp?.genTime
+	|| policy.value
+	|| hashAlgorithm.value
+	|| serialNumber.value),
+)
+
+const toggleAriaLabel = computed(() =>
+	open.value
+		? t('libresign', 'Collapse timestamp authority details')
+		: t('libresign', 'Expand timestamp authority details'),
+)
+
+function dateFromSqlAnsi(date?: string | number | null) {
+	if (!date) return ''
+	return Moment(String(date)).format('LLL')
+}
+
+defineExpose({
+	open,
+	authority,
+	policy,
+	hashAlgorithm,
+	serialNumber,
+	hasContent,
+	toggleAriaLabel,
+	dateFromSqlAnsi,
+})
+</script>
+
+<style scoped lang="scss">
+.timestamp-wrapper {
+	padding-left: 44px;
+}
+
+.timestamp-item {
+	padding: 0;
+}
+
+.timestamp-details {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	width: 100%;
+	margin: 0;
+	padding: 4px 0;
+	list-style: none;
+}
+
+.timestamp-field {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 4px;
+	line-height: 1.5;
+	word-break: break-word;
+
+	dt {
+		font-weight: bold;
+		min-width: 120px;
+		text-align: right;
+		margin: 0;
+		padding: 0;
+	}
+
+	dd {
+		margin: 0;
+		padding: 0;
+		word-break: break-all;
+	}
+}
+
+.extra {
+	padding-left: 44px;
+	background-color: var(--color-background-hover);
+
+	:deep(.list-item-content__name) {
+		white-space: normal;
+		line-height: 1.4;
+	}
+}
+
+.extra-chain {
+	padding-left: 48px;
+
+	:deep(.list-item) {
+		--list-item-height: auto;
+	}
+
+	:deep(.list-item-content__name) {
+		white-space: normal !important;
+		overflow: visible !important;
+		text-overflow: clip !important;
+	}
+}
+</style>

--- a/src/tests/components/validation/SignerDetails.spec.ts
+++ b/src/tests/components/validation/SignerDetails.spec.ts
@@ -6,6 +6,10 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
 import SignerDetails from '../../../components/validation/SignerDetails.vue'
+import {
+	mdiCheckCircle,
+	mdiCloseCircle,
+} from '@mdi/js'
 
 describe('SignerDetails.vue - Business Logic', () => {
 	type SignerDetailsProps = {
@@ -350,6 +354,52 @@ describe('SignerDetails.vue - Business Logic', () => {
 		it('returns icon-warning for unknown status', () => {
 			const signer = { crl_validation: 'unknown_status' }
 			expect(wrapper.vm.getCrlValidationIconClass(signer)).toBe('icon-warning')
+		})
+	})
+
+	describe('getCrlValidationIconPath method', () => {
+		it('returns mdiCloseCircle when revoked before signing', () => {
+			const signer = {
+				crl_validation: 'revoked',
+				crl_revoked_at: '2024-05-01T00:00:00Z',
+				signed: '2024-06-01T00:00:00Z',
+			}
+			expect(wrapper.vm.getCrlValidationIconPath(signer)).toBe(mdiCloseCircle)
+		})
+
+		it('returns mdiCheckCircle when revoked after signing', () => {
+			const signer = {
+				crl_validation: 'revoked',
+				crl_revoked_at: '2024-07-01T00:00:00Z',
+				signed: '2024-06-01T00:00:00Z',
+			}
+			expect(wrapper.vm.getCrlValidationIconPath(signer)).toBe(mdiCheckCircle)
+		})
+	})
+
+	describe('getCrlStatusText method', () => {
+		it('shows valid-at-signing message with revocation date when revoked after signing', () => {
+			const signer = {
+				crl_validation: 'revoked',
+				crl_revoked_at: '2024-07-01T00:00:00Z',
+				signed: '2024-06-01T00:00:00Z',
+			}
+
+			const text = wrapper.vm.getCrlStatusText(signer)
+			expect(text).toContain('Valid at signing time')
+			expect(text).toContain('revocation date:')
+		})
+
+		it('shows revoked-before-signing message with revocation date when revoked before signing', () => {
+			const signer = {
+				crl_validation: 'revoked',
+				crl_revoked_at: '2024-05-01T00:00:00Z',
+				signed: '2024-06-01T00:00:00Z',
+			}
+
+			const text = wrapper.vm.getCrlStatusText(signer)
+			expect(text).toContain('Certificate revoked before signing')
+			expect(text).toContain('revocation date:')
 		})
 	})
 

--- a/src/tests/components/validation/SignerTimestamp.spec.ts
+++ b/src/tests/components/validation/SignerTimestamp.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+
+type SignerTimestampComponent = typeof import('../../../components/validation/SignerTimestamp.vue').default
+
+type SignerTimestampData = {
+	genTime?: string
+	policy?: string
+	policyName?: string
+	hash?: string
+	hashAlgorithm?: string
+	serialNumber?: string | number
+	authority?: string
+	tsaName?: string
+	cnHints?: { commonName?: string }
+}
+
+type SignerTimestampVm = {
+	open: boolean
+	authority: string
+	policy: string
+	hashAlgorithm: string
+	serialNumber: string
+	hasContent: boolean
+	toggleAriaLabel: string
+	$nextTick: () => Promise<void>
+	dateFromSqlAnsi: (date?: string | number | null) => string
+}
+
+type SignerTimestampWrapper = VueWrapper<SignerTimestampVm>
+
+let SignerTimestamp: SignerTimestampComponent
+
+vi.mock('@nextcloud/l10n', () => globalThis.mockNextcloudL10n())
+
+vi.mock('@nextcloud/moment', () => ({
+	default: vi.fn((value: string) => ({
+		format: vi.fn(() => `Formatted: ${value}`),
+	})),
+}))
+
+beforeAll(async () => {
+	;({ default: SignerTimestamp } = await import('../../../components/validation/SignerTimestamp.vue'))
+})
+
+describe('SignerTimestamp', () => {
+	let wrapper!: SignerTimestampWrapper
+
+	const createWrapper = (props: { timestamp?: SignerTimestampData } = {}): SignerTimestampWrapper => {
+		return mount(SignerTimestamp, {
+			props,
+			global: {
+				stubs: {
+					NcListItem: false,
+					NcButton: true,
+					NcIconSvgWrapper: { template: '<div class="icon-stub"></div>' },
+				},
+				mocks: {
+					t: (_app: string, text: string) => text,
+				},
+			},
+		}) as unknown as SignerTimestampWrapper
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('RULE: renders nothing when timestamp has no meaningful content', () => {
+		it('renders nothing when timestamp is undefined', () => {
+			wrapper = createWrapper()
+			expect(wrapper.find('.extra').exists()).toBe(false)
+		})
+
+		it('renders nothing when timestamp is an empty object', () => {
+			wrapper = createWrapper({ timestamp: {} })
+			expect(wrapper.find('.extra').exists()).toBe(false)
+		})
+
+		it('hasContent is false when all fields are absent', () => {
+			wrapper = createWrapper({ timestamp: {} })
+			expect(wrapper.vm.hasContent).toBe(false)
+		})
+	})
+
+	describe('RULE: renders header when any timestamp field is present', () => {
+		it('renders header when authority is provided', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+			expect(wrapper.vm.hasContent).toBe(true)
+		})
+
+		it('renders header when cnHints.commonName is provided', () => {
+			wrapper = createWrapper({ timestamp: { cnHints: { commonName: 'tsa.example.org' } } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when tsaName is provided', () => {
+			wrapper = createWrapper({ timestamp: { tsaName: 'FreeTSA' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when genTime is provided', () => {
+			wrapper = createWrapper({ timestamp: { genTime: '2026-04-25T18:36:28+00:00' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when policyName is provided', () => {
+			wrapper = createWrapper({ timestamp: { policyName: '1.2.3.4.1' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when hashAlgorithm is provided', () => {
+			wrapper = createWrapper({ timestamp: { hashAlgorithm: 'SHA-256' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when serialNumber is a string', () => {
+			wrapper = createWrapper({ timestamp: { serialNumber: 'AABB' } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+
+		it('renders header when serialNumber is a number', () => {
+			wrapper = createWrapper({ timestamp: { serialNumber: 42 } })
+			expect(wrapper.find('.extra').exists()).toBe(true)
+		})
+	})
+
+	describe('RULE: details panel is hidden by default and toggles on click', () => {
+		it('initializes with closed state', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.vm.open).toBe(false)
+		})
+
+		it('does not render detail panel when closed', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.find('.timestamp-wrapper').exists()).toBe(false)
+		})
+
+		it('renders detail panel when open', async () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.timestamp-wrapper').exists()).toBe(true)
+		})
+
+		it('toggles open state', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			wrapper.vm.open = true
+			expect(wrapper.vm.open).toBe(true)
+			wrapper.vm.open = false
+			expect(wrapper.vm.open).toBe(false)
+		})
+	})
+
+	describe('RULE: authority resolves with priority cnHints > authority > tsaName', () => {
+		it('prefers cnHints.commonName over authority and tsaName', () => {
+			wrapper = createWrapper({
+				timestamp: {
+					cnHints: { commonName: 'cn.example.org' },
+					authority: 'auth.example.org',
+					tsaName: 'tsa.example.org',
+				},
+			})
+			expect(wrapper.vm.authority).toBe('cn.example.org')
+		})
+
+		it('falls back to authority when cnHints is absent', () => {
+			wrapper = createWrapper({
+				timestamp: {
+					authority: 'auth.example.org',
+					tsaName: 'tsa.example.org',
+				},
+			})
+			expect(wrapper.vm.authority).toBe('auth.example.org')
+		})
+
+		it('falls back to tsaName when both cnHints and authority are absent', () => {
+			wrapper = createWrapper({ timestamp: { tsaName: 'tsa.example.org' } })
+			expect(wrapper.vm.authority).toBe('tsa.example.org')
+		})
+
+		it('returns empty string when no authority field is present', () => {
+			wrapper = createWrapper({ timestamp: { genTime: '2026-01-01T00:00:00Z' } })
+			expect(wrapper.vm.authority).toBe('')
+		})
+	})
+
+	describe('RULE: policy resolves policyName before policy', () => {
+		it('prefers policyName over policy', () => {
+			wrapper = createWrapper({ timestamp: { policyName: 'named-policy', policy: 'raw-policy' } })
+			expect(wrapper.vm.policy).toBe('named-policy')
+		})
+
+		it('falls back to policy when policyName is absent', () => {
+			wrapper = createWrapper({ timestamp: { policy: 'raw-policy' } })
+			expect(wrapper.vm.policy).toBe('raw-policy')
+		})
+
+		it('returns empty string when neither is present', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.vm.policy).toBe('')
+		})
+	})
+
+	describe('RULE: hashAlgorithm resolves hashAlgorithm before hash', () => {
+		it('prefers hashAlgorithm over hash', () => {
+			wrapper = createWrapper({ timestamp: { hashAlgorithm: 'SHA-256', hash: 'SHA-1' } })
+			expect(wrapper.vm.hashAlgorithm).toBe('SHA-256')
+		})
+
+		it('falls back to hash when hashAlgorithm is absent', () => {
+			wrapper = createWrapper({ timestamp: { hash: 'SHA-1' } })
+			expect(wrapper.vm.hashAlgorithm).toBe('SHA-1')
+		})
+	})
+
+	describe('RULE: serialNumber is coerced to string', () => {
+		it('returns string serial as-is', () => {
+			wrapper = createWrapper({ timestamp: { serialNumber: 'AABB' } })
+			expect(wrapper.vm.serialNumber).toBe('AABB')
+		})
+
+		it('converts numeric serial to string', () => {
+			wrapper = createWrapper({ timestamp: { serialNumber: 42 } })
+			expect(wrapper.vm.serialNumber).toBe('42')
+		})
+
+		it('returns empty string when serialNumber is absent', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.vm.serialNumber).toBe('')
+		})
+	})
+
+	describe('RULE: toggleAriaLabel reflects open state', () => {
+		it('shows "Expand" label when closed', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.vm.toggleAriaLabel).toBe('Expand timestamp authority details')
+		})
+
+		it('shows "Collapse" label when open', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			wrapper.vm.open = true
+			expect(wrapper.vm.toggleAriaLabel).toBe('Collapse timestamp authority details')
+		})
+	})
+
+	describe('RULE: detail fields render when open and data is present', () => {
+		const fullTimestamp: SignerTimestampData = {
+			cnHints: { commonName: 'tsa.example.org' },
+			genTime: '2026-04-25T18:36:28+00:00',
+			policyName: '1.2.3.4.1',
+			hashAlgorithm: 'SHA-256',
+			serialNumber: '01AB',
+		}
+
+		it('renders authority field', async () => {
+			wrapper = createWrapper({ timestamp: fullTimestamp })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.timestamp-wrapper').text()).toContain('tsa.example.org')
+		})
+
+		it('renders policy field', async () => {
+			wrapper = createWrapper({ timestamp: fullTimestamp })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.timestamp-wrapper').text()).toContain('1.2.3.4.1')
+		})
+
+		it('renders hashAlgorithm field', async () => {
+			wrapper = createWrapper({ timestamp: fullTimestamp })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.timestamp-wrapper').text()).toContain('SHA-256')
+		})
+
+		it('renders serialNumber field', async () => {
+			wrapper = createWrapper({ timestamp: fullTimestamp })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.timestamp-wrapper').text()).toContain('01AB')
+		})
+
+		it('does not render absent optional fields', async () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			wrapper.vm.open = true
+			await wrapper.vm.$nextTick()
+			const fields = wrapper.findAll('.timestamp-field')
+			expect(fields).toHaveLength(1)
+		})
+	})
+
+	describe('RULE: dateFromSqlAnsi formats dates via Moment', () => {
+		it('returns empty string for falsy input', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			expect(wrapper.vm.dateFromSqlAnsi(null)).toBe('')
+			expect(wrapper.vm.dateFromSqlAnsi(undefined)).toBe('')
+			expect(wrapper.vm.dateFromSqlAnsi('')).toBe('')
+		})
+
+		it('formats a valid date string', () => {
+			wrapper = createWrapper({ timestamp: { authority: 'tsa.example.org' } })
+			const result = wrapper.vm.dateFromSqlAnsi('2026-04-25T18:36:28+00:00')
+			expect(result).toContain('Formatted:')
+		})
+	})
+})

--- a/src/tests/services/validationDocument.spec.ts
+++ b/src/tests/services/validationDocument.spec.ts
@@ -204,6 +204,33 @@ describe('validationDocument', () => {
 		expect(Object.prototype.hasOwnProperty.call(normalized?.signers[0] ?? {}, 'email')).toBe(false)
 	})
 
+	it('rejects payload when technical timestamp entry is mixed into signers array', () => {
+		const normalized = toValidationDocument(createValidationPayload({
+			signers: [
+				createSigner({
+					signRequestId: 638,
+					displayName: 'Daiane Alves',
+					email: null,
+					status: SIGN_REQUEST_STATUS.SIGNED,
+					statusText: 'Signed',
+					request_sign_date: '2026-04-25T18:35:29+00:00',
+				}),
+				{
+					status: SIGN_REQUEST_STATUS.SIGNED,
+					statusText: 'Signed',
+					signed: '2026-04-25T18:36:28+00:00',
+					timestamp: {
+						genTime: '2026-04-25T18:36:28+00:00',
+						policy: '1.2.3.4.1',
+					},
+					chain: [],
+				},
+			],
+		}))
+
+		expect(normalized).toBeNull()
+	})
+
 	it.each([
 		['status null', { status: null }],
 		['status outside allowed values', { status: 99 }],

--- a/tests/php/Unit/Listener/RevokeClickToSignCertificateListenerTest.php
+++ b/tests/php/Unit/Listener/RevokeClickToSignCertificateListenerTest.php
@@ -86,7 +86,9 @@ class RevokeClickToSignCertificateListenerTest extends TestCase {
 				$serialNumber,
 				CRLReason::SUPERSEDED,
 				$this->anything(),
-				$this->anything()
+				$this->anything(),
+				null,
+				$this->isInstanceOf(\DateTime::class),
 			)
 			->willReturn(true);
 
@@ -102,7 +104,9 @@ class RevokeClickToSignCertificateListenerTest extends TestCase {
 				$this->anything(),
 				$this->anything(),
 				$this->anything(),
-				'system'
+				'system',
+				null,
+				$this->isInstanceOf(\DateTime::class),
 			)
 			->willReturn(true);
 
@@ -122,7 +126,9 @@ class RevokeClickToSignCertificateListenerTest extends TestCase {
 					$this->stringContains('click-to-sign'),
 					$this->stringContains('revoked after document signing')
 				),
-				$this->anything()
+				$this->anything(),
+				null,
+				$this->isInstanceOf(\DateTime::class),
 			)
 			->willReturn(true);
 
@@ -153,6 +159,31 @@ class RevokeClickToSignCertificateListenerTest extends TestCase {
 				'Successfully revoked click-to-sign certificate',
 				$this->callback(fn ($ctx) => $ctx['serial'] === $serialNumber && isset($ctx['signRequestId']))
 			);
+
+		$this->listener->handle($event);
+	}
+
+	public function testRevocationDateIsSetAtLeastOneSecondInFutureToAvoidTimestampTie(): void {
+		$event = $this->createSignedEvent(true, 'OFFSET_123');
+		$beforeCall = new \DateTime();
+
+		$this->crlService->expects($this->once())
+			->method('revokeCertificate')
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				null,
+				$this->callback(function ($revokedAt) use ($beforeCall): bool {
+					if (!($revokedAt instanceof \DateTime)) {
+						return false;
+					}
+					$delta = $revokedAt->getTimestamp() - $beforeCall->getTimestamp();
+					return $delta >= 1;
+				})
+			)
+			->willReturn(true);
 
 		$this->listener->handle($event);
 	}

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -282,7 +282,8 @@ class CrlServiceTest extends TestCase {
 				$reasonText,
 				$revokedBy,
 				null,
-				5
+				5,
+				null,
 			);
 
 		$result = $this->service->revokeCertificate($serialNumber, $reason, $reasonText, $revokedBy);

--- a/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service\File;
+
+use DateTime;
+use OCA\Libresign\Service\File\CertificateSignersMergeService;
+use OCA\Libresign\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class CertificateSignersMergeServiceTest extends TestCase {
+	private function getService(): CertificateSignersMergeService {
+		return new CertificateSignersMergeService();
+	}
+
+	public function testMergeSkipsUnmatchedTsaSignerWhenContractSignerExists(): void {
+		$fileData = new \stdClass();
+		$fileData->signers = [
+			(object)[
+				'signRequestId' => 1,
+				'uid' => 'whatsapp:+5500000000',
+				'displayName' => 'Contract Signer',
+			],
+		];
+
+		$certData = [
+			[
+				'chain' => [
+					[
+						'subject' => [
+							'UID' => 'whatsapp:+5500000000',
+							'CN' => 'Contract Signer',
+						],
+					],
+				],
+			],
+			[
+				'timestamp' => [
+					'genTime' => new DateTime('2026-04-25T18:36:28Z'),
+				],
+				'chain' => [
+					[
+						'subject' => ['CN' => 'www.freetsa.org'],
+					],
+				],
+			],
+		];
+
+		$this->getService()->merge(
+			$fileData,
+			$certData,
+			'example.com',
+			'Signed',
+			fn (array $cert, string $host): ?string => $cert['subject']['UID'] ?? null,
+			fn (string $method, string $value): string => $method . ':' . $value,
+			fn (string $accountId): ?string => null,
+		);
+
+		$this->assertCount(1, $fileData->signers);
+		$this->assertArrayHasKey('timestamp', (array)$fileData->signers[0]);
+		$this->assertSame('2026-04-25T18:36:28+00:00', $fileData->signers[0]->timestamp['genTime']);
+		$this->assertObjectNotHasProperty('tsa', $fileData);
+	}
+
+	#[DataProvider('providerDisplayNameResolution')]
+	public function testMergeResolvesDisplayNameForAccountUid(?string $accountDisplayName, string $expected): void {
+		$fileData = new \stdClass();
+
+		$certData = [
+			[
+				'uid' => 'account:admin',
+				'chain' => [
+					[
+						'name' => 'Admin Cert',
+						'subject' => ['CN' => 'admin'],
+					],
+				],
+			],
+		];
+
+		$this->getService()->merge(
+			$fileData,
+			$certData,
+			'example.com',
+			'Signed',
+			fn (array $cert, string $host): ?string => null,
+			fn (string $method, string $value): string => $method . ':' . $value,
+			fn (string $accountId): ?string => $accountDisplayName,
+		);
+
+		$this->assertSame($expected, $fileData->signers[0]->displayName);
+	}
+
+	public static function providerDisplayNameResolution(): array {
+		return [
+			'display name from lookup' => ['Admin User', 'Admin User'],
+			'fallback to account id' => [null, 'admin'],
+		];
+	}
+
+	#[DataProvider('providerCertificateInfoMatching')]
+	public function testMergeMatchesExistingSignerByCertificateInfo(string $certificateField, string $value): void {
+		$fileData = new \stdClass();
+		$fileData->signers = [
+			(object)[
+				'signRequestId' => 88,
+				'uid' => 'account:existing',
+				'displayName' => 'Existing Display Name',
+				'metadata' => [
+					'certificate_info' => [
+						$certificateField => $value,
+					],
+				],
+			],
+		];
+
+		$certData = [
+			[
+				'chain' => [
+					[
+						$certificateField => $value,
+						'subject' => ['CN' => 'Certificate CN'],
+					],
+				],
+			],
+		];
+
+		$this->getService()->merge(
+			$fileData,
+			$certData,
+			'example.com',
+			'Signed',
+			fn (array $cert, string $host): ?string => 'resolved:uid',
+			fn (string $method, string $rawValue): string => $method . ':' . $rawValue,
+			fn (string $accountId): ?string => 'Overwritten Name',
+		);
+
+		$this->assertCount(1, $fileData->signers);
+		$this->assertSame('account:existing', $fileData->signers[0]->uid);
+		$this->assertSame('Existing Display Name', $fileData->signers[0]->displayName);
+		$this->assertSame(2, $fileData->signers[0]->status);
+	}
+
+	public static function providerCertificateInfoMatching(): array {
+		return [
+			'match by serial number' => ['serialNumber', '1234567890'],
+			'match by serial number hex' => ['serialNumberHex', 'ABCDEF01'],
+			'match by hash' => ['hash', 'deadbeefcafebabe'],
+		];
+	}
+
+	public function testMergeDoesNotExportTopLevelTsaWithTimestampData(): void {
+		$fileData = new \stdClass();
+		$fileData->signers = [];
+
+		$certData = [[
+			'uid' => 'email:signer@example.com',
+			'timestamp' => [
+				'genTime' => new DateTime('2026-01-01T00:00:00Z'),
+				'cnHints' => ['commonName' => 'tsa.example.org'],
+			],
+			'chain' => [[
+				'subject' => ['CN' => 'Signer User'],
+			]],
+		]];
+
+		$this->getService()->merge(
+			$fileData,
+			$certData,
+			'example.com',
+			'Signed',
+			fn (array $cert, string $host): ?string => null,
+			fn (string $method, string $value): string => $method . ':' . $value,
+			fn (string $accountId): ?string => null,
+		);
+
+		$this->assertCount(1, $fileData->signers);
+		$this->assertArrayHasKey('timestamp', (array)$fileData->signers[0]);
+		$this->assertObjectNotHasProperty('tsa', $fileData);
+	}
+}

--- a/tests/php/Unit/Service/File/SignersLoaderTest.php
+++ b/tests/php/Unit/Service/File/SignersLoaderTest.php
@@ -380,6 +380,80 @@ final class SignersLoaderTest extends TestCase {
 		$this->assertTrue(isset($signer->name));
 	}
 
+	public function testLoadSignersFromCertDataDoesNotAppendUnmatchedTsaEntryWhenContractSignersExist(): void {
+		$this->signRequestMapper->method('getTextOfSignerStatus')->willReturn('Signed');
+		$this->identifyMethodService->method('resolveUid')->willReturn('email:external@example.com');
+
+		$fileData = new \stdClass();
+		$fileData->signers = [
+			(object)[
+				'signRequestId' => 638,
+				'uid' => 'whatsapp:+5521976887906',
+				'displayName' => 'Daiane Alves',
+			],
+		];
+
+		$certData = [
+			[
+				'chain' => [
+					[
+						'subject' => [
+							'UID' => 'whatsapp:+5521976887906',
+							'CN' => 'Daiane Alves',
+						],
+					],
+				],
+				'signingTime' => new DateTime('2026-04-25T18:36:27Z'),
+			],
+			[
+				'status' => 2,
+				'statusText' => 'Signed',
+				'timestamp' => [
+					'genTime' => new DateTime('2026-04-25T18:36:28Z'),
+				],
+				'chain' => [
+					[
+						'subject' => [
+							'CN' => 'www.freetsa.org',
+						],
+					],
+				],
+			],
+		];
+
+		$this->getService()->loadSignersFromCertData($fileData, $certData, 'example.com');
+
+		$this->assertCount(1, $fileData->signers);
+		$this->assertSame(638, $fileData->signers[0]->signRequestId);
+		$this->assertSame('Daiane Alves', $fileData->signers[0]->displayName);
+		$this->assertArrayHasKey('timestamp', (array)$fileData->signers[0]);
+		$this->assertSame('2026-04-25T18:36:28+00:00', $fileData->signers[0]->timestamp['genTime']);
+		$this->assertObjectNotHasProperty('tsa', $fileData);
+	}
+
+	public function testLoadSignersFromCertDataDoesNotExportTopLevelTsaWithoutTimestamp(): void {
+		$this->signRequestMapper->method('getTextOfSignerStatus')->willReturn('Signed');
+		$this->identifyMethodService->method('resolveUid')->willReturn('email:signer@example.com');
+
+		$fileData = new \stdClass();
+
+		$certData = [
+			[
+				'chain' => [
+					[
+						'subject' => [
+							'CN' => 'Signer CN',
+						],
+					],
+				],
+			],
+		];
+
+		$this->getService()->loadSignersFromCertData($fileData, $certData, 'example.com');
+
+		$this->assertObjectNotHasProperty('tsa', $fileData);
+	}
+
 	public function testLoadSignersFromCertDataPreventsDuplicateFormattedDates(): void {
 		$this->signRequestMapper->method('getTextOfSignerStatus')->willReturn('Signed');
 		$this->identifyMethodService->expects($this->never())->method('resolveUid');


### PR DESCRIPTION
## Summary
- extract signer timestamp UI into dedicated `SignerTimestamp` component
- simplify CRL status messaging to focus on business outcome (revoked before signing vs valid at signing)
- remove legacy top-level TSA compatibility checks in validation document tests
- introduce `CertificateSignersMergeService` and update `SignersLoader` to delegate merge logic
- support optional revocation timestamp override in CRL mapper/service
- offset click-to-sign automatic revocation timestamp by +1 second to avoid tie with signing time

## Commit Strategy
- one signed-off commit per file (`-s`), as requested

## Tests
- `npx vitest run src/tests/components/validation/SignerDetails.spec.ts src/tests/components/validation/SignerTimestamp.spec.ts src/tests/services/validationDocument.spec.ts`
- `composer test:unit -- --filter 'RevokeClickToSignCertificateListenerTest|CrlServiceTest|SignersLoaderTest|CertificateSignersMergeServiceTest'`
- `npm run ts:check`
