### PR TITLE
chore(release): align npm version with v15.0.0-dev.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libresign",
-  "version": "13.0.0-dev.0",
+  "version": "15.0.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libresign",
-      "version": "13.0.0-dev.0",
+      "version": "15.0.0-dev.1",
       "license": "agpl",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libresign",
   "description": "A app for signing documents",
-  "version": "13.0.0-dev.0",
+  "version": "15.0.0-dev.1",
   "license": "agpl",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- align `package.json` with `appinfo/info.xml`
- align `package-lock.json` with the current main development version

## Why
The main branch currently reports `15.0.0-dev.1` in `appinfo/info.xml`, but both npm package files still declare `13.0.0-dev.0`.

## Testing
- confirm `package.json` version matches `appinfo/info.xml`
- confirm `package-lock.json` root version matches `appinfo/info.xml`