### PR TITLE
chore(release): bump version to v12.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 12.4.5 - 2026-06-12
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- Update translations
+- Bump dependencies [#7633](https://github.com/LibreSign/libresign/pull/7633) [#7638](https://github.com/LibreSign/libresign/pull/7638) [#7640](https://github.com/LibreSign/libresign/pull/7640)
+
+### Fixes
+- align getArchitectures typing with main [#7684](https://github.com/LibreSign/libresign/pull/7684)
+- keep groups_request_sign JSON unicode serialization consistent [#7675](https://github.com/LibreSign/libresign/pull/7675)
+- use default DataResponse success constructor in id docs [#7666](https://github.com/LibreSign/libresign/pull/7666)
+- harden openapi contracts for sdk generators [#7664](https://github.com/LibreSign/libresign/pull/7664)
+- align openapi file metadata contract with runtime payloads [#7659](https://github.com/LibreSign/libresign/pull/7659)
+- expose ValidationURL and qrcode in signature stamp templates [#7657](https://github.com/LibreSign/libresign/pull/7657)
+- render envelope validation data correctly for multi-file requests [#7648](https://github.com/LibreSign/libresign/pull/7648)
+- remove stale addStyle icons call from TemplateLoader [#7643](https://github.com/LibreSign/libresign/pull/7643)
+- support Twig date filter for ServerSignatureDate in JSign [#7645](https://github.com/LibreSign/libresign/pull/7645)
+
 ## 12.4.4 - 2026-04-26
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ If your organization uses LibreSign, support its development:
 For enterprise support, contact LibreCode:
 https://libresign.coop
 	]]></description>
-	<version>12.4.4</version>
+	<version>12.4.5</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "12.4.4",
+  "version": "12.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "12.4.4",
+      "version": "12.4.5",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "12.4.4",
+  "version": "12.4.5",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for v12.4.5: version bump and changelog.