### PR TITLE
[stable32] chore(release): bump version to v12.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 12.4.7 - 2026-07-06
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help upgrading or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- update translations
+- bump dependencies [#7803](https://github.com/LibreSign/libresign/pull/7803) [#7816](https://github.com/LibreSign/libresign/pull/7816) [#7848](https://github.com/LibreSign/libresign/pull/7848)
+- surface setup checks in the admin overview and `occ setupchecks:check` [#7839](https://github.com/LibreSign/libresign/pull/7839)
+
+### Fixed
+- avoid autoload issues from the authoritative classmap configuration [#7777](https://github.com/LibreSign/libresign/pull/7777)
+- cache generated CRL data in appdata correctly [#7781](https://github.com/LibreSign/libresign/pull/7781)
+- prevent invalid user element rows from breaking node ID writes [#7809](https://github.com/LibreSign/libresign/pull/7809)
+- honor notification preferences more consistently for email notifications [#7833](https://github.com/LibreSign/libresign/pull/7833)
+- avoid transient CFSSL startup failures during setup [#7836](https://github.com/LibreSign/libresign/pull/7836)
+- clarify the error shown when a signing link is opened in the wrong authenticated session [#7859](https://github.com/LibreSign/libresign/pull/7859)
+
 ## 12.4.6 - 2026-06-14
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ If your organization uses LibreSign, support its development:
 For enterprise support, contact LibreCode:
 https://libresign.coop
 	]]></description>
-	<version>12.4.6</version>
+	<version>12.4.7</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "12.4.6",
+  "version": "12.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "12.4.6",
+      "version": "12.4.7",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "12.4.6",
+  "version": "12.4.7",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for `v12.4.7`.

Checklist issue: #7864

Scope:
- `CHANGELOG.md`
- `appinfo/info.xml`
- `package.json`
- `package-lock.json`
