### PR TITLE
chore(release): changelog for v14.0.0, v13.2.5, v12.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,70 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 14.0.0 - 2026-06-12
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- update translations
+- bump dependencies [#7636](https://github.com/LibreSign/libresign/pull/7636) [#7620](https://github.com/LibreSign/libresign/pull/7620) [#7618](https://github.com/LibreSign/libresign/pull/7618) [#7633](https://github.com/LibreSign/libresign/pull/7633)
+- harden openapi contracts for sdk generators [#7662](https://github.com/LibreSign/libresign/pull/7662)
+- use default DataResponse success constructor in id docs [#7661](https://github.com/LibreSign/libresign/pull/7661)
+
+### Fixed
+- align getArchitectures typing with main [#7680](https://github.com/LibreSign/libresign/pull/7680)
+- keep groups_request_sign JSON unicode serialization consistent [#7675](https://github.com/LibreSign/libresign/pull/7675)
+- align openapi signatureflow structure [#7668](https://github.com/LibreSign/libresign/pull/7668)
+- align openapi file metadata contract with runtime payloads [#7656](https://github.com/LibreSign/libresign/pull/7656)
+- expose ValidationURL and qrcode in signature stamp templates [#7650](https://github.com/LibreSign/libresign/pull/7650)
+- render envelope validation data correctly for multi-file requests [#7647](https://github.com/LibreSign/libresign/pull/7647)
+- remove stale addStyle icons call from TemplateLoader [#7641](https://github.com/LibreSign/libresign/pull/7641)
+- support Twig date filter for ServerSignatureDate in JSign [#7644](https://github.com/LibreSign/libresign/pull/7644)
+
+## 13.2.5 - 2026-06-12
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- update translations
+- bump dependencies [#7634](https://github.com/LibreSign/libresign/pull/7634) [#7637](https://github.com/LibreSign/libresign/pull/7637) [#7639](https://github.com/LibreSign/libresign/pull/7639)
+
+### Fixed
+- align getArchitectures typing with main [#7683](https://github.com/LibreSign/libresign/pull/7683)
+- keep groups_request_sign JSON unicode serialization consistent [#7681](https://github.com/LibreSign/libresign/pull/7681)
+- use default DataResponse success constructor in id docs [#7663](https://github.com/LibreSign/libresign/pull/7663)
+- harden openapi contracts for sdk generators [#7665](https://github.com/LibreSign/libresign/pull/7665)
+- align openapi file metadata contract with runtime payloads [#7660](https://github.com/LibreSign/libresign/pull/7660)
+- expose ValidationURL and qrcode in signature stamp templates [#7658](https://github.com/LibreSign/libresign/pull/7658)
+- render envelope validation data correctly for multi-file requests [#7649](https://github.com/LibreSign/libresign/pull/7649)
+- remove stale addStyle icons call from TemplateLoader [#7642](https://github.com/LibreSign/libresign/pull/7642)
+- support Twig date filter for ServerSignatureDate in JSign [#7646](https://github.com/LibreSign/libresign/pull/7646)
+
+## 12.4.5 - 2026-06-12
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- update translations
+- bump dependencies [#7633](https://github.com/LibreSign/libresign/pull/7633) [#7638](https://github.com/LibreSign/libresign/pull/7638) [#7640](https://github.com/LibreSign/libresign/pull/7640)
+
+### Fixed
+- align getArchitectures typing with main [#7684](https://github.com/LibreSign/libresign/pull/7684)
+- keep groups_request_sign JSON unicode serialization consistent [#7675](https://github.com/LibreSign/libresign/pull/7675)
+- use default DataResponse success constructor in id docs [#7666](https://github.com/LibreSign/libresign/pull/7666)
+- harden openapi contracts for sdk generators [#7664](https://github.com/LibreSign/libresign/pull/7664)
+- align openapi file metadata contract with runtime payloads [#7659](https://github.com/LibreSign/libresign/pull/7659)
+- expose ValidationURL and qrcode in signature stamp templates [#7657](https://github.com/LibreSign/libresign/pull/7657)
+- render envelope validation data correctly for multi-file requests [#7648](https://github.com/LibreSign/libresign/pull/7648)
+- remove stale addStyle icons call from TemplateLoader [#7643](https://github.com/LibreSign/libresign/pull/7643)
+- support Twig date filter for ServerSignatureDate in JSign [#7645](https://github.com/LibreSign/libresign/pull/7645)
+
 ## 13.2.4 - 2026-04-25
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign


### PR DESCRIPTION
Release preparation: changelog entries for v14.0.0, v13.2.5, and v12.4.5.