### PR TITLE
fix: enforce non-null user element node id

### DIFF
--- a/lib/Migration/Version18003Date20260616000000.php
+++ b/lib/Migration/Version18003Date20260616000000.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version18003Date20260616000000 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[\Override]
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('libresign_user_element')
+			->where($qb->expr()->isNull('node_id'));
+		$deleted = $qb->executeStatement();
+		if ($deleted > 0) {
+			$output->warning(sprintf(
+				'Deleted %d row(s) from libresign_user_element with NULL node_id (corrupted rows with no associated file).',
+				$deleted,
+			));
+		}
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return ISchemaWrapper|null
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('libresign_user_element');
+		$column = $table->getColumn('node_id');
+		if ($column->getNotnull()) {
+			return null;
+		}
+
+		$column->setNotnull(true);
+		return $schema;
+	}
+}


### PR DESCRIPTION
Delete corrupted rows with NULL node_id before enforcing the database constraint for future writes.

