### PR TITLE
chore: remove redundant title field from feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@
 
 name: Feature request
 description: Suggest an idea for this project
+type: Feature
 labels: [ 'feature-request' ]
 assignees: 'your-username'
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,6 @@
 
 name: Feature request
 description: Suggest an idea for this project
-title: '[FEATURE]: '
 labels: [ 'feature-request' ]
 assignees: 'your-username'
 


### PR DESCRIPTION
Resolves: #5073 

## 📝 Summary

Remove the redundant title field from feature request issue template, because already exists a label for feature request.

## 🧪 How to test
<!--
IMPORTANT: The "How to see this running using GitHub Codespaces" details block SHOULD NOT be included in the final template.
Testing instructions should be written specifically for each PR,
describing the steps needed to validate the proposed changes.

Example:
1. Access the signatures page
2. Upload a test PDF
3. Click "Sign" and verify the modal opens correctly
4. Confirm the signature was applied

Feel free to paste terminal commands or URLs that help reviewers follow along.
-->

1. Create a new Issue
2. Select the Feature Request template
3. Confirm the title field is empty

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [ ] The content of this PR was partially or fully generated using AI
