### PR TITLE
[stable34] chore(release): bump version to v14.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ Types of changes:
 
 <!-- changelog-linker -->
 <!-- changelog-linker -->
+## 14.0.2 - 2026-07-06
+
+💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign
+
+🏢 **ENTERPRISE SUPPORT** — Need help with migration or custom implementations? Contact us: contact@librecode.coop
+
+### Changed
+- update translations
+- bump dependencies [#7780](https://github.com/LibreSign/libresign/pull/7780) [#7805](https://github.com/LibreSign/libresign/pull/7805) [#7818](https://github.com/LibreSign/libresign/pull/7818) [#7850](https://github.com/LibreSign/libresign/pull/7850)
+- surface setup checks in the admin overview and `occ setupchecks:check` [#7841](https://github.com/LibreSign/libresign/pull/7841)
+
+### Fixed
+- avoid autoload issues from the authoritative classmap configuration [#7776](https://github.com/LibreSign/libresign/pull/7776)
+- cache generated CRL data in appdata correctly [#7783](https://github.com/LibreSign/libresign/pull/7783)
+- prevent invalid user element rows from breaking node ID writes [#7811](https://github.com/LibreSign/libresign/pull/7811)
+- honor notification preferences more consistently for email notifications [#7835](https://github.com/LibreSign/libresign/pull/7835)
+- avoid transient CFSSL startup failures during setup [#7838](https://github.com/LibreSign/libresign/pull/7838)
+- clarify the error shown when a signing link is opened in the wrong authenticated session [#7857](https://github.com/LibreSign/libresign/pull/7857)
+
 ## 14.0.1 - 2026-06-14
 
 💝 **SUPPORT LIBRESIGN** — If you find this project useful, please consider supporting its development: https://github.com/sponsors/LibreSign

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ If your organization uses LibreSign, support its development:
 For enterprise support, contact LibreCode:
 https://libresign.coop
 	]]></description>
-	<version>14.0.1</version>
+	<version>14.0.2</version>
 	<licence>agpl</licence>
 	<author mail="contact@librecode.coop" homepage="https://librecode.coop">LibreCode</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "14.0.1",
+      "version": "14.0.2",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for `v14.0.2`.

Checklist issue: #7864

Scope:
- `CHANGELOG.md`
- `appinfo/info.xml`
- `package.json`
- `package-lock.json`
