### PR TITLE
chore(release): bump version to v13.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 13.2.5 - 2026-06-12
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- Update translations
+- Bump dependencies [#7634](https://github.com/LibreSign/libresign/pull/7634) [#7637](https://github.com/LibreSign/libresign/pull/7637) [#7639](https://github.com/LibreSign/libresign/pull/7639)
+
+### Fixes
+- align getArchitectures typing with main [#7683](https://github.com/LibreSign/libresign/pull/7683)
+- keep groups_request_sign JSON unicode serialization consistent [#7681](https://github.com/LibreSign/libresign/pull/7681)
+- use default DataResponse success constructor in id docs [#7663](https://github.com/LibreSign/libresign/pull/7663)
+- harden openapi contracts for sdk generators [#7665](https://github.com/LibreSign/libresign/pull/7665)
+- align openapi file metadata contract with runtime payloads [#7660](https://github.com/LibreSign/libresign/pull/7660)
+- expose ValidationURL and qrcode in signature stamp templates [#7658](https://github.com/LibreSign/libresign/pull/7658)
+- render envelope validation data correctly for multi-file requests [#7649](https://github.com/LibreSign/libresign/pull/7649)
+- remove stale addStyle icons call from TemplateLoader [#7642](https://github.com/LibreSign/libresign/pull/7642)
+- support Twig date filter for ServerSignatureDate in JSign [#7646](https://github.com/LibreSign/libresign/pull/7646)
+
 ## 13.2.4 - 2026-04-25
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ If your organization uses LibreSign, support its development:
 For enterprise support, contact LibreCode:
 https://libresign.coop
 	]]></description>
-	<version>13.2.4</version>
+	<version>13.2.5</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "13.2.4",
+  "version": "13.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "13.2.4",
+      "version": "13.2.5",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "13.2.4",
+  "version": "13.2.5",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for v13.2.5: version bump and changelog.