### PR TITLE
chore: structure environment info into specific fields in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,19 +48,59 @@ body:
       placeholder: Press the button below to add screenshots.
       description: If applicable, add screenshots to help explain your problem.
 
-  - type: textarea
-    id: environment
+  - type: input
+    id: operational-system
     attributes:
-      label: Environment information
-      description: Please complete the following infomation
-      placeholder: |
-        - OS: [e.g. Linux Debian, Docker]
-        - Browser [e.g. chrome, safari]
-        - LibreSign Version [e.g. 3.2.1]
-        - Nextcloud Server Version [e.g. 24.0.1]
-        - Logs (get the entries from nextcloud.log related with LibreSign i.e `tail -f data/nextcloud.log|grep libresign`)
+      label: Operational System
+      description: |
+        e.g. Linux, Debian, Docker. If Docker, what's the used image or the base image.
     validations:
       required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser Type and Version
+      description: e.g. Chrome 148.0.7778.97, Safari 26.3.1
+    validations:
+      required: false
+
+  - type: input
+    id: libresign-version
+    attributes:
+      label: Libresign Version
+      description: e.g. 3.2.1
+    validations:
+      required: true
+
+  - type: input
+    id: nextcloud-version
+    attributes:
+      label: Nextcloud Server Version
+      description: e.g. 24.0.1
+    validations:
+        required: false
+
+  - type: textarea
+    id: nextcloud-logs
+    attributes:
+      label: Logs from Nextcloud Server
+      placeholder: |
+        Get the enrties from nextcloud.log related with LibreSign i.e `tail -f data/nextcloud.log|grep libresign`
+    validations:
+      required: true
+
+  - type: textarea
+    id: developer-logs
+    attributes:
+      label: Logs from Developers tools
+      placeholder: |
+        - JavaScript errors
+        - List of API requests to LibreSign endpoints (would be good to apply filter)
+        - Status code of requests to LibreSign API
+        - Or any additional logs or console output that might help diagnose the issue
+    validations:
+      required: false
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,7 @@ body:
     id: operational-system
     attributes:
       label: Operational System
+      description: Specify the operating system where the bug occurs.
       placeholder: |
         e.g. Linux, Debian, Docker. If Docker, what's the used image or the base image.
     validations:
@@ -62,6 +63,7 @@ body:
     id: browser
     attributes:
       label: Browser Type and Version
+      description: Only required if the issue is related to the Web interface.
       placeholder: e.g. Chrome 148.0.7778.97, Safari 26.3.1
     validations:
       required: false
@@ -70,6 +72,7 @@ body:
     id: libresign-version
     attributes:
       label: Libresign Version
+      description: The version of the LibreSign installed.
       placeholder: e.g. 3.2.1
     validations:
       required: true
@@ -78,6 +81,7 @@ body:
     id: nextcloud-version
     attributes:
       label: Nextcloud Server Version
+      description: Optional. Useful if you are using a specific or outdated stable version.
       placeholder: e.g. 24.0.1
     validations:
         required: false
@@ -86,6 +90,7 @@ body:
     id: nextcloud-logs
     attributes:
       label: Logs from Nextcloud Server
+      description: Entries from Nextcloud logs related with LibreSign.
       placeholder: |
         Get the enrties from nextcloud.log related with LibreSign i.e `tail -f data/nextcloud.log|grep libresign`
     validations:
@@ -95,11 +100,11 @@ body:
     id: developer-logs
     attributes:
       label: Logs from Developers tools
+      description: Any additional logs or console output that might help diagnose the issue.
       placeholder: |
         - JavaScript errors
         - List of API requests to LibreSign endpoints (would be good to apply filter)
         - Status code of requests to LibreSign API
-        - Or any additional logs or console output that might help diagnose the issue
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@
 
 name: Bug report
 description: Create a report to help us improve
+type: Bug
 labels: [ 'bug' ]
 assignees: 'your-username'
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,7 @@ body:
     id: operational-system
     attributes:
       label: Operational System
-      description: |
+      placeholder: |
         e.g. Linux, Debian, Docker. If Docker, what's the used image or the base image.
     validations:
       required: true
@@ -62,7 +62,7 @@ body:
     id: browser
     attributes:
       label: Browser Type and Version
-      description: e.g. Chrome 148.0.7778.97, Safari 26.3.1
+      placeholder: e.g. Chrome 148.0.7778.97, Safari 26.3.1
     validations:
       required: false
 
@@ -70,7 +70,7 @@ body:
     id: libresign-version
     attributes:
       label: Libresign Version
-      description: e.g. 3.2.1
+      placeholder: e.g. 3.2.1
     validations:
       required: true
 
@@ -78,7 +78,7 @@ body:
     id: nextcloud-version
     attributes:
       label: Nextcloud Server Version
-      description: e.g. 24.0.1
+      placeholder: e.g. 24.0.1
     validations:
         required: false
 


### PR DESCRIPTION
Resolves: #5072 

## 📝 Summary

- Split environment information in bug report issue template
- Add type `Bug` to bug report issue template