### PR TITLE
fix(crl): match local CRL distribution points by path, not by request host

### DIFF
--- a/lib/Service/Crl/CrlRevocationChecker.php
+++ b/lib/Service/Crl/CrlRevocationChecker.php
@@ -187,7 +187,7 @@ class CrlRevocationChecker {
 	 * URL generator and then cached in a property to avoid redundant work on
 	 * installations that validate many certificates in a single request.
 	 */
-	private function getLocalCrlPattern(): string {
+	protected function getLocalCrlPattern(): string {
 		if ($this->localCrlPattern !== null) {
 			return $this->localCrlPattern;
 		}
@@ -198,14 +198,19 @@ class CrlRevocationChecker {
 			'engineType' => 'ENGINETYPE',
 		]);
 
-		$patternUrl = str_replace('INSTANCEID', '([^/_]+)', $templateUrl);
-		$patternUrl = str_replace('999999', '(\d+)', $patternUrl);
-		$patternUrl = str_replace('ENGINETYPE', '([^/_]+)', $patternUrl);
+		// Match the path only and accept any scheme/host: the CRL DP host is fixed
+		// at certificate issuance and may differ from the request host (already
+		// vetted as trusted by isLocalCrlUrl()).
+		$templatePath = parse_url($templateUrl, PHP_URL_PATH) ?: $templateUrl;
 
-		$escapedPattern = str_replace([':', '/', '.'], ['\:', '\/', '\.'], $patternUrl);
+		$patternPath = str_replace('INSTANCEID', '([^/_]+)', $templatePath);
+		$patternPath = str_replace('999999', '(\d+)', $patternPath);
+		$patternPath = str_replace('ENGINETYPE', '([^/_]+)', $patternPath);
+
+		$escapedPattern = str_replace([':', '/', '.'], ['\:', '\/', '\.'], $patternPath);
 		$escapedPattern = str_replace('\/apps\/', '(?:\/index\.php)?\/apps\/', $escapedPattern);
 
-		$this->localCrlPattern = '/^' . $escapedPattern . '$/';
+		$this->localCrlPattern = '/^https?\:\/\/[^\/]+' . $escapedPattern . '$/';
 		return $this->localCrlPattern;
 	}
 

--- a/tests/php/Unit/Service/Crl/CrlRevocationCheckerTest.php
+++ b/tests/php/Unit/Service/Crl/CrlRevocationCheckerTest.php
@@ -36,6 +36,10 @@ class CrlRevocationCheckerTestable extends CrlRevocationChecker {
 	public function publicExtractRevocationDateFromCrlText(string $crlText, array $serialNumbers): ?string {
 		return $this->extractRevocationDateFromCrlText($crlText, $serialNumbers);
 	}
+
+	public function publicGetLocalCrlPattern(): string {
+		return $this->getLocalCrlPattern();
+	}
 }
 
 class CrlRevocationCheckerTest extends TestCase {
@@ -212,6 +216,62 @@ class CrlRevocationCheckerTest extends TestCase {
 		);
 
 		$this->assertNotSame(CrlValidationStatus::DISABLED, $result['status'], 'Local CRL URLs must not be skipped when external validation is disabled');
+	}
+
+	/**
+	 * In a given request the CRL route resolves to one specific host. The tests
+	 * below assert that the recognition pattern does not depend on that host.
+	 */
+	private function mockCrlRouteUrlGenerator(): void {
+		$this->urlGenerator
+			->method('linkToRouteAbsolute')
+			->with('libresign.crl.getRevocationList', [
+				'instanceId' => 'INSTANCEID',
+				'generation' => 999999,
+				'engineType' => 'ENGINETYPE',
+			])
+			->willReturn('https://cloud.example.com/apps/libresign/crl/libresign_INSTANCEID_999999_ENGINETYPE.crl');
+	}
+
+	#[DataProvider('dataProviderLocalCrlUrlsWithDifferentHosts')]
+	public function testGetLocalCrlPatternMatchesAnyHost(
+		string $url,
+		string $expectedInstanceId,
+		string $expectedGeneration,
+		string $expectedEngineType,
+	): void {
+		// A certificate's embedded CRL DP host is fixed at issuance and may differ
+		// from the current request host (e.g. signing through the API from another
+		// origin). The pattern must still recognise the local CRL and capture its
+		// instanceId / generation / engineType regardless of the host.
+		$this->mockCrlRouteUrlGenerator();
+
+		$pattern = $this->checker->publicGetLocalCrlPattern();
+
+		$this->assertSame(1, preg_match($pattern, $url, $matches), 'Local CRL URL should match');
+		$this->assertSame($expectedInstanceId, $matches[1], 'instanceId should be captured');
+		$this->assertSame($expectedGeneration, $matches[2], 'generation should be captured');
+		$this->assertSame($expectedEngineType, $matches[3], 'engineType should be captured');
+	}
+
+	public static function dataProviderLocalCrlUrlsWithDifferentHosts(): array {
+		return [
+			'same host' => ['https://cloud.example.com/apps/libresign/crl/libresign_abc123_4_o.crl', 'abc123', '4', 'o'],
+			'different host and port' => ['http://localhost:9000/apps/libresign/crl/libresign_abc123_4_o.crl', 'abc123', '4', 'o'],
+			'different host with index.php' => ['http://host.docker.internal:9000/index.php/apps/libresign/crl/libresign_abc123_4_o.crl', 'abc123', '4', 'o'],
+		];
+	}
+
+	public function testGetLocalCrlPatternRejectsNonCrlUrls(): void {
+		$this->mockCrlRouteUrlGenerator();
+
+		$pattern = $this->checker->publicGetLocalCrlPattern();
+
+		$this->assertSame(
+			0,
+			preg_match($pattern, 'https://cloud.example.com/apps/libresign/crl/not-a-crl.txt'),
+			'A non-CRL path must not match the local CRL pattern',
+		);
 	}
 
 	#[DataProvider('dataProviderIsSerialNumberInCrl')]


### PR DESCRIPTION
## Problem

Signing is blocked with `URLS_INACCESSIBLE` (HTTP 422, `action 2000`, "Cannot reach the certificate revocation service. Signing is not allowed.") whenever a certificate is validated from a request whose host differs from the host embedded in the certificate's CRL Distribution Point, even though that CRL is local and managed by LibreSign. It reproduces on instances accessible under multiple trusted domains.

## Root Cause

`CrlRevocationChecker::getLocalCrlPattern()` builds the recognition regex from `IURLGenerator::linkToRouteAbsolute()`, which resolves to the **current request host**. A certificate's CRL DP host is fixed at issuance and can legitimately differ from the request host. When they differ, the pattern does not match, `generateLocalCrl()` returns `null`, the local CRL is never generated, and the distribution point is counted as inaccessible => signing is blocked.

`isLocalCrlUrl()` already authorizes the URL by checking its host against `trusted_domains`, so re-anchoring the pattern to a single host afterwards is both redundant and the source of the bug.

## Fix

Build the pattern from the **route path** only and accept any `scheme://host` prefix. The host is still validated by `isLocalCrlUrl()`, and the CRL is still generated from the instance's own PKI on disk via `CrlService::generateCrlDer()`, so there is no change to the trust boundary.

## Reproduction

1. A certificate whose CRL DP host is fixed at a specific value (set at issuance).
2. A signing request arrives with a `Host` header that is a **different trusted domain**.
3. Before: `422` / `urls_inaccessible`; log shows `CRL URL does not match expected pattern`. After: `200` / signed; revocation still verified.

## Security

No change to the trust model. `generateLocalCrl()` is only reached after `isLocalCrlUrl()` confirms the host is in `trusted_domains`. The local CRL is generated from local PKI, never fetched from the URL, so its content cannot be spoofed, and revoked serials are still detected. The patch removes only a false negative that blocked legitimate signing.