### PR TITLE
fix: expose ValidationURL and qrcode in signature stamp templates

### DIFF
--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -929,15 +929,29 @@ class SignFileService {
 	private function buildBaseSignatureParams(array $certificateData): array {
 		$issuerCommonName = $this->normalizeCertificateFieldToString($certificateData['issuer']['CN'] ?? '');
 		$signerCommonName = $this->normalizeCertificateFieldToString($certificateData['subject']['CN'] ?? '');
+		$documentUuid = $this->libreSignFile?->getUuid() ?? '';
+		$validationUrl = $documentUuid ? $this->buildValidationUrl($documentUuid) : '';
 
 		return [
-			'DocumentUUID' => $this->libreSignFile?->getUuid(),
+			'DocumentUUID' => $documentUuid,
 			'IssuerCommonName' => $issuerCommonName,
 			'SignerCommonName' => $signerCommonName,
 			'LocalSignerTimezone' => $this->dateTimeZone->getTimeZone()->getName(),
+			'ValidationURL' => $validationUrl,
 			'LocalSignerSignatureDateTime' => (new DateTime('now', new \DateTimeZone('UTC')))
 				->format(DateTimeInterface::ATOM)
 		];
+	}
+
+	private function buildValidationUrl(string $uuid): string {
+		$validationSite = trim($this->appConfig->getValueString(Application::APP_ID, 'validation_site', ''));
+		if ($validationSite !== '') {
+			return rtrim($validationSite, '/') . '/' . $uuid;
+		}
+
+		return $this->urlGenerator->linkToRouteAbsolute('libresign.page.validationFileWithShortUrl', [
+			'uuid' => $uuid,
+		]);
 	}
 
 	private function normalizeCertificateFieldToString(mixed $value): string {

--- a/lib/Service/SignatureTextService.php
+++ b/lib/Service/SignatureTextService.php
@@ -15,6 +15,12 @@ use ImagickDraw;
 use ImagickPixel;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Vendor\Endroid\QrCode\Color\Color;
+use OCA\Libresign\Vendor\Endroid\QrCode\Encoding\Encoding;
+use OCA\Libresign\Vendor\Endroid\QrCode\ErrorCorrectionLevel;
+use OCA\Libresign\Vendor\Endroid\QrCode\QrCode;
+use OCA\Libresign\Vendor\Endroid\QrCode\RoundBlockSizeMode;
+use OCA\Libresign\Vendor\Endroid\QrCode\Writer\PngWriter;
 use OCA\Libresign\Vendor\Twig\Environment;
 use OCA\Libresign\Vendor\Twig\Error\SyntaxError;
 use OCA\Libresign\Vendor\Twig\Loader\FilesystemLoader;
@@ -22,6 +28,7 @@ use OCP\IAppConfig;
 use OCP\IDateTimeZone;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\UUIDUtil;
@@ -34,12 +41,14 @@ class SignatureTextService {
 	public const FRONT_SIZE_MAX = 30;
 	public const DEFAULT_SIGNATURE_WIDTH = 350;
 	public const DEFAULT_SIGNATURE_HEIGHT = 100;
+	private const QRCODE_SIZE = 100;
 	public function __construct(
 		private IAppConfig $appConfig,
 		private IL10N $l10n,
 		private IDateTimeZone $dateTimeZone,
 		private IRequest $request,
 		private IUserSession $userSession,
+		private IURLGenerator $urlGenerator,
 		protected LoggerInterface $logger,
 	) {
 	}
@@ -137,8 +146,10 @@ class SignatureTextService {
 		}
 		if (empty($context)) {
 			$date = new \DateTime('now', new \DateTimeZone('UTC'));
+			$documentUuid = UUIDUtil::getUUID();
+			$validationUrl = $this->buildValidationUrl($documentUuid);
 			$context = [
-				'DocumentUUID' => UUIDUtil::getUUID(),
+				'DocumentUUID' => $documentUuid,
 				'IssuerCommonName' => 'Acme Cooperative',
 				'LocalSignerSignatureDateOnly' => ($date)->format('Y-m-d'),
 				'LocalSignerSignatureDateTime' => ($date)->format(DateTimeInterface::ATOM),
@@ -148,7 +159,16 @@ class SignatureTextService {
 				'SignerCommonName' => $this->userSession?->getUser()?->getDisplayName() ?? 'John Doe',
 				'SignerEmail' => $this->userSession?->getUser()?->getEMailAddress() ?? 'john.doe@libresign.coop',
 				'SignerUserAgent' => $this->request->getHeader('User-Agent'),
+				'ValidationURL' => $validationUrl,
+				'qrcode' => $this->getQrCodeImageBase64($validationUrl),
 			];
+		}
+
+		if (!isset($context['ValidationURL']) && isset($context['DocumentUUID']) && is_string($context['DocumentUUID']) && $context['DocumentUUID'] !== '') {
+			$context['ValidationURL'] = $this->buildValidationUrl($context['DocumentUUID']);
+		}
+		if (!isset($context['qrcode']) && isset($context['ValidationURL']) && is_string($context['ValidationURL'])) {
+			$context['qrcode'] = $this->getQrCodeImageBase64($context['ValidationURL']);
 		}
 		try {
 			$twigEnvironment = new Environment(
@@ -189,6 +209,13 @@ class SignatureTextService {
 			'{{SignerCommonName}}' => $this->l10n->t('Common Name (CN) used to identify the document signer.'),
 			'{{SignerEmail}}' => $this->l10n->t('The signer\'s email is optional and can be left blank.'),
 			'{{SignerIdentifier}}' => $this->l10n->t('Unique information used to identify the signer (such as email, phone number, or username).'),
+			'{{ValidationURL}}' => $this->l10n->t('Validation URL of the signed document.'),
+			// TRANSLATORS This sentence is a description shown in the list of
+			// available template variables.
+			// Keep placeholder names unchanged: {{ qrcode }} and {{ValidationURL}}.
+			// Keep this HTML snippet unchanged:
+			// <img src="data:image/png;base64,{{ qrcode }}">
+			'{{qrcode}}' => $this->l10n->t('Base64-encoded PNG QR code for the validation URL. In HTML/Twig, use <img src="data:image/png;base64,{{ qrcode }}">. In plain-text templates, use {{ValidationURL}}.'),
 		];
 		$collectMetadata = $this->appConfig->getValueBool(Application::APP_ID, 'collect_metadata', false);
 		if ($collectMetadata) {
@@ -196,6 +223,24 @@ class SignatureTextService {
 			$list['{{SignerUserAgent}}'] = $this->l10n->t('Browser and device information of the person who signed the document.');
 		}
 		return $list;
+	}
+
+	private function getQrCodeImageBase64(string $text): string {
+		$qrCode = new QrCode(
+			data: $text,
+			encoding: new Encoding('UTF-8'),
+			errorCorrectionLevel: ErrorCorrectionLevel::Low,
+			size: self::QRCODE_SIZE,
+			margin: 4,
+			roundBlockSizeMode: RoundBlockSizeMode::Margin,
+			foregroundColor: new Color(0, 0, 0),
+			backgroundColor: new Color(255, 255, 255)
+		);
+
+		$writer = new PngWriter();
+		$result = $writer->write($qrCode);
+
+		return base64_encode($result->getString());
 	}
 
 	public function signerNameImage(
@@ -505,5 +550,16 @@ class SignatureTextService {
 
 	public function isEnabled(): bool {
 		return !empty($this->getTemplate());
+	}
+
+	private function buildValidationUrl(string $uuid): string {
+		$validationSite = trim($this->appConfig->getValueString(Application::APP_ID, 'validation_site', ''));
+		if ($validationSite !== '') {
+			return rtrim($validationSite, '/') . '/' . $uuid;
+		}
+
+		return $this->urlGenerator->linkToRouteAbsolute('libresign.page.validationFileWithShortUrl', [
+			'uuid' => $uuid,
+		]);
 	}
 }

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -26,6 +26,7 @@ use OCP\IAppConfig;
 use OCP\IDateTimeZone;
 use OCP\IRequest;
 use OCP\ITempManager;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\L10N\IFactory as IL10NFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -74,12 +75,18 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	private function getInstance(array $methods = []): JSignPdfHandler|MockObject {
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator
+			->method('linkToRouteAbsolute')
+			->willReturnCallback(fn (string $route, array $params): string => 'https://example.test/' . $route . '/' . ($params['uuid'] ?? ''));
+
 		$signatureTextService = new SignatureTextService(
 			$this->appConfig,
 			\OCP\Server::get(IL10NFactory::class)->get(Application::APP_ID),
 			\OCP\Server::get(IDateTimeZone::class),
 			\OCP\Server::get(IRequest::class),
 			\OCP\Server::get(IUserSession::class),
+			$urlGenerator,
 			\OCP\Server::get(LoggerInterface::class),
 		);
 

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -12,6 +12,7 @@ namespace OCA\Libresign\Tests\Unit\Service;
 use bovigo\vfs\vfsStream;
 use DateTime;
 use OC\User\NoUserException;
+use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\BackgroundJob\SignSingleFileJob;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileElement;
@@ -147,6 +148,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->secureRandom = \OCP\Server::get(\OCP\Security\ISecureRandom::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->urlGenerator
+			->method('linkToRouteAbsolute')
+			->willReturnCallback(fn (string $route, array $params): string => 'https://example.test/' . $route . '/' . ($params['uuid'] ?? ''));
 		$this->identifyMethodMapper = $this->createMock(IdentifyMethodMapper::class);
 		$this->tempManager = $this->createMock(ITempManager::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
@@ -1215,9 +1219,37 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertEquals($expectedIssuerCN, $actual['IssuerCommonName']);
 		$this->assertEquals($expectedSignerCN, $actual['SignerCommonName']);
 		$this->assertEquals('uuid', $actual['DocumentUUID']);
+		$this->assertEquals('https://example.test/libresign.page.validationFileWithShortUrl/uuid', $actual['ValidationURL']);
 		$this->assertArrayHasKey('DocumentUUID', $actual);
+		$this->assertArrayHasKey('ValidationURL', $actual);
+		$this->assertArrayNotHasKey('qrcode', $actual);
 		$this->assertArrayHasKey('LocalSignerTimezone', $actual);
 		$this->assertArrayHasKey('LocalSignerSignatureDateTime', $actual);
+	}
+
+	public function testGetSignatureParamsUsesCustomValidationSite(): void {
+		$service = $this->getService(['readCertificate']);
+
+		$this->appConfig->setValueString(Application::APP_ID, 'validation_site', 'https://validator.example/path/');
+
+		$libreSignFile = new \OCA\Libresign\Db\File();
+		$libreSignFile->setUuid('uuid');
+		$service->setLibreSignFile($libreSignFile);
+
+		$service->method('readCertificate')->willReturn([
+			'issuer' => ['CN' => 'LibreCode'],
+			'subject' => ['CN' => 'Jane Doe'],
+		]);
+
+		$signRequest = $this->createSignRequestMock([
+			'getId' => 171,
+			'getMetadata' => [],
+		]);
+		$service->setSignRequest($signRequest);
+
+		$actual = $this->invokePrivate($service, 'getSignatureParams');
+		$this->assertEquals('https://validator.example/path/uuid', $actual['ValidationURL']);
+		$this->assertArrayNotHasKey('qrcode', $actual);
 	}
 
 	public static function providerGetSignatureParamsCommonName(): array {

--- a/tests/php/Unit/Service/SignatureTextServiceTest.php
+++ b/tests/php/Unit/Service/SignatureTextServiceTest.php
@@ -17,6 +17,7 @@ use OCP\IAppConfig;
 use OCP\IDateTimeZone;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\L10N\IFactory as IL10NFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -30,6 +31,7 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 	private IDateTimeZone $dateTimeZone;
 	private IRequest&MockObject $request;
 	private IUserSession&MockObject $userSession;
+	private IURLGenerator&MockObject $urlGenerator;
 	private LoggerInterface&MockObject $logger;
 
 
@@ -39,6 +41,10 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 		$this->dateTimeZone = \OCP\Server::get(IDateTimeZone::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->urlGenerator
+			->method('linkToRouteAbsolute')
+			->willReturnCallback(fn (string $route, array $params): string => 'https://example.test/' . $route . '/' . ($params['uuid'] ?? ''));
 		$this->logger = $this->createMock(LoggerInterface::class);
 	}
 
@@ -49,6 +55,7 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 			$this->dateTimeZone,
 			$this->request,
 			$this->userSession,
+			$this->urlGenerator,
 			$this->logger,
 		);
 		return $this->service;
@@ -60,6 +67,9 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 
 		$actual = $this->getClass()->getAvailableVariables();
 		$this->assertArrayHasKey('{{SignerIP}}', $actual);
+		$this->assertArrayHasKey('{{SignerUserAgent}}', $actual);
+		$this->assertArrayHasKey('{{qrcode}}', $actual);
+		$this->assertArrayHasKey('{{ValidationURL}}', $actual);
 
 		$template = $this->getClass()->getDefaultTemplate();
 		$this->assertStringContainsString('IP', $template);
@@ -71,6 +81,9 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 
 		$actual = $this->getClass()->getAvailableVariables();
 		$this->assertArrayNotHasKey('{{SignerIP}}', $actual);
+		$this->assertArrayNotHasKey('{{SignerUserAgent}}', $actual);
+		$this->assertArrayHasKey('{{qrcode}}', $actual);
+		$this->assertArrayHasKey('{{ValidationURL}}', $actual);
 
 		$template = $this->getClass()->getDefaultTemplate();
 		$this->assertStringNotContainsString('IP', $template);
@@ -128,6 +141,21 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 				"John Doe\n\nsigned the document on 2025-03-31T23:53:47+00:00",
 			],
 		];
+	}
+
+	public function testParseShouldGenerateQrcodeAsBase64FromValidationUrl(): void {
+		$actual = $this->getClass()->parse('{{qrcode}}', [
+			'DocumentUUID' => 'abc-123',
+			'ValidationURL' => 'https://validator.example/abc-123',
+		]);
+
+		$this->assertNotEmpty($actual['parsed']);
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/=]+$/', $actual['parsed']);
+		$this->assertNotEquals('https://validator.example/abc-123', $actual['parsed']);
+
+		$decoded = base64_decode($actual['parsed'], true);
+		$this->assertNotFalse($decoded);
+		$this->assertStringStartsWith("\x89PNG\r\n\x1A\n", $decoded);
 	}
 
 	#[DataProvider('providerSplitAndGetLongestHalfLength')]


### PR DESCRIPTION
## Summary
- add `{{ValidationURL}}` and `{{qrcode}}` to signature stamp available variables
- generate `qrcode` as base64 PNG from `ValidationURL` in stamp parsing context
- include `ValidationURL` in signature params with `validation_site` override support
- update unit tests for `SignatureTextService`, `SignFileService`, and `JSignPdfHandler`

## Validation
- `docker compose exec -u www-data nextcloud bash -lc 'cd apps-extra/libresign && composer test:unit -- --filter "(SignatureTextServiceTest|SignFileServiceTest|JSignPdfHandlerTest)"'`

Ref #7514