### PR TITLE
[stable33] fix: align getArchitectures typing with main

### DIFF
--- a/lib/Service/Install/SignSetupService.php
+++ b/lib/Service/Install/SignSetupService.php
@@ -70,10 +70,15 @@ class SignSetupService {
 
 	public function getArchitectures(): array {
 		$appInfo = $this->appManager->getAppInfo(Application::APP_ID);
-		if (empty($appInfo['dependencies']['architecture'])) {
+		if (!is_array($appInfo) || !isset($appInfo['dependencies'])) {
 			throw new \Exception('dependencies>architecture not found at info.xml');
 		}
-		return $appInfo['dependencies']['architecture'];
+		/** @var list<string> $architectures */
+		$architectures = $appInfo['dependencies']['architecture'] ?? [];
+		if ($architectures === []) {
+			throw new \Exception('dependencies>architecture not found at info.xml');
+		}
+		return $architectures;
 	}
 
 	public function setPrivateKey(PrivateKey $privateKey): void {


### PR DESCRIPTION
## Summary
- align SignSetupService::getArchitectures() typing and guards with main
- avoid divergent return-type assumptions across maintenance branches

## Why
- keep behavior and static-analysis expectations consistent with main
- reduce branch drift for future backports touching install setup

Ref: #7675