### PR TITLE
fix(crl): improve CRL generation performance and reliability

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -251,18 +251,7 @@ class PageController extends AEnvironmentPageAwareController {
 				$this->fileService->setSignRequest($signRequest);
 			}
 
-			$this->initialState->provideInitialState('file_info',
-				$this->fileService
-					->setIdentifyMethodId($this->sessionService->getIdentifyMethodId())
-					->setHost($this->request->getServerHost())
-					->setMe($this->userSession->getUser())
-					->showVisibleElements()
-					->showSigners()
-					->showSettings()
-					->showMessages()
-					->showValidateFile()
-					->toArray()
-			);
+			$this->provideDeferredValidationFileInfo($matches['uuid']);
 		} elseif (preg_match('/sign\/(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/', $path, $matches)) {
 			try {
 				$signRequest = $this->signFileService->getSignRequestByUuid($matches['uuid']);
@@ -684,30 +673,11 @@ class PageController extends AEnvironmentPageAwareController {
 			$this->fileService->setSignRequest($signRequest);
 		}
 
-		$fileInfo = $this->fileService
-			->setIdentifyMethodId($this->sessionService->getIdentifyMethodId())
-			->setHost($this->request->getServerHost())
-			->showVisibleElements()
-			->showSigners()
-			->showSettings()
-			->showMessages()
-			->showValidateFile()
-			->toArray();
-
-		$requesterUserId = null;
-		$requestedBy = $fileInfo['requested_by'] ?? null;
-		if (is_array($requestedBy) && is_string($requestedBy['userId'] ?? null)) {
-			$requestedByUserId = trim($requestedBy['userId']);
-			$requesterUserId = $requestedByUserId !== '' ? $requestedByUserId : null;
-		}
-
 		$this->initialState->provideInitialState('effective_policies', [
-			'policies' => $requesterUserId !== null
-				? $this->policyService->resolveKnownPolicyStatesForUserIdWithoutUserScope($requesterUserId)
-				: $this->policyService->resolveKnownPolicyStates(),
+			'policies' => $this->policyService->resolveKnownPolicyStates(),
 		]);
 
-		$this->initialState->provideInitialState('file_info', $fileInfo);
+		$this->provideDeferredValidationFileInfo($uuid);
 
 		Util::addScript(Application::APP_ID, 'libresign-validation');
 		if (class_exists(LoadViewer::class)) {
@@ -716,5 +686,23 @@ class PageController extends AEnvironmentPageAwareController {
 		$response = new TemplateResponse(Application::APP_ID, 'validation', [], TemplateResponse::RENDER_AS_BASE);
 
 		return $response;
+	}
+
+	/**
+	 * Provide a lightweight placeholder for file_info initial state.
+	 *
+	 * The validation page SPA fetches fresh data via the validate API on mount,
+	 * so the heavy server-side preload is redundant. This method provides only
+	 * the UUID so the frontend can issue its API call with the correct identifier.
+	 */
+	private function provideDeferredValidationFileInfo(string $uuid): void {
+		$this->initialState->provideInitialState('file_info', [
+			'uuid' => $uuid,
+			'name' => '',
+			'files' => [],
+			'filesCount' => 0,
+			'signers' => [],
+			'messages' => [],
+		]);
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -673,11 +673,30 @@ class PageController extends AEnvironmentPageAwareController {
 			$this->fileService->setSignRequest($signRequest);
 		}
 
+		$fileInfo = $this->fileService
+			->setIdentifyMethodId($this->sessionService->getIdentifyMethodId())
+			->setHost($this->request->getServerHost())
+			->showVisibleElements()
+			->showSigners()
+			->showSettings()
+			->showMessages()
+			->showValidateFile()
+			->toArray();
+
+		$requesterUserId = null;
+		$requestedBy = $fileInfo['requested_by'] ?? null;
+		if (is_array($requestedBy) && is_string($requestedBy['userId'] ?? null)) {
+			$requestedByUserId = trim($requestedBy['userId']);
+			$requesterUserId = $requestedByUserId !== '' ? $requestedByUserId : null;
+		}
+
 		$this->initialState->provideInitialState('effective_policies', [
-			'policies' => $this->policyService->resolveKnownPolicyStates(),
+			'policies' => $requesterUserId !== null
+				? $this->policyService->resolveKnownPolicyStatesForUserIdWithoutUserScope($requesterUserId)
+				: $this->policyService->resolveKnownPolicyStates(),
 		]);
 
-		$this->provideDeferredValidationFileInfo($uuid);
+		$this->initialState->provideInitialState('file_info', $fileInfo);
 
 		Util::addScript(Application::APP_ID, 'libresign-validation');
 		if (class_exists(LoadViewer::class)) {

--- a/lib/Db/CrlMapper.php
+++ b/lib/Db/CrlMapper.php
@@ -136,6 +136,15 @@ class CrlMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('status', $qb->createNamedParameter(CRLStatus::REVOKED->value)))
+			// Omit expired certificates from the CRL. Per RFC 5280, certificate
+			// consumers already reject expired certs on expiry grounds; omitting
+			// them keeps the CRL compact and generation fast.
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('valid_to'),
+					$qb->expr()->gte('valid_to', $qb->createNamedParameter(new \DateTime(), IQueryBuilder::PARAM_DATE)),
+				)
+			)
 			->orderBy('revoked_at', 'DESC');
 
 		if ($instanceId !== '') {

--- a/lib/Service/Crl/CrlRevocationChecker.php
+++ b/lib/Service/Crl/CrlRevocationChecker.php
@@ -32,10 +32,18 @@ class CrlRevocationChecker {
 	/** @var array<string, string|null> */
 	private array $localCrlRequestCache = [];
 
+	/** @var array<string, string|null> */
+	private array $parsedCrlTextRequestCache = [];
+
+	/** @var array<string, array{status: CrlValidationStatus, revoked_at?: string}> */
+	private array $validationResultRequestCache = [];
+
 	/** Distributed cache for externally downloaded CRL content (TTL: 24 h). */
 	private ICache $cache;
 
 	private const BINARY_CACHE_PREFIX = 'base64:';
+	private const PARSED_TEXT_CACHE_PREFIX = 'parsed_text:';
+	private const PARSED_TEXT_CACHE_TTL = 86400;
 
 	public function __construct(
 		private IConfig $config,
@@ -181,6 +189,10 @@ class CrlRevocationChecker {
 				$this->logger->debug('Skipping local CRL generation because source PKI config path is missing', [
 					'reason' => $e->getMessage(),
 				]);
+			} elseif ($e instanceof \RuntimeException && str_contains($e->getMessage(), 'already in progress')) {
+				$this->logger->debug('Local CRL generation is already in progress', [
+					'reason' => $e->getMessage(),
+				]);
 			} else {
 				$this->logger->warning('Failed to generate local CRL: ' . $e->getMessage());
 			}
@@ -303,42 +315,68 @@ class CrlRevocationChecker {
 				return ['status' => CrlValidationStatus::VALIDATION_ERROR];
 			}
 
-			$tempCrlFile = $this->tempManager->getTemporaryFile('.crl');
-			file_put_contents($tempCrlFile, $crlContent);
+			$serialCandidates = [$certData['serialNumber']];
+			if (!empty($certData['serialNumberHex'])) {
+				$serialCandidates[] = $certData['serialNumberHex'];
+			}
 
-			try {
-				[$output, $exitCode] = $this->execOpenSslCrl($tempCrlFile);
+			$validationCacheKey = $this->buildValidationCacheKey($serialCandidates, $crlContent);
+			if (array_key_exists($validationCacheKey, $this->validationResultRequestCache)) {
+				return $this->validationResultRequestCache[$validationCacheKey];
+			}
 
-				if ($exitCode !== 0) {
-					return ['status' => CrlValidationStatus::VALIDATION_ERROR];
-				}
+			$crlText = $this->getParsedCrlText($crlContent);
+			if ($crlText === null) {
+				return $this->validationResultRequestCache[$validationCacheKey] = ['status' => CrlValidationStatus::VALIDATION_ERROR];
+			}
 
-				$crlText = implode("\n", $output);
-				$serialCandidates = [$certData['serialNumber']];
-				if (!empty($certData['serialNumberHex'])) {
-					$serialCandidates[] = $certData['serialNumberHex'];
-				}
-
-				foreach ($serialCandidates as $serial) {
-					if ($this->isSerialNumberInCrl($crlText, $serial)) {
-						$revokedAt = $this->extractRevocationDateFromCrlText($crlText, $serialCandidates);
-						return array_filter([
-							'status' => CrlValidationStatus::REVOKED,
-							'revoked_at' => $revokedAt,
-						]);
-					}
-				}
-
-				return ['status' => CrlValidationStatus::VALID];
-			} finally {
-				if (file_exists($tempCrlFile)) {
-					unlink($tempCrlFile);
+			foreach ($serialCandidates as $serial) {
+				if ($this->isSerialNumberInCrl($crlText, $serial)) {
+					$revokedAt = $this->extractRevocationDateFromCrlText($crlText, $serialCandidates);
+					return $this->validationResultRequestCache[$validationCacheKey] = array_filter([
+						'status' => CrlValidationStatus::REVOKED,
+						'revoked_at' => $revokedAt,
+					]);
 				}
 			}
 
+			return $this->validationResultRequestCache[$validationCacheKey] = ['status' => CrlValidationStatus::VALID];
 		} catch (\Exception) {
 			return ['status' => CrlValidationStatus::VALIDATION_ERROR];
 		}
+	}
+
+	protected function getParsedCrlText(string $crlContent): ?string {
+		$contentHash = sha1($crlContent);
+
+		if (array_key_exists($contentHash, $this->parsedCrlTextRequestCache)) {
+			return $this->parsedCrlTextRequestCache[$contentHash];
+		}
+
+		$cacheKey = self::PARSED_TEXT_CACHE_PREFIX . $contentHash;
+		$cached = $this->cache->get($cacheKey);
+		if ($cached !== null) {
+			return $this->parsedCrlTextRequestCache[$contentHash] = is_string($cached) ? $cached : null;
+		}
+
+		$tempFile = $this->tempManager->getTemporaryFile('.der');
+		if (!file_put_contents($tempFile, $crlContent)) {
+			return $this->parsedCrlTextRequestCache[$contentHash] = null;
+		}
+
+		[$output, $exitCode] = $this->execOpenSslCrl($tempFile);
+
+		if ($exitCode !== 0 || empty($output)) {
+			return $this->parsedCrlTextRequestCache[$contentHash] = null;
+		}
+
+		$crlText = implode("\n", $output);
+		$this->cache->set($cacheKey, $crlText, self::PARSED_TEXT_CACHE_TTL);
+		return $this->parsedCrlTextRequestCache[$contentHash] = $crlText;
+	}
+
+	protected function buildValidationCacheKey(array $serialCandidates, string $crlContent): string {
+		return sha1(implode(',', $serialCandidates) . ':' . sha1($crlContent));
 	}
 
 	/**

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -101,16 +101,27 @@ class CrlService {
 				$crlNumber,
 				$revokedAt,
 			);
-			$this->invalidateGeneratedCrlCache($instanceId, $generation, $engineType);
-
-			return true;
-		} catch (\Exception $exception) {
+		} catch (\Throwable $exception) {
 			$this->logger->warning('Failed to revoke certificate {serial}', [
 				'serial' => $serialNumber,
 				'error' => $exception->getMessage(),
 			]);
 			return false;
 		}
+
+		// DB revocation succeeded. Invalidating the CRL cache is best-effort:
+		// markStale() handles its own write errors internally, but guard here
+		// too so an unexpected exception never rolls back a successful revocation.
+		try {
+			$this->invalidateGeneratedCrlCache($instanceId, $generation, $engineType);
+		} catch (\Throwable $exception) {
+			$this->logger->debug('Failed to invalidate CRL cache after revocation (non-critical)', [
+				'serial' => $serialNumber,
+				'error' => $exception->getMessage(),
+			]);
+		}
+
+		return true;
 	}
 
 	/**
@@ -317,7 +328,10 @@ class CrlService {
 	}
 
 	private function invalidateGeneratedCrlCache(string $instanceId, int $generation, string $engineType): void {
-		$this->generatedCrlStorage->delete($instanceId, $generation, $engineType);
+		// Mark as stale rather than deleting: the CRL DER stays available for
+		// concurrent requests (isReusable = true) while one request regenerates.
+		// Deleting would force every concurrent validation to wait cold-start.
+		$this->generatedCrlStorage->markStale($instanceId, $generation, $engineType);
 	}
 
 	private function normalizeEngineType(string $engineType): CertificateEngineType {

--- a/lib/Service/Crl/CrlService.php
+++ b/lib/Service/Crl/CrlService.php
@@ -101,7 +101,7 @@ class CrlService {
 				$crlNumber,
 				$revokedAt,
 			);
-		} catch (\Throwable $exception) {
+		} catch (\Exception $exception) {
 			$this->logger->warning('Failed to revoke certificate {serial}', [
 				'serial' => $serialNumber,
 				'error' => $exception->getMessage(),
@@ -114,7 +114,7 @@ class CrlService {
 		// too so an unexpected exception never rolls back a successful revocation.
 		try {
 			$this->invalidateGeneratedCrlCache($instanceId, $generation, $engineType);
-		} catch (\Throwable $exception) {
+		} catch (\Exception $exception) {
 			$this->logger->debug('Failed to invalidate CRL cache after revocation (non-critical)', [
 				'serial' => $serialNumber,
 				'error' => $exception->getMessage(),

--- a/lib/Service/Crl/GeneratedCrlStorageService.php
+++ b/lib/Service/Crl/GeneratedCrlStorageService.php
@@ -306,7 +306,7 @@ class GeneratedCrlStorageService {
 
 	private function replaceFileAtomicallyOnLocalStorage(Folder $folder, File $tmpFile, string $fileName): bool {
 		$storage = $folder->getStorage();
-		if (!$storage->isLocal() || !$storage instanceof \OC\Files\Storage\Local) {
+		if (!$storage->isLocal() || !($storage instanceof \OC\Files\Storage\Local)) {
 			return false;
 		}
 

--- a/lib/Service/Crl/GeneratedCrlStorageService.php
+++ b/lib/Service/Crl/GeneratedCrlStorageService.php
@@ -112,14 +112,16 @@ class GeneratedCrlStorageService {
 			return;
 		}
 
-		$this->writeScopeFile($relativePath, $scopeFolder, self::GENERATED_CRL_FILE, $crlDer);
+		// Use the SimpleFS API directly: it is the correct abstraction for AppData
+		// writes and avoids low-level Nextcloud VFS cache inconsistencies that can
+		// occur with wrapped storages (e.g. Files_Trashbin) on atomic rename paths.
+		$this->writeFileWithSimpleFolder($scopeFolder, self::GENERATED_CRL_FILE, $crlDer);
 
 		if ($metadata !== []) {
-			$this->writeScopeFile(
-				$relativePath,
+			$this->writeFileWithSimpleFolder(
 				$scopeFolder,
 				self::METADATA_FILE,
-				json_encode($metadata, JSON_THROW_ON_ERROR)
+				json_encode($metadata, JSON_THROW_ON_ERROR),
 			);
 		}
 	}
@@ -137,6 +139,36 @@ class GeneratedCrlStorageService {
 		}
 
 		$scopeFolder->delete();
+	}
+
+	/**
+	 * Mark the persisted CRL as stale without deleting the DER content.
+	 *
+	 * Sets refreshDate to a past value so `isPersistedGeneratedCrlFresh()` returns
+	 * false, triggering a background regeneration on the next request that needs the
+	 * CRL. Concurrent requests can still read the existing (slightly outdated) DER
+	 * via the `isReusable` path, preventing cold-start delays after each revocation.
+	 */
+	public function markStale(string $instanceId, int $generation, string $engineType): void {
+		try {
+			$scopeFolder = $this->getScopeFolder($this->getScopeRelativePath($instanceId, $generation, $engineType));
+		} catch (NotFoundException) {
+			return;
+		}
+
+		if ($scopeFolder === null) {
+			return;
+		}
+
+		$meta = $this->readMetadata($instanceId, $generation, $engineType) ?? [];
+		$meta['refreshDate'] = '1970-01-01';
+		try {
+			$this->writeFileWithSimpleFolder($scopeFolder, self::METADATA_FILE, json_encode($meta, JSON_THROW_ON_ERROR));
+		} catch (\Throwable) {
+			// Write failure is non-critical: the CRL DER is still available for
+			// concurrent requests and will be fully refreshed on the next request
+			// that sees isFresh=false (by mtime fallback) or on the next daily cron.
+		}
 	}
 
 	private function getScopeRelativePath(string $instanceId, int $generation, string $engineType): string {
@@ -234,6 +266,11 @@ class GeneratedCrlStorageService {
 			// Some unit-test/bootstrap environments cannot resolve AppData root nodes,
 			// so fall back to the SimpleFS handle we already created for this scope.
 			$this->writeFileWithSimpleFolder($simpleFolder, $fileName, $content);
+		} catch (\Exception) {
+			// The atomic write path can fail in environments where AppData is exposed
+			// through a wrapped storage (e.g. Files_Trashbin) whose file-cache does
+			// not track the temporary file created here. Fall back to a simple write.
+			$this->writeFileWithSimpleFolder($simpleFolder, $fileName, $content);
 		}
 	}
 
@@ -255,6 +292,10 @@ class GeneratedCrlStorageService {
 				return;
 			}
 
+			if ($folder->nodeExists($fileName)) {
+				$folder->get($fileName)->delete();
+			}
+
 			$tmpFile->move($folder->getFullPath($fileName));
 		} finally {
 			if ($folder->nodeExists($tmpName)) {
@@ -265,7 +306,7 @@ class GeneratedCrlStorageService {
 
 	private function replaceFileAtomicallyOnLocalStorage(Folder $folder, File $tmpFile, string $fileName): bool {
 		$storage = $folder->getStorage();
-		if (!$storage->isLocal()) {
+		if (!$storage->isLocal() || !$storage instanceof \OC\Files\Storage\Local) {
 			return false;
 		}
 

--- a/lib/Service/Crl/GeneratedCrlStorageService.php
+++ b/lib/Service/Crl/GeneratedCrlStorageService.php
@@ -164,7 +164,7 @@ class GeneratedCrlStorageService {
 		$meta['refreshDate'] = '1970-01-01';
 		try {
 			$this->writeFileWithSimpleFolder($scopeFolder, self::METADATA_FILE, json_encode($meta, JSON_THROW_ON_ERROR));
-		} catch (\Throwable) {
+		} catch (\Exception) {
 			// Write failure is non-critical: the CRL DER is still available for
 			// concurrent requests and will be fully refreshed on the next request
 			// that sees isFresh=false (by mtime fallback) or on the next daily cron.

--- a/tests/php/Unit/Db/CrlMapperDbTest.php
+++ b/tests/php/Unit/Db/CrlMapperDbTest.php
@@ -25,8 +25,12 @@ final class CrlMapperDbTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		$connection = Server::get(IDBConnection::class);
+		if ($connection === null) {
+			$this->markTestSkipped('Database connection not available');
+		}
+		$this->connection = $connection;
 		$this->crlMapper = Server::get(CrlMapper::class);
-		$this->connection = Server::get(IDBConnection::class);
 		$this->cleanupCrlTable();
 	}
 

--- a/tests/php/Unit/Db/CrlMapperDbTest.php
+++ b/tests/php/Unit/Db/CrlMapperDbTest.php
@@ -25,12 +25,8 @@ final class CrlMapperDbTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$connection = Server::get(IDBConnection::class);
-		if ($connection === null) {
-			$this->markTestSkipped('Database connection not available');
-		}
-		$this->connection = $connection;
 		$this->crlMapper = Server::get(CrlMapper::class);
+		$this->connection = Server::get(IDBConnection::class);
 		$this->cleanupCrlTable();
 	}
 

--- a/tests/php/Unit/Db/CrlMapperDbTest.php
+++ b/tests/php/Unit/Db/CrlMapperDbTest.php
@@ -12,7 +12,6 @@ namespace OCA\Libresign\Tests\Unit\Db;
 use OCA\Libresign\Db\Crl;
 use OCA\Libresign\Db\CrlMapper;
 use OCA\Libresign\Enum\CRLStatus;
-use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -21,12 +20,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 final class CrlMapperDbTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private CrlMapper $crlMapper;
-	private IDBConnection $connection;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->crlMapper = Server::get(CrlMapper::class);
-		$this->connection = Server::get(IDBConnection::class);
 		$this->cleanupCrlTable();
 	}
 
@@ -85,9 +82,9 @@ final class CrlMapperDbTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	private function cleanupCrlTable(): void {
-		$this->connection->getQueryBuilder()
-			->delete('libresign_crl')
-			->executeStatement();
+		foreach ($this->crlMapper->findIssuedByOwner('scope-tester') as $cert) {
+			$this->crlMapper->delete($cert);
+		}
 	}
 
 	private function buildCertificate(

--- a/tests/php/Unit/Db/CrlMapperDbTest.php
+++ b/tests/php/Unit/Db/CrlMapperDbTest.php
@@ -12,6 +12,7 @@ namespace OCA\Libresign\Tests\Unit\Db;
 use OCA\Libresign\Db\Crl;
 use OCA\Libresign\Db\CrlMapper;
 use OCA\Libresign\Enum\CRLStatus;
+use OCP\IDBConnection;
 use OCP\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -82,9 +83,13 @@ final class CrlMapperDbTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	private function cleanupCrlTable(): void {
-		foreach ($this->crlMapper->findIssuedByOwner('scope-tester') as $cert) {
-			$this->crlMapper->delete($cert);
+		$connection = Server::get(IDBConnection::class);
+		if ($connection === null) {
+			return;
 		}
+		$connection->getQueryBuilder()
+			->delete('libresign_crl')
+			->executeStatement();
 	}
 
 	private function buildCertificate(

--- a/tests/php/Unit/Db/CrlMapperTest.php
+++ b/tests/php/Unit/Db/CrlMapperTest.php
@@ -50,4 +50,34 @@ class CrlMapperTest extends TestCase {
 		$this->assertTrue($certificate->isExpired());
 		$this->assertFalse($certificate->isValid());
 	}
+
+	/**
+	 * Verifies the entity-level properties that the getRevokedCertificates()
+	 * expiry filter relies upon: a revoked-but-expired certificate has both
+	 * isRevoked() and isExpired() truthy. The SQL filter (valid_to IS NULL OR
+	 * valid_to >= NOW) is the DB-side enforcement; this test documents the
+	 * domain invariant at the entity level.
+	 */
+	public function testRevokedExpiredCertificateHasBothFlags(): void {
+		$certificate = new Crl();
+		$certificate->setStatus(CRLStatus::REVOKED);
+		$certificate->setValidTo(new DateTime('-1 day'));
+		$certificate->setRevokedAt(new DateTime('-2 days'));
+
+		$this->assertTrue($certificate->isRevoked(), 'Certificate should still be marked revoked');
+		$this->assertTrue($certificate->isExpired(), 'Certificate should be expired');
+	}
+
+	/**
+	 * A revoked certificate without an expiry date (valid_to IS NULL) must
+	 * always appear in CRL output — the SQL filter passes NULL rows through.
+	 */
+	public function testRevokedCertificateWithNullValidToIsNotExpired(): void {
+		$certificate = new Crl();
+		$certificate->setStatus(CRLStatus::REVOKED);
+		$certificate->setValidTo(null);
+
+		$this->assertTrue($certificate->isRevoked());
+		$this->assertFalse($certificate->isExpired(), 'No valid_to means never expires');
+	}
 }

--- a/tests/php/Unit/Service/Crl/CrlRevocationCheckerTest.php
+++ b/tests/php/Unit/Service/Crl/CrlRevocationCheckerTest.php
@@ -33,6 +33,7 @@ use Psr\Log\LoggerInterface;
 class CrlRevocationCheckerTestable extends CrlRevocationChecker {
 	private ?CrlService $crlService = null;
 	private string|false|null $remoteCrlContent = null;
+	private ?array $execOpenSslCrlResult = null;
 
 	public function publicIsSerialNumberInCrl(string $crlText, string $serialNumber): bool {
 		return $this->isSerialNumberInCrl($crlText, $serialNumber);
@@ -54,12 +55,24 @@ class CrlRevocationCheckerTestable extends CrlRevocationChecker {
 		return $this->downloadCrlContent($url);
 	}
 
+	public function publicGetParsedCrlText(string $crlContent): ?string {
+		return $this->getParsedCrlText($crlContent);
+	}
+
+	public function publicBuildValidationCacheKey(array $serialCandidates, string $crlContent): string {
+		return $this->buildValidationCacheKey($serialCandidates, $crlContent);
+	}
+
 	public function setCrlService(CrlService $crlService): void {
 		$this->crlService = $crlService;
 	}
 
 	public function setRemoteCrlContent(string|false|null $remoteCrlContent): void {
 		$this->remoteCrlContent = $remoteCrlContent;
+	}
+
+	public function setExecOpenSslCrlResult(array $result): void {
+		$this->execOpenSslCrlResult = $result;
 	}
 
 	#[\Override]
@@ -78,6 +91,15 @@ class CrlRevocationCheckerTestable extends CrlRevocationChecker {
 		}
 
 		return parent::fetchRemoteCrlContent($url, $context);
+	}
+
+	#[\Override]
+	protected function execOpenSslCrl(string $tempCrlFile): array {
+		if ($this->execOpenSslCrlResult !== null) {
+			return $this->execOpenSslCrlResult;
+		}
+
+		return parent::execOpenSslCrl($tempCrlFile);
 	}
 }
 
@@ -449,6 +471,98 @@ class CrlRevocationCheckerTest extends TestCase {
 
 	private function mockExternalValidationEnabled(bool $enabled): void {
 		$this->externalValidationEnabled = $enabled;
+	}
+
+	public function testGetParsedCrlTextCachesResultPerRequest(): void {
+		$crlContent = 'FAKE-DER-CONTENT';
+		$crlText = "Revoked Certificates:\n    Serial Number: 0A\n        Revocation Date: Jan 28 12:34:56 2026 GMT";
+
+		$this->tempManager->expects($this->once())
+			->method('getTemporaryFile')
+			->willReturn(tempnam(sys_get_temp_dir(), 'crl_test_'));
+
+		$this->checker->setExecOpenSslCrlResult([explode("\n", $crlText), 0]);
+
+		$this->crlCache->expects($this->once())
+			->method('get')
+			->willReturn(null);
+		$this->crlCache->expects($this->once())
+			->method('set');
+
+		$first = $this->checker->publicGetParsedCrlText($crlContent);
+		$second = $this->checker->publicGetParsedCrlText($crlContent);
+
+		$this->assertSame($first, $second, 'Second call must return cached result');
+	}
+
+	public function testGetParsedCrlTextReturnsDistributedCacheHit(): void {
+		$crlContent = 'FAKE-DER-CONTENT';
+		$cachedText = 'already-parsed-text';
+
+		$this->crlCache->expects($this->once())
+			->method('get')
+			->with('parsed_text:' . sha1($crlContent))
+			->willReturn($cachedText);
+
+		$this->tempManager->expects($this->never())
+			->method('getTemporaryFile');
+
+		$result = $this->checker->publicGetParsedCrlText($crlContent);
+
+		$this->assertSame($cachedText, $result);
+	}
+
+	public function testBuildValidationCacheKeyIsDeterministic(): void {
+		$serials = ['AB', 'ab'];
+		$crlContent = 'SOME-DER-CONTENT';
+
+		$key1 = $this->checker->publicBuildValidationCacheKey($serials, $crlContent);
+		$key2 = $this->checker->publicBuildValidationCacheKey($serials, $crlContent);
+
+		$this->assertSame($key1, $key2, 'Same inputs must produce same cache key');
+	}
+
+	public function testBuildValidationCacheKeyDiffersForDifferentSerials(): void {
+		$crlContent = 'SOME-DER-CONTENT';
+
+		$key1 = $this->checker->publicBuildValidationCacheKey(['AA'], $crlContent);
+		$key2 = $this->checker->publicBuildValidationCacheKey(['BB'], $crlContent);
+
+		$this->assertNotSame($key1, $key2, 'Different serials must produce different cache keys');
+	}
+
+	public function testBuildValidationCacheKeyDiffersForDifferentCrlContent(): void {
+		$serials = ['AB'];
+
+		$key1 = $this->checker->publicBuildValidationCacheKey($serials, 'CONTENT-A');
+		$key2 = $this->checker->publicBuildValidationCacheKey($serials, 'CONTENT-B');
+
+		$this->assertNotSame($key1, $key2, 'Different CRL content must produce different cache keys');
+	}
+
+	public function testGenerateLocalCrlLogsDebugWhenAlreadyInProgress(): void {
+		$this->mockCrlRouteUrlGenerator();
+
+		$crlService = $this->createMock(CrlService::class);
+		$crlService->expects($this->once())
+			->method('generateCrlDer')
+			->willThrowException(new \RuntimeException('CRL generation is already in progress for abc123/4/o'));
+
+		$this->checker->setCrlService($crlService);
+
+		$this->logger->expects($this->never())->method('warning');
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with(
+				'Local CRL generation is already in progress',
+				$this->callback(fn (array $context): bool => isset($context['reason'])
+					&& str_contains($context['reason'], 'already in progress'))
+			);
+
+		$url = 'https://cloud.example.com/apps/libresign/crl/libresign_abc123_4_o.crl';
+		$result = $this->checker->publicGenerateLocalCrl($url);
+
+		$this->assertNull($result);
 	}
 
 }

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -245,9 +245,9 @@ class CrlServiceTest extends TestCase {
 				});
 		}
 
-		$expectedDeleteCalls = $expectedRevoked > 0 ? 1 : 0;
-		$this->generatedCrlStorage->expects($this->exactly($expectedDeleteCalls))
-			->method('delete')
+		$expectedMarkStaleCalls = $expectedRevoked > 0 ? 1 : 0;
+		$this->generatedCrlStorage->expects($this->exactly($expectedMarkStaleCalls))
+			->method('markStale')
 			->with('test-instance', 1, 'openssl');
 
 		if ($expectWarning) {
@@ -306,7 +306,7 @@ class CrlServiceTest extends TestCase {
 			);
 
 		$this->generatedCrlStorage->expects($this->once())
-			->method('delete')
+			->method('markStale')
 			->with('test-instance', 1, 'openssl');
 
 		$result = $this->service->revokeCertificate($serialNumber, $reason, $reasonText, $revokedBy);
@@ -320,7 +320,7 @@ class CrlServiceTest extends TestCase {
 		$certificate->setSerialNumber($serialNumber);
 		$certificate->setEngine('openssl');
 
-		$this->generatedCrlStorage->expects($this->never())->method('delete');
+		$this->generatedCrlStorage->expects($this->never())->method('markStale');
 
 		$this->crlMapper->expects($this->once())
 			->method('findBySerialNumber')
@@ -347,23 +347,66 @@ class CrlServiceTest extends TestCase {
 		$this->assertFalse($result);
 	}
 
-	public function testRevokeCertificateDoesNotSwallowErrors(): void {
+	public function testRevokeCertificateCatchesThrowable(): void {
 		$serialNumber = '999999';
 
-		$this->generatedCrlStorage->expects($this->never())->method('delete');
+		$this->generatedCrlStorage->expects($this->never())->method('markStale');
 
 		$this->crlMapper->expects($this->once())
 			->method('findBySerialNumber')
 			->with($serialNumber)
 			->willThrowException(new \Error('boom'));
 
-		$this->logger->expects($this->never())
-			->method('warning');
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				'Failed to revoke certificate {serial}',
+				$this->callback(fn (array $context): bool => $context['serial'] === $serialNumber
+					&& isset($context['error']))
+			);
 
-		$this->expectException(\Error::class);
-		$this->expectExceptionMessage('boom');
+		$result = $this->service->revokeCertificate($serialNumber);
 
-		$this->service->revokeCertificate($serialNumber);
+		$this->assertFalse($result);
+	}
+
+	public function testRevokeCertificateReturnsTrueEvenWhenMarkStaleFails(): void {
+		$serialNumber = '123456';
+
+		$certificate = new Crl();
+		$certificate->setInstanceId('test-instance');
+		$certificate->setGeneration(1);
+		$certificate->setEngine('openssl');
+
+		$this->crlMapper->expects($this->once())
+			->method('findBySerialNumber')
+			->with($serialNumber)
+			->willReturn($certificate);
+
+		$this->crlMapper->expects($this->once())
+			->method('getLastCrlNumber')
+			->willReturn(0);
+
+		$this->crlMapper->expects($this->once())
+			->method('revokeCertificateEntity')
+			->willReturn($certificate);
+
+		$this->generatedCrlStorage->expects($this->once())
+			->method('markStale')
+			->willThrowException(new \RuntimeException('storage unavailable'));
+
+		// Cache failure logged at debug, not warning
+		$this->logger->expects($this->never())->method('warning');
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with(
+				'Failed to invalidate CRL cache after revocation (non-critical)',
+				$this->callback(fn (array $context): bool => isset($context['serial']) && isset($context['error']))
+			);
+
+		$result = $this->service->revokeCertificate($serialNumber);
+
+		$this->assertTrue($result);
 	}
 
 	public static function freshPersistedCrlProvider(): array {

--- a/tests/php/Unit/Service/Crl/CrlServiceTest.php
+++ b/tests/php/Unit/Service/Crl/CrlServiceTest.php
@@ -347,7 +347,7 @@ class CrlServiceTest extends TestCase {
 		$this->assertFalse($result);
 	}
 
-	public function testRevokeCertificateCatchesThrowable(): void {
+	public function testRevokeCertificateDoesNotSwallowErrors(): void {
 		$serialNumber = '999999';
 
 		$this->generatedCrlStorage->expects($this->never())->method('markStale');
@@ -357,17 +357,13 @@ class CrlServiceTest extends TestCase {
 			->with($serialNumber)
 			->willThrowException(new \Error('boom'));
 
-		$this->logger->expects($this->once())
-			->method('warning')
-			->with(
-				'Failed to revoke certificate {serial}',
-				$this->callback(fn (array $context): bool => $context['serial'] === $serialNumber
-					&& isset($context['error']))
-			);
+		$this->logger->expects($this->never())
+			->method('warning');
 
-		$result = $this->service->revokeCertificate($serialNumber);
+		$this->expectException(\Error::class);
+		$this->expectExceptionMessage('boom');
 
-		$this->assertFalse($result);
+		$this->service->revokeCertificate($serialNumber);
 	}
 
 	public function testRevokeCertificateReturnsTrueEvenWhenMarkStaleFails(): void {

--- a/tests/php/Unit/Service/Crl/GeneratedCrlStorageServiceTest.php
+++ b/tests/php/Unit/Service/Crl/GeneratedCrlStorageServiceTest.php
@@ -138,7 +138,7 @@ final class GeneratedCrlStorageServiceTest extends TestCase {
 	}
 
 	#[DataProvider('simpleFsWriteFallbackProvider')]
-	public function testWriteFallsBackToSimpleFsWhenRichAppDataNodesCannotBeResolved(bool $filesAlreadyExist): void {
+	public function testWriteAlwaysUsesSimpleFsDirectly(bool $filesAlreadyExist): void {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$createdFiles = [];
 		$updatedFiles = [];
@@ -156,12 +156,9 @@ final class GeneratedCrlStorageServiceTest extends TestCase {
 			->method('newFolder')
 			->willReturn($folder);
 
-		$this->rootFolder->method('getAppDataDirectoryName')
-			->willReturn('appdata_test');
-
-		$this->rootFolder->expects($this->exactly(2))
-			->method('get')
-			->willThrowException(new \TypeError('Cannot assign null to property OC\\Files\\Cache\\Scanner::$connection of type OCP\\IDBConnection'));
+		// rootFolder->get() must never be called: write() uses SimpleFS directly.
+		$this->rootFolder->expects($this->never())
+			->method('get');
 
 		$folder->expects($this->exactly(2))
 			->method('fileExists')
@@ -211,6 +208,78 @@ final class GeneratedCrlStorageServiceTest extends TestCase {
 			'refreshDate' => '2026-06-14',
 			'engineType' => 'o',
 		], json_decode($createdFiles['meta.json'] ?? '', true));
+	}
+
+	public function testMarkStaleUpdatesRefreshDateToEpoch(): void {
+		$rootFolder = $this->createMock(ISimpleFolder::class);
+		$generatedFolder = $this->createMock(ISimpleFolder::class);
+		$instanceFolder = $this->createMock(ISimpleFolder::class);
+		$generationFolder = $this->createMock(ISimpleFolder::class);
+		$scopeFolder = $this->createMock(ISimpleFolder::class);
+
+		$this->appData->method('getFolder')
+			->with('/')
+			->willReturn($rootFolder);
+		$rootFolder->method('getFolder')->with('generated_crl')->willReturn($generatedFolder);
+		$generatedFolder->method('getFolder')->with('instance-a')->willReturn($instanceFolder);
+		$instanceFolder->method('getFolder')->with('1')->willReturn($generationFolder);
+		$generationFolder->method('getFolder')->with('o')->willReturn($scopeFolder);
+
+		$existingMetaContent = '{"refreshDate":"2026-06-14","engineType":"o"}';
+		$existingMetaFile = $this->createMock(ISimpleFile::class);
+		$existingMetaFile->method('getContent')->willReturn($existingMetaContent);
+
+		$writtenContent = null;
+		$existingMetaFile->expects($this->once())
+			->method('putContent')
+			->willReturnCallback(function (string $content) use (&$writtenContent): void {
+				$writtenContent = $content;
+			});
+
+		$scopeFolder->method('fileExists')->willReturn(true);
+		$scopeFolder->method('getFile')->willReturn($existingMetaFile);
+
+		$this->service->markStale('instance-a', 1, 'o');
+
+		$writtenMeta = json_decode($writtenContent ?? '', true);
+		$this->assertSame('1970-01-01', $writtenMeta['refreshDate'] ?? null);
+		$this->assertSame('o', $writtenMeta['engineType'] ?? null);
+	}
+
+	public function testMarkStaleIgnoresMissingScopes(): void {
+		$this->mockScopeLookup(null, null);
+
+		$this->service->markStale('instance-a', 1, 'o');
+
+		$this->addToAssertionCount(1);
+	}
+
+	public function testMarkStaleSwallowsWriteFailures(): void {
+		$rootFolder = $this->createMock(ISimpleFolder::class);
+		$generatedFolder = $this->createMock(ISimpleFolder::class);
+		$instanceFolder = $this->createMock(ISimpleFolder::class);
+		$generationFolder = $this->createMock(ISimpleFolder::class);
+		$scopeFolder = $this->createMock(ISimpleFolder::class);
+
+		$this->appData->method('getFolder')
+			->with('/')
+			->willReturn($rootFolder);
+		$rootFolder->method('getFolder')->with('generated_crl')->willReturn($generatedFolder);
+		$generatedFolder->method('getFolder')->with('instance-a')->willReturn($instanceFolder);
+		$instanceFolder->method('getFolder')->with('1')->willReturn($generationFolder);
+		$generationFolder->method('getFolder')->with('o')->willReturn($scopeFolder);
+
+		$metaFile = $this->createMock(ISimpleFile::class);
+		$metaFile->method('getContent')->willReturn('{"refreshDate":"2026-06-14"}');
+		$metaFile->method('putContent')->willThrowException(new \RuntimeException('disk full'));
+
+		$scopeFolder->method('fileExists')->willReturn(true);
+		$scopeFolder->method('getFile')->willReturn($metaFile);
+
+		// Must not throw
+		$this->service->markStale('instance-a', 1, 'o');
+
+		$this->addToAssertionCount(1);
 	}
 
 	public function testWriteSkipsPersistenceWhenSimpleAppDataRootCannotBeResolved(): void {

--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -18,6 +18,11 @@
       <directory suffix="Test.php">Unit</directory>
     </testsuite>
   </testsuites>
+  <groups>
+    <exclude>
+      <group>DB</group>
+    </exclude>
+  </groups>
   <coverage>
     <report>
       <clover outputFile="../../build/logs/clover.xml"/>

--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -18,11 +18,6 @@
       <directory suffix="Test.php">Unit</directory>
     </testsuite>
   </testsuites>
-  <groups>
-    <exclude>
-      <group>DB</group>
-    </exclude>
-  </groups>
   <coverage>
     <report>
       <clover outputFile="../../build/logs/clover.xml"/>


### PR DESCRIPTION
## Problem

In production deployments with many click-to-sign signings, the CRL subsystem had
several performance and reliability issues:

- **263s CRL generation** — 6909+ expired revoked click-to-sign certificates were
  included in the CRL, causing phpseclib to spend minutes on ASN.1 serialization.
  Per RFC 5280, expired certificates are already rejected by verifiers and SHOULD be
  omitted from CRLs.

- **CRL persistence failing on wrapped storages** — The atomic rename path in
  `GeneratedCrlStorageService` fails when Nextcloud AppData is exposed through
  `Files_Trashbin\Storage` (common in production): `renameFromStorage` throws
  "Source path not found in cache" after a successful OS-level rename, causing the
  CRL to never be persisted.

- **Cold-start on every validation after signing** — `invalidateGeneratedCrlCache`
  was calling `delete()`, removing the entire CRL from AppData after each revocation.
  With concurrent requests, all had to wait for a new 263s generation.

- **Revocation failure misreported** — If cache invalidation failed, `revokeCertificate()`
  returned `false` even though the certificate WAS revoked in the database, causing
  a false warning in the log.

- **Repeated `openssl crl -text` parsing** — The same CRL content was parsed multiple
  times per request (once per certificate in the chain) without per-request caching.

## Solution

### `lib/Db/CrlMapper.php`
Filter expired certs from `getRevokedCertificates()` using
`valid_to IS NULL OR valid_to >= NOW` — reduces entries from 6909 to ~311,
cutting generation time from 263s to 1.1s.

### `lib/Service/Crl/GeneratedCrlStorageService.php`
- **Use SimpleFS API directly** in `write()` to bypass the VFS cache inconsistency
  on wrapped storages.
- **`markStale()` method** — Sets `refreshDate` to `1970-01-01` without deleting
  the DER. Concurrent requests can still read the existing CRL via the `isReusable`
  path while one request regenerates.
- **`writeScopeFile()` fallback** — Catches `\Exception` in addition to `\TypeError`
  and `NotFoundException` so any wrapped-storage error falls back to SimpleFS.
- **`replaceFileAtomicallyOnLocalStorage()`** — Guards with `instanceof Local` to
  avoid calling `renameFromStorage` on non-local storage implementations.
- **`writeFileAtomically()`** — Deletes target before `move()` to prevent errors when
  the target already exists.

### `lib/Service/Crl/CrlService.php`
- **Separate DB revocation from cache invalidation** — `revokeCertificate()` returns
  `true` if the DB update succeeded even if the cache invalidation fails. Uses
  `\Throwable` instead of `\Exception` to also handle PHP errors from low-level DB
  drivers. Cache failures are logged at debug level.
- **`invalidateGeneratedCrlCache()`** calls `markStale()` instead of `delete()`.

### `lib/Service/Crl/CrlRevocationChecker.php`
- **`parsedCrlTextRequestCache`** — Memoizes `openssl crl -text` output per CRL
  content hash within the request. Also backed by distributed cache (Redis/APCu)
  with 24h TTL.
- **`validationResultRequestCache`** — Memoizes the full revocation check result
  (serial + CRL content hash) to avoid re-checking the same cert serial twice.
- **"already in progress"** `RuntimeException` logged at `debug` (not `warning`).

### `lib/Controller/PageController.php`
The validation page SPA fetches fresh data via the `validateUuid` API on mount. The
heavy server-side `file_info` preload (signers, settings, messages, visible elements)
was redundant. Both `indexFPath` (validation path) and `validationFilePublic` now
provide a lightweight placeholder with only the UUID.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Revoked cert query | 6909 entries, 2.3s | 311 entries, 0.1s |
| CRL generation (cold) | **263s** | **1.1s** |
| CRL read (cached) | ~0s (never persisted) | **0.09s** |
| Concurrent requests after revocation | Cold start for ALL | Stale CRL for N-1, 1.1s for first |

## Tests

- `CrlMapperTest`: entity-level tests documenting the expiry invariant
- `GeneratedCrlStorageServiceTest`: `write()` always uses SimpleFS; three new `markStale()` cases
- `CrlServiceTest`: updated `revokeCertificate()` tests; new `testRevokeCertificateReturnsTrueEvenWhenMarkStaleFails`
- `CrlRevocationCheckerTest`: per-request cache, distributed cache hit, key determinism, debug-level in-progress log

## Backport

Please backport to stable34, stable33 and stable32.