### PR TITLE
refactor: use default DataResponse success constructor in id docs

### DIFF
--- a/lib/Controller/IdDocsController.php
+++ b/lib/Controller/IdDocsController.php
@@ -73,7 +73,7 @@ class IdDocsController extends AEnvironmentAwareController implements ISignature
 			} else {
 				throw new Exception('Invalid data');
 			}
-			return new DataResponse([], Http::STATUS_OK);
+			return new DataResponse();
 		} catch (\Exception $exception) {
 			$exceptionData = json_decode($exception->getMessage());
 			if (isset($exceptionData->file)) {
@@ -122,7 +122,7 @@ class IdDocsController extends AEnvironmentAwareController implements ISignature
 			} else {
 				throw new Exception('Invalid data');
 			}
-			return new DataResponse([], Http::STATUS_OK);
+			return new DataResponse();
 		} catch (\Exception $exception) {
 			return new DataResponse(
 				[


### PR DESCRIPTION
## Summary
- simplify successful responses in `IdDocsController` by using the `DataResponse` default constructor
- remove redundant explicit `[]` body and `Http::STATUS_OK` in two success paths

## Why
`new DataResponse()` already defaults to empty payload with HTTP 200. The explicit arguments were redundant.

## Changes
- `lib/Controller/IdDocsController.php`
  - `addFiles()` success return: `new DataResponse([], Http::STATUS_OK)` -> `new DataResponse()`
  - `delete()` success return: `new DataResponse([], Http::STATUS_OK)` -> `new DataResponse()`

## Notes
- No API behavior change intended.
- No OpenAPI regeneration needed because return docblocks remain unchanged.