### PR TITLE
fix: align OpenAPI file metadata contract with runtime payloads

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -363,6 +363,7 @@ namespace OCA\Libresign;
  *     pdfVersion?: string,
  *     status_changed_at?: string,
  * }
+ * @psalm-type LibresignFileRuntimeMetadata = LibresignValidateMetadata|array<string, mixed>
  * @psalm-type LibresignValidationPageResolution = array{
  *     w: float,
  *     h: float,
@@ -465,11 +466,11 @@ namespace OCA\Libresign;
  *     statusText: string,
  *     nodeType: 'file'|'envelope',
  *     created_at: string,
- *     metadata: LibresignValidateMetadata,
+ *     metadata: LibresignFileRuntimeMetadata,
  *     docmdpLevel: int,
  *     signatureFlow: 'none'|'parallel'|'ordered_numeric',
  *     signersCount: int,
- *     signers: list<empty>,
+ *     signers: list<LibresignSignerSummary>,
  *     requested_by: LibresignRequestedBy,
  *     filesCount: int<0, max>,
  *     canSign: bool,
@@ -485,7 +486,7 @@ namespace OCA\Libresign;
  *     docmdpLevel: int,
  *     signersCount: int,
  *     file: string,
- *     metadata: LibresignValidateMetadata,
+ *     metadata: LibresignFileRuntimeMetadata,
  *     size: non-negative-int,
  *     signers: list<LibresignSignerSummary>,
  * }
@@ -499,8 +500,8 @@ namespace OCA\Libresign;
  *     name: string,
  *     status: int,
  *     statusText: string,
- *     nodeType: string,
- *     metadata: array<string, mixed>,
+ *     nodeType: 'file'|'envelope',
+ *     metadata: LibresignFileRuntimeMetadata,
  *     size: non-negative-int,
  *     docmdpLevel: int,
  *     signatureFlow: 'none'|'parallel'|'ordered_numeric',
@@ -513,7 +514,7 @@ namespace OCA\Libresign;
  *     message: string,
  *     name: non-falsy-string,
  *     nodeType: 'file'|'envelope',
- *     metadata: LibresignValidateMetadata,
+ *     metadata: LibresignFileRuntimeMetadata,
  *     signatureFlow: 'none'|'parallel'|'ordered_numeric',
  * }
  * @psalm-type LibresignFileListResponse = array{
@@ -593,7 +594,7 @@ namespace OCA\Libresign;
  * }
  * @psalm-type LibresignConfigValueResponse = array{
  *     key: string,
- *     value: mixed,
+ *     value: ?string,
  * }
  * @psalm-type LibresignIdDocsUploadErrorResponse = array{
  *     file: ?int,

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -425,7 +425,8 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "object"
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -815,13 +816,14 @@
                         "type": "string"
                     },
                     "nodeType": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "file",
+                            "envelope"
+                        ]
                     },
                     "metadata": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "object"
-                        }
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "size": {
                         "type": "integer",
@@ -890,7 +892,7 @@
                                 ]
                             },
                             "metadata": {
-                                "$ref": "#/components/schemas/ValidateMetadata"
+                                "$ref": "#/components/schemas/FileRuntimeMetadata"
                             },
                             "signatureFlow": {
                                 "type": "string",
@@ -1250,7 +1252,7 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "$ref": "#/components/schemas/ValidateMetadata"
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "size": {
                         "type": "integer",
@@ -1292,6 +1294,19 @@
                         "$ref": "#/components/schemas/Settings"
                     }
                 }
+            },
+            "FileRuntimeMetadata": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidateMetadata"
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object"
+                        }
+                    }
+                ]
             },
             "FileSummary": {
                 "type": "object",
@@ -1347,7 +1362,7 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "$ref": "#/components/schemas/ValidateMetadata"
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "docmdpLevel": {
                         "type": "integer",
@@ -1367,7 +1382,9 @@
                     },
                     "signers": {
                         "type": "array",
-                        "maxItems": 0
+                        "items": {
+                            "$ref": "#/components/schemas/SignerSummary"
+                        }
                     },
                     "requested_by": {
                         "$ref": "#/components/schemas/RequestedBy"

--- a/openapi.json
+++ b/openapi.json
@@ -303,7 +303,8 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "object"
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -531,13 +532,14 @@
                         "type": "string"
                     },
                     "nodeType": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "file",
+                            "envelope"
+                        ]
                     },
                     "metadata": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "object"
-                        }
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "size": {
                         "type": "integer",
@@ -606,7 +608,7 @@
                                 ]
                             },
                             "metadata": {
-                                "$ref": "#/components/schemas/ValidateMetadata"
+                                "$ref": "#/components/schemas/FileRuntimeMetadata"
                             },
                             "signatureFlow": {
                                 "type": "string",
@@ -851,7 +853,7 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "$ref": "#/components/schemas/ValidateMetadata"
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "size": {
                         "type": "integer",
@@ -893,6 +895,19 @@
                         "$ref": "#/components/schemas/Settings"
                     }
                 }
+            },
+            "FileRuntimeMetadata": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ValidateMetadata"
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object"
+                        }
+                    }
+                ]
             },
             "FileSummary": {
                 "type": "object",
@@ -948,7 +963,7 @@
                         "type": "string"
                     },
                     "metadata": {
-                        "$ref": "#/components/schemas/ValidateMetadata"
+                        "$ref": "#/components/schemas/FileRuntimeMetadata"
                     },
                     "docmdpLevel": {
                         "type": "integer",
@@ -968,7 +983,9 @@
                     },
                     "signers": {
                         "type": "array",
-                        "maxItems": 0
+                        "items": {
+                            "$ref": "#/components/schemas/SignerSummary"
+                        }
                     },
                     "requested_by": {
                         "$ref": "#/components/schemas/RequestedBy"

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1630,7 +1630,7 @@ export type components = {
         };
         ConfigValueResponse: {
             key: string;
-            value: Record<string, never>;
+            value: string | null;
         };
         ConfigureCheck: {
             message: string;
@@ -1745,10 +1745,9 @@ export type components = {
             /** Format: int64 */
             status: number;
             statusText: string;
-            nodeType: string;
-            metadata: {
-                [key: string]: Record<string, never>;
-            };
+            /** @enum {string} */
+            nodeType: "file" | "envelope";
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             size: number;
             /** Format: int64 */
@@ -1766,7 +1765,7 @@ export type components = {
             name: string;
             /** @enum {string} */
             nodeType: "file" | "envelope";
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** @enum {string} */
             signatureFlow: "none" | "parallel" | "ordered_numeric";
         };
@@ -1865,7 +1864,7 @@ export type components = {
             /** Format: int64 */
             signersCount: number;
             file: string;
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             size: number;
             signers: components["schemas"]["SignerSummary"][];
@@ -1874,6 +1873,9 @@ export type components = {
             pagination: components["schemas"]["Pagination"];
             data: (components["schemas"]["FileSummary"] | components["schemas"]["DetailedFile"])[];
             settings?: components["schemas"]["Settings"];
+        };
+        FileRuntimeMetadata: components["schemas"]["ValidateMetadata"] | {
+            [key: string]: Record<string, never>;
         };
         FileSummary: {
             /** Format: int64 */
@@ -1888,14 +1890,14 @@ export type components = {
             /** @enum {string} */
             nodeType: "file" | "envelope";
             created_at: string;
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             docmdpLevel: number;
             /** @enum {string} */
             signatureFlow: "none" | "parallel" | "ordered_numeric";
             /** Format: int64 */
             signersCount: number;
-            signers: unknown[];
+            signers: components["schemas"]["SignerSummary"][];
             requested_by: components["schemas"]["RequestedBy"];
             /** Format: int64 */
             filesCount: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1118,7 +1118,7 @@ export type components = {
         };
         ConfigValueResponse: {
             key: string;
-            value: Record<string, never>;
+            value: string | null;
         };
         Coordinate: {
             /** Format: int64 */
@@ -1190,10 +1190,9 @@ export type components = {
             /** Format: int64 */
             status: number;
             statusText: string;
-            nodeType: string;
-            metadata: {
-                [key: string]: Record<string, never>;
-            };
+            /** @enum {string} */
+            nodeType: "file" | "envelope";
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             size: number;
             /** Format: int64 */
@@ -1211,7 +1210,7 @@ export type components = {
             name: string;
             /** @enum {string} */
             nodeType: "file" | "envelope";
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** @enum {string} */
             signatureFlow: "none" | "parallel" | "ordered_numeric";
         };
@@ -1279,7 +1278,7 @@ export type components = {
             /** Format: int64 */
             signersCount: number;
             file: string;
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             size: number;
             signers: components["schemas"]["SignerSummary"][];
@@ -1288,6 +1287,9 @@ export type components = {
             pagination: components["schemas"]["Pagination"];
             data: (components["schemas"]["FileSummary"] | components["schemas"]["DetailedFile"])[];
             settings?: components["schemas"]["Settings"];
+        };
+        FileRuntimeMetadata: components["schemas"]["ValidateMetadata"] | {
+            [key: string]: Record<string, never>;
         };
         FileSummary: {
             /** Format: int64 */
@@ -1302,14 +1304,14 @@ export type components = {
             /** @enum {string} */
             nodeType: "file" | "envelope";
             created_at: string;
-            metadata: components["schemas"]["ValidateMetadata"];
+            metadata: components["schemas"]["FileRuntimeMetadata"];
             /** Format: int64 */
             docmdpLevel: number;
             /** @enum {string} */
             signatureFlow: "none" | "parallel" | "ordered_numeric";
             /** Format: int64 */
             signersCount: number;
-            signers: unknown[];
+            signers: components["schemas"]["SignerSummary"][];
             requested_by: components["schemas"]["RequestedBy"];
             /** Format: int64 */
             filesCount: number;


### PR DESCRIPTION
## Summary
- align file listing/detail metadata contracts with runtime behavior by introducing `FileRuntimeMetadata`
- keep strict `ValidateMetadata` for validation-specific payloads
- keep improved typing for `nodeType`, `signers` (summary/detail), and `ConfigValueResponse.value`
- regenerate OpenAPI specs and TypeScript types

## Why
File-related endpoints can return metadata keys beyond the strict validation shape. The previous contract was too narrow for runtime payloads in listing/detail responses and could mislead strict SDK/frontend consumers.

## Changes
- `lib/ResponseDefinitions.php`
  - add `LibresignFileRuntimeMetadata = LibresignValidateMetadata|array<string, mixed>`
  - apply `LibresignFileRuntimeMetadata` to file list/detail contracts
  - keep `LibresignValidateMetadata` unchanged for validation payloads
  - keep `LibresignConfigValueResponse.value` as `?string`
- regenerated artifacts:
  - `openapi.json`
  - `openapi-full.json`
  - `src/types/openapi/openapi.ts`
  - `src/types/openapi/openapi-full.ts`

## Validation
- `composer openapi` (inside nextcloud container)
- `npm run typescript:generate`
- `npm run ts:check`

All checks passed.