### PR TITLE
chore(release): bump version to v12.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 12.4.6 - 2026-06-14
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
+
+### Fixes
+- skip non-signature /Contents entries while preserving valid signature extraction [#7739](https://github.com/LibreSign/libresign/pull/7739)
+- run playwright in official container [#7745](https://github.com/LibreSign/libresign/pull/7745)
+- psalm fixes [#7748](https://github.com/LibreSign/libresign/pull/7748)
+- match local CRL distribution points by path, not by request host [#7750](https://github.com/LibreSign/libresign/pull/7750)
+
 ## 12.4.5 - 2026-06-12
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ If your organization uses LibreSign, support its development:
 For enterprise support, contact LibreCode:
 https://libresign.coop
 	]]></description>
-	<version>12.4.5</version>
+	<version>12.4.6</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "12.4.5",
+  "version": "12.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "12.4.5",
+      "version": "12.4.6",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "12.4.5",
+  "version": "12.4.6",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for v12.4.6 on stable32: app version bump, npm version bump, and changelog update.