### PR TITLE
fix(sign-engine): skip non-signature /Contents entries while preserving valid signature extraction

### DIFF
--- a/lib/Handler/SignEngine/Pkcs12Handler.php
+++ b/lib/Handler/SignEngine/Pkcs12Handler.php
@@ -162,15 +162,16 @@ class Pkcs12Handler extends SignEngineHandler {
 		return array_merge($result, $docMdpData);
 	}
 
-	private function extractTimestampData(array $decoded, array $result): array {
+	private function extractTimestampData(?array $decoded, array $result): array {
+		if ($decoded === null) {
+			return $result;
+		}
+
 		$tsa = new TSA();
 
-		try {
-			$timestampData = $tsa->extract($decoded);
-			if (!empty($timestampData['genTime']) || !empty($timestampData['policy']) || !empty($timestampData['serialNumber'])) {
-				$result['timestamp'] = $timestampData;
-			}
-		} catch (\Throwable) {
+		$timestampData = $tsa->extract($decoded);
+		if (!empty($timestampData['genTime']) || !empty($timestampData['policy']) || !empty($timestampData['serialNumber'])) {
+			$result['timestamp'] = $timestampData;
 		}
 
 		if (!isset($result['signingTime']) || !$result['signingTime'] instanceof \DateTime) {

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -235,7 +235,11 @@ class TSA {
 
 		$tsa['cnHints'] = $cnHints;
 		$tsa['displayName'] = $this->generateDistinguishedNames($cnHints);
-		$tsa['genTime'] = $tsa['genTime'] ? new \DateTime($tsa['genTime']) : null;
+		try {
+			$tsa['genTime'] = $tsa['genTime'] ? new \DateTime($tsa['genTime']) : null;
+		} catch (\Exception) {
+			$tsa['genTime'] = null;
+		}
 
 		return $tsa;
 	}

--- a/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
@@ -24,6 +24,7 @@ use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\ITempManager;
 use OCP\L10N\IFactory as IL10NFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -353,6 +354,28 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				$this->assertIsArray($signatureData['chain']);
 			}
 		}
+	}
+
+	public static function provideExtractableFixture(): array {
+		foreach ((new PdfFixtureCatalog())->getAll() as $fixture) {
+			if ($fixture->shouldExtract()) {
+				return [[$fixture]];
+			}
+		}
+		return [];
+	}
+
+	#[DataProvider('provideExtractableFixture')]
+	public function testGetCertificateChainPreservesRealSignaturesWhenPdfAlsoHasHyperlinkAnnotation($fixture): void {
+		$this->docMdpHandler->method('extractDocMdpData')->willReturn([]);
+
+		$resource = fopen('php://memory', 'r+');
+		fwrite($resource, file_get_contents($fixture->getFilePath())
+			. "\n99 0 obj<</Type/Annot/Subtype/Link/Contents <" . bin2hex('https://example.com') . ">>>>\nendobj\n");
+		rewind($resource);
+
+		$this->assertCount($fixture->getSignatureCount(), $this->getHandler()->getCertificateChain($resource));
+		fclose($resource);
 	}
 
 	public function testDocMdpPdfsExtraction(): void {


### PR DESCRIPTION
## Summary
- avoid timestamp extraction when BER decoding returns null
- normalize invalid TSA genTime parsing
- add unit coverage for PDFs that contain annotation `/Contents` alongside valid signatures
