### PR TITLE
fix: support Twig date filter for ServerSignatureDate in JSign

### DIFF
--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -582,10 +582,35 @@ class JSignPdfHandler extends Pkcs12Handler {
 	private function parseSignatureText(): array {
 		if (!$this->parsedSignatureText) {
 			$params = $this->getSignatureParams();
-			$params['ServerSignatureDate'] = '${timestamp}';
+			$template = $this->signatureTextService->getTemplate();
+			$params['ServerSignatureDate'] = $this->shouldUseJSignTimestampPlaceholder($template)
+				? '${timestamp}'
+				: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+					->format(\DateTimeInterface::ATOM);
 			$this->parsedSignatureText = $this->signatureTextService->parse(context: $params);
 		}
 		return $this->parsedSignatureText;
+	}
+
+	private function shouldUseJSignTimestampPlaceholder(string $template): bool {
+		if (!preg_match_all('/{{\s*(.*?)\s*}}/s', $template, $matches)) {
+			return true;
+		}
+
+		$hasPlainServerSignatureDate = false;
+		foreach ($matches[1] as $expression) {
+			if (!str_contains($expression, 'ServerSignatureDate')) {
+				continue;
+			}
+			if (trim($expression) === 'ServerSignatureDate') {
+				$hasPlainServerSignatureDate = true;
+				continue;
+			}
+			// Any transformation (for example Twig date filter) requires a real date value.
+			return false;
+		}
+
+		return $hasPlainServerSignatureDate;
 	}
 
 	public function getSignatureText(): string {

--- a/lib/Handler/SignEngine/PhpNativeHandler.php
+++ b/lib/Handler/SignEngine/PhpNativeHandler.php
@@ -267,9 +267,8 @@ class PhpNativeHandler extends Pkcs12Handler {
 		}
 
 		$params = $this->getSignatureParams();
-		$serverTimezone = new \DateTimeZone(date_default_timezone_get());
-		$now = new \DateTime('now', $serverTimezone);
-		$params['ServerSignatureDate'] = $now->format('Y.m.d H:i:s \U\T\C');
+		$params['ServerSignatureDate'] = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+			->format(\DateTimeInterface::ATOM);
 
 		$textData = $this->signatureTextService->parse(context: $params);
 		$parsed = trim((string)($textData['parsed'] ?? ''));

--- a/lib/Service/SignatureTextService.php
+++ b/lib/Service/SignatureTextService.php
@@ -185,7 +185,7 @@ class SignatureTextService {
 			'{{LocalSignerSignatureDateOnly}}' => $this->l10n->t('Date when the signer sent the request to sign (without time, in their local time zone).'),
 			'{{LocalSignerSignatureDateTime}}' => $this->l10n->t('Date and time when the signer sent the request to sign (in their local time zone).'),
 			'{{LocalSignerTimezone}}' => $this->l10n->t('Time zone of signer when sent the request to sign (in their local time zone).'),
-			'{{ServerSignatureDate}}' => $this->l10n->t('Date and time when the signature was applied on the server. Cannot be formatted using Twig.'),
+			'{{ServerSignatureDate}}' => $this->l10n->t('Date and time when the signature was applied on the server (ISO 8601 format). Can be formatted using the Twig date filter.'),
 			'{{SignerCommonName}}' => $this->l10n->t('Common Name (CN) used to identify the document signer.'),
 			'{{SignerEmail}}' => $this->l10n->t('The signer\'s email is optional and can be left blank.'),
 			'{{SignerIdentifier}}' => $this->l10n->t('Unique information used to identify the signer (such as email, phone number, or username).'),

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -733,6 +733,34 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertMatchesRegularExpression('/^"\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2} [A-Z]{3,4}"$/', $actual);
 	}
 
+	public function testGetSignatureTextWithTwigDateFilterWithoutTimezone(): void {
+		$this->appConfig->setValueString(
+			'libresign',
+			'signature_text_template',
+			'{{ ServerSignatureDate|date("d/m/Y") }}'
+		);
+		$this->appConfig->setValueString('libresign', 'signature_render_mode', SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY);
+
+		$jSignPdfHandler = $this->getInstance();
+		$actual = $jSignPdfHandler->getSignatureText();
+
+		$this->assertMatchesRegularExpression('/^"\d{2}\/\d{2}\/\d{4}"$/', $actual);
+	}
+
+	public function testGetSignatureTextGraphicOnlyWithTwigDateFilterAlwaysReturnsEmpty(): void {
+		$this->appConfig->setValueString(
+			'libresign',
+			'signature_text_template',
+			'{{ ServerSignatureDate|date("d/m/Y H:i:s T", "Europe/Paris") }}'
+		);
+		$this->appConfig->setValueString('libresign', 'signature_render_mode', SignerElementsService::RENDER_MODE_GRAPHIC_ONLY);
+
+		$jSignPdfHandler = $this->getInstance();
+		$actual = $jSignPdfHandler->getSignatureText();
+
+		$this->assertSame('""', $actual);
+	}
+
 	public static function providerGetSignatureText(): array {
 		return [
 			['FAKE_RENDER_MODE', '',     '""'],
@@ -740,7 +768,10 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			['FAKE_RENDER_MODE', "a\na", "\"a\na\""],
 			['FAKE_RENDER_MODE', 'a"a',  '"a\"a"'],
 			['FAKE_RENDER_MODE', 'a$a',  '"a\$a"'],
+			// Plain {{ServerSignatureDate}} (no spaces) preserves JSign placeholder
 			['FAKE_RENDER_MODE', '{{ServerSignatureDate}}', '"\${timestamp}"'],
+			// Plain {{ ServerSignatureDate }} (with spaces) also preserves JSign placeholder
+			['FAKE_RENDER_MODE', '{{ ServerSignatureDate }}', '"\${timestamp}"'],
 			['GRAPHIC_ONLY',     '',     '""'],
 			['GRAPHIC_ONLY',     'a',    '""'],
 			['GRAPHIC_ONLY',     "a\na", '""'],

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -719,6 +719,20 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	public function testGetSignatureTextWithTwigDateFilterAndTimezone(): void {
+		$this->appConfig->setValueString(
+			'libresign',
+			'signature_text_template',
+			'{{ ServerSignatureDate|date("d/m/Y H:i:s T", "Europe/Paris") }}'
+		);
+		$this->appConfig->setValueString('libresign', 'signature_render_mode', SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY);
+
+		$jSignPdfHandler = $this->getInstance();
+		$actual = $jSignPdfHandler->getSignatureText();
+
+		$this->assertMatchesRegularExpression('/^"\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2} [A-Z]{3,4}"$/', $actual);
+	}
+
 	public static function providerGetSignatureText(): array {
 		return [
 			['FAKE_RENDER_MODE', '',     '""'],
@@ -726,6 +740,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			['FAKE_RENDER_MODE', "a\na", "\"a\na\""],
 			['FAKE_RENDER_MODE', 'a"a',  '"a\"a"'],
 			['FAKE_RENDER_MODE', 'a$a',  '"a\$a"'],
+			['FAKE_RENDER_MODE', '{{ServerSignatureDate}}', '"\${timestamp}"'],
 			['GRAPHIC_ONLY',     '',     '""'],
 			['GRAPHIC_ONLY',     'a',    '""'],
 			['GRAPHIC_ONLY',     "a\na", '""'],

--- a/tests/php/Unit/Handler/SignEngine/PhpNativeHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/PhpNativeHandlerTest.php
@@ -420,6 +420,47 @@ final class PhpNativeHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertStringNotContainsString('() Tj', $xObject->stream);
 	}
 
+	/**
+	 * Regression: ServerSignatureDate must be passed to signatureTextService->parse()
+	 * as a valid ISO 8601 (ATOM) string so that Twig's |date() filter can parse it.
+	 * Before the fix the value was "Y.m.d H:i:s UTC" which Twig's date filter
+	 * would fail to parse reliably across PHP versions.
+	 */
+	public function testBuildXObjectPassesAtomFormatServerSignatureDateToParseContext(): void {
+		$capturedContext = null;
+
+		$signatureTextService = $this->createMock(SignatureTextService::class);
+		$signatureTextService->method('getRenderMode')
+			->willReturn(SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY);
+		$signatureTextService->method('parse')
+			->willReturnCallback(function (string $template = '', array $context = []) use (&$capturedContext): array {
+				$capturedContext = $context;
+				return ['parsed' => 'Signed by', 'templateFontSize' => 10.0];
+			});
+		$signatureTextService->method('getTemplateFontSize')->willReturn(10.0);
+		$signatureTextService->method('getSignatureFontSize')->willReturn(20.0);
+
+		$handler = new PhpNativeHandler(
+			$this->appConfig,
+			$this->docMdpConfigService,
+			$signatureTextService,
+			$this->signatureBackgroundService,
+			$this->certificateEngineFactory,
+		);
+
+		$this->callPrivateMethod($handler, 'buildXObject', 100, 50, SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY);
+
+		$this->assertArrayHasKey('ServerSignatureDate', $capturedContext);
+		$serverSignatureDate = $capturedContext['ServerSignatureDate'];
+
+		// Must be parseable as a valid date by PHP (required for Twig |date() filter)
+		$parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $serverSignatureDate);
+		$this->assertNotFalse(
+			$parsed,
+			"ServerSignatureDate must be a valid ATOM/ISO 8601 string, got: {$serverSignatureDate}"
+		);
+	}
+
 	private function getHandler(): PhpNativeHandler {
 		return $this->getHandlerWithMode(SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY);
 	}


### PR DESCRIPTION
## Summary
Fixes signing failures when `ServerSignatureDate` is transformed in Twig templates (for example `|date("d/m/Y H:i:s T", "Europe/Paris")`) while preserving the existing `${timestamp}` behavior for plain templates.

## What changed
- `JSignPdfHandler::parseSignatureText()` now chooses the source of `ServerSignatureDate` based on template usage:
  - keeps `${timestamp}` when template uses plain `{{ServerSignatureDate}}`
  - uses real ISO timestamp when template applies Twig transformations (e.g. filters)
- Added regression test for Twig `date` filter with timezone.
- Added compatibility assertion ensuring plain `{{ServerSignatureDate}}` still renders to JSign placeholder (`${timestamp}`).

## Why
Issue #7619 reproduces only during signing because JSign path previously fed `${timestamp}` into Twig parsing. This works for plain interpolation but breaks when Twig tries to format it as a date.

## Validation
- `composer test:unit -- --filter "JSignPdfHandlerTest::testGetSignatureText"`
- `composer test:unit -- --filter "JSignPdfHandlerTest::testGetSignatureTextWithTwigDateFilterAndTimezone"`

Ref #7619