### PR TITLE
perf(crl): cache generated CRL DER to avoid DB query on every validation

### DIFF
--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -16,6 +16,8 @@ use OCA\Libresign\Enum\CRLReason;
 use OCA\Libresign\Enum\CRLStatus;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Service\Certificate\FileService;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,6 +27,17 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type LibresignCrlListResponse from \OCA\Libresign\ResponseDefinitions
  */
 class CrlService {
+	/** Distributed cache for generated CRL DER content (TTL: 24 h). */
+	private ICache $cache;
+
+	/** How long (seconds) a generated CRL DER is kept in cache.
+	 *
+	 * Must be ≤ the CRL's own nextUpdate window, which AEngineHandler sets to
+	 * 7 days (+7 days in createAndSignCrl). Cache invalidation happens
+	 * explicitly on every revocation, so this TTL is only a safety-net for
+	 * edge cases that bypass the normal revocation flow.
+	 */
+	private const GENERATED_CRL_TTL = 7 * 86400; // 7 days
 
 	public function __construct(
 		private CrlMapper $crlMapper,
@@ -32,7 +45,9 @@ class CrlService {
 		private CertificateEngineFactory $certificateEngineFactory,
 		private CrlUrlParserService $crlUrlParserService,
 		private FileService $certificateFileService,
+		ICacheFactory $cacheFactory,
 	) {
+		$this->cache = $cacheFactory->createDistributed('libresign_crl_generated');
 	}
 
 	public function getRootCertificateFromCrlUrls(array $crlUrls): string {
@@ -78,6 +93,8 @@ class CrlService {
 				$crlNumber,
 				$revokedAt,
 			);
+
+			$this->invalidateGeneratedCrlCache($instanceId, $generation, $engineType);
 
 			return true;
 		} catch (\Throwable $exception) {
@@ -130,6 +147,8 @@ class CrlService {
 		?string $revokedBy = null,
 	): int {
 		$revokedCount = 0;
+		/** @var array<string, true> $invalidated keys already evicted this call */
+		$invalidated = [];
 
 		foreach ($certificates as $certificate) {
 			try {
@@ -145,6 +164,12 @@ class CrlService {
 					null,
 					$crlNumber
 				);
+
+				$cacheKey = $this->generatedCrlCacheKey($instanceId, $generation, $engineType);
+				if (!isset($invalidated[$cacheKey])) {
+					$this->invalidateGeneratedCrlCache($instanceId, $generation, $engineType);
+					$invalidated[$cacheKey] = true;
+				}
 
 				$revokedCount++;
 			} catch (\Exception $e) {
@@ -263,6 +288,14 @@ class CrlService {
 		return $lastCrlNumber + 1;
 	}
 
+	private function generatedCrlCacheKey(string $instanceId, int $generation, string $engineType): string {
+		return sha1($instanceId . '_' . $generation . '_' . $engineType);
+	}
+
+	private function invalidateGeneratedCrlCache(string $instanceId, int $generation, string $engineType): void {
+		$this->cache->remove($this->generatedCrlCacheKey($instanceId, $generation, $engineType));
+	}
+
 	public function cleanupExpiredCertificates(?DateTime $before = null): int {
 		return $this->crlMapper->cleanupExpiredCertificates($before);
 	}
@@ -276,6 +309,12 @@ class CrlService {
 	}
 
 	public function generateCrlDer(string $instanceId, int $generation, string $engineType): string {
+		$cacheKey = $this->generatedCrlCacheKey($instanceId, $generation, $engineType);
+		$cached = $this->cache->get($cacheKey);
+		if ($cached !== null) {
+			return $cached;
+		}
+
 		try {
 			$revokedCertificates = $this->crlMapper->getRevokedCertificates($instanceId, $generation, $engineType);
 
@@ -287,7 +326,11 @@ class CrlService {
 
 			$crlNumber = $this->getNextCrlNumber($instanceId, $generation, $engineType);
 
-			return $engine->generateCrlDer($revokedCertificates, $instanceId, $generation, $crlNumber);
+			$crlDer = $engine->generateCrlDer($revokedCertificates, $instanceId, $generation, $crlNumber);
+
+			$this->cache->set($cacheKey, $crlDer, self::GENERATED_CRL_TTL);
+
+			return $crlDer;
 		} catch (\Throwable $e) {
 			if ($e instanceof \RuntimeException && str_starts_with($e->getMessage(), 'Config path does not exist for instanceId:')) {
 				$this->logger->debug('Skipping local CRL generation because source PKI config path is missing', [

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -19,6 +19,8 @@ use OCA\Libresign\Handler\CertificateEngine\IEngineHandler;
 use OCA\Libresign\Service\Certificate\FileService;
 use OCA\Libresign\Service\Crl\CrlService;
 use OCA\Libresign\Service\Crl\CrlUrlParserService;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +33,8 @@ class CrlServiceTest extends TestCase {
 	private CertificateEngineFactory&MockObject $certificateEngineFactory;
 	private CrlUrlParserService&MockObject $crlUrlParserService;
 	private FileService&MockObject $certificateFileService;
+	private ICache&MockObject $cache;
+	private ICacheFactory&MockObject $cacheFactory;
 
 	protected function setUp(): void {
 		$this->crlMapper = $this->createMock(CrlMapper::class);
@@ -38,6 +42,9 @@ class CrlServiceTest extends TestCase {
 		$this->certificateEngineFactory = $this->createMock(CertificateEngineFactory::class);
 		$this->crlUrlParserService = $this->createMock(CrlUrlParserService::class);
 		$this->certificateFileService = $this->createMock(FileService::class);
+		$this->cache = $this->createMock(ICache::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cacheFactory->method('createDistributed')->willReturn($this->cache);
 
 		$this->service = new CrlService(
 			$this->crlMapper,
@@ -45,6 +52,7 @@ class CrlServiceTest extends TestCase {
 			$this->certificateEngineFactory,
 			$this->crlUrlParserService,
 			$this->certificateFileService,
+			$this->cacheFactory,
 		);
 	}
 
@@ -198,6 +206,14 @@ class CrlServiceTest extends TestCase {
 		int $expectedRevoked,
 		bool $expectWarning,
 	): void {
+		// All test certificates share the same PKI metadata, so the cache key is
+		// the same for all of them; invalidation is deduped to at most one call.
+		$expectedCacheRemovals = $expectedRevoked > 0 ? 1 : 0;
+		if ($expectedCacheRemovals > 0) {
+			$this->cache->expects($this->once())->method('remove')->with($this->isType('string'));
+		} else {
+			$this->cache->expects($this->never())->method('remove');
+		}
 		$certificates = [];
 		for ($i = 1; $i <= $certificateCount; $i++) {
 			$cert = new Crl();
@@ -286,6 +302,10 @@ class CrlServiceTest extends TestCase {
 				null,
 			);
 
+		$this->cache->expects($this->once())
+			->method('remove')
+			->with($this->isType('string'));
+
 		$result = $this->service->revokeCertificate($serialNumber, $reason, $reasonText, $revokedBy);
 
 		$this->assertTrue($result);
@@ -296,6 +316,8 @@ class CrlServiceTest extends TestCase {
 		$certificate = new Crl();
 		$certificate->setSerialNumber($serialNumber);
 		$certificate->setEngine('openssl');
+
+		$this->cache->expects($this->never())->method('remove');
 
 		$this->crlMapper->expects($this->once())
 			->method('findBySerialNumber')
@@ -322,18 +344,40 @@ class CrlServiceTest extends TestCase {
 		$this->assertFalse($result);
 	}
 
-	public function testGenerateCrlDerReturnsValidBinaryData(): void {
-		// Create revoked certificates data
+	public function testGenerateCrlDerReturnsCachedResultWithoutHittingDb(): void {
+		$cachedDer = "\x30\x82\x01\x00";
+
+		$this->cache->expects($this->once())
+			->method('get')
+			->with($this->isType('string'))
+			->willReturn($cachedDer);
+
+		// DB and engine must NOT be called when cache is warm
+		$this->crlMapper->expects($this->never())->method('getRevokedCertificates');
+		$this->certificateEngineFactory->expects($this->never())->method('getEngine');
+		$this->cache->expects($this->never())->method('set');
+
+		$result = $this->service->generateCrlDer('test-instance', 1, 'openssl');
+
+		$this->assertSame($cachedDer, $result);
+	}
+
+	public function testGenerateCrlDerGeneratesAndCachesOnCacheMiss(): void {
 		$revokedCertificates = [
 			$this->createRevokedCertificateEntity(123456, 'user1@example.com', 1),
 			$this->createRevokedCertificateEntity(789012, 'user2@example.com', 2),
 		];
 
+		// Cache miss
+		$this->cache->expects($this->once())
+			->method('get')
+			->with($this->isType('string'))
+			->willReturn(null);
+
 		$this->crlMapper->expects($this->once())
 			->method('getRevokedCertificates')
 			->willReturn($revokedCertificates);
 
-		// Mock the certificate engine
 		$mockEngine = $this->createMock(IEngineHandler::class);
 		$mockCrlDer = "\x30\x82\x01\x00"; // Valid DER sequence
 		$mockEngine->expects($this->once())
@@ -345,11 +389,15 @@ class CrlServiceTest extends TestCase {
 			->method('getEngine')
 			->willReturn($mockEngine);
 
-		// Mock the getLastCrlNumber method
 		$this->crlMapper->expects($this->once())
 			->method('getLastCrlNumber')
 			->with('test-instance', 1, 'openssl')
 			->willReturn(0);
+
+		// Must be stored in cache for 7 days (aligned with CRL nextUpdate)
+		$this->cache->expects($this->once())
+			->method('set')
+			->with($this->isType('string'), $mockCrlDer, 7 * 86400);
 
 		$result = $this->service->generateCrlDer('test-instance', 1, 'openssl');
 


### PR DESCRIPTION
## Summary

Installations with many revocations (e.g. 20 000+ rows in `libresign_crl`) experienced severe performance degradation during PDF validation: `CrlService::generateCrlDer()` was querying **all** revoked certificates and regenerating the full CRL binary on every single validation request.

External CRL URLs already had a 24 h distributed cache in `CrlRevocationChecker::downloadCrlContent()`. This PR closes the same gap for locally generated CRLs.