### PR TITLE
feat: add drag-and-drop document upload to Files page

### DIFF
--- a/src/components/Request/RequestPicker.vue
+++ b/src/components/Request/RequestPicker.vue
@@ -401,6 +401,31 @@ function cancelUpload() {
 	uploadAbortController.value?.abort()
 }
 
+async function handleFilesSelected(files: UploadFile[]) {
+	if (files.length === 0) {
+		return
+	}
+
+	if (!validateMaxFileUploads(files.length)) {
+		return
+	}
+
+	if (files.length > 1 && !envelopeEnabled.value) {
+		// TRANSLATORS Shown when more than one file is selected/dropped but envelopes (multi-file requests) are not enabled.
+		showError(t('libresign', 'Only one file can be uploaded at a time.'))
+		return
+	}
+
+	if (files.length > 1 && envelopeEnabled.value) {
+		pendingFiles.value = files
+		envelopeNameInput.value = ''
+		showEnvelopeNameDialog.value = true
+		return
+	}
+
+	await upload(files)
+}
+
 function uploadFile() {
 	openedMenu.value = false
 	const input = document.createElement('input')
@@ -411,23 +436,7 @@ function uploadFile() {
 	input.onchange = async (event) => {
 		const target = event.target as HTMLInputElement | null
 		const files = Array.from(target?.files ?? []) as unknown as UploadFile[]
-		if (!validateMaxFileUploads(files.length)) {
-			input.remove()
-			return
-		}
-
-		if (files.length > 1 && envelopeEnabled.value) {
-			pendingFiles.value = files
-			envelopeNameInput.value = ''
-			showEnvelopeNameDialog.value = true
-			input.remove()
-			return
-		}
-
-		if (files.length > 0) {
-			await upload(files)
-		}
-
+		await handleFilesSelected(files)
 		input.remove()
 	}
 
@@ -544,6 +553,7 @@ defineExpose({
 	closeModalUploadFromUrl,
 	upload,
 	cancelUpload,
+	handleFilesSelected,
 	uploadFile,
 	uploadUrl,
 	handleFileChoose,

--- a/src/tests/components/Request/RequestPicker.spec.ts
+++ b/src/tests/components/Request/RequestPicker.spec.ts
@@ -458,6 +458,77 @@ describe('RequestPicker component rules', () => {
 		})
 	})
 
+	describe('handleFilesSelected (shared entry point for click-upload and drag-and-drop)', () => {
+		it('does nothing when no files are provided', async () => {
+			await wrapper.vm.handleFilesSelected([])
+			expect(filesStore.upload).not.toHaveBeenCalled()
+		})
+
+		it('shows error and does not upload when exceeding max file uploads limit', async () => {
+			getCapabilitiesMock.mockReturnValue({
+				libresign: {
+					config: {
+						envelope: { 'is-available': true },
+						upload: { 'max-file-uploads': 1 },
+					},
+				},
+			})
+			const files = [
+				{ name: 'document1.pdf', size: 1000 },
+				{ name: 'document2.pdf', size: 1000 },
+			]
+			await wrapper.vm.handleFilesSelected(files)
+			expect(showError).toHaveBeenCalled()
+			expect(filesStore.upload).not.toHaveBeenCalled()
+		})
+
+		it('shows error and does not upload when multiple files provided while envelope is disabled', async () => {
+			getCapabilitiesMock.mockReturnValue({
+				libresign: {
+					config: {
+						envelope: { 'is-available': false },
+						upload: { 'max-file-uploads': 20 },
+					},
+				},
+			})
+			const files = [
+				{ name: 'document1.pdf', size: 1000 },
+				{ name: 'document2.pdf', size: 1000 },
+			]
+			await wrapper.vm.handleFilesSelected(files)
+			expect(showError).toHaveBeenCalledWith('Only one file can be uploaded at a time.')
+			expect(filesStore.upload).not.toHaveBeenCalled()
+			expect(wrapper.vm.showEnvelopeNameDialog).toBe(false)
+		})
+
+		it('opens envelope name dialog for multiple files when envelope is enabled', async () => {
+			getCapabilitiesMock.mockReturnValue({
+				libresign: {
+					config: {
+						envelope: { 'is-available': true },
+						upload: { 'max-file-uploads': 20 },
+					},
+				},
+			})
+			const files = [
+				{ name: 'document1.pdf', size: 1000 },
+				{ name: 'document2.pdf', size: 1000 },
+			]
+			await wrapper.vm.handleFilesSelected(files)
+			expect(wrapper.vm.showEnvelopeNameDialog).toBe(true)
+			expect(wrapper.vm.pendingFiles).toEqual(files)
+			expect(filesStore.upload).not.toHaveBeenCalled()
+		})
+
+		it('uploads directly when a single file is provided', async () => {
+			filesStore.upload.mockResolvedValue(42)
+			const files = [{ name: 'document.pdf', size: 1000 }]
+			await wrapper.vm.handleFilesSelected(files)
+			expect(filesStore.upload).toHaveBeenCalled()
+			expect(filesStore.selectFile).toHaveBeenCalledWith(42)
+		})
+	})
+
 	describe('envelope name dialog submission', () => {
 		it('creates envelope with trimmed name when minimum length met', async () => {
 			filesStore.upload.mockResolvedValue(1)

--- a/src/tests/views/FilesList/FilesList.spec.ts
+++ b/src/tests/views/FilesList/FilesList.spec.ts
@@ -122,10 +122,17 @@ vi.mock('../../../views/FilesList/FileListFilters.vue', () => ({
 	},
 }))
 
+const handleFilesSelectedMock = vi.fn()
+
 vi.mock('../../../components/Request/RequestPicker.vue', () => ({
 	default: {
 		name: 'RequestPicker',
 		template: '<div class="request-picker-stub" />',
+		methods: {
+			handleFilesSelected(files: File[]) {
+				return handleFilesSelectedMock(files)
+			},
+		},
 	},
 }))
 
@@ -312,5 +319,117 @@ describe('FilesList.vue rendering rules', () => {
 		wrapper.unmount()
 
 		expect(selectSpy).toHaveBeenCalledWith()
+	})
+
+	describe('drag-and-drop upload', () => {
+		function createDragEvent(files: File[] = [], types: string[] = ['Files']) {
+			return {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					types,
+					files,
+					dropEffect: '',
+				},
+			} as unknown as DragEvent
+		}
+
+		it('shows the drop overlay when a file is dragged over and user can request sign', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = true
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			expect(wrapper.vm.isDraggingFiles).toBe(false)
+			wrapper.vm.onDragEnter(createDragEvent())
+			expect(wrapper.vm.isDraggingFiles).toBe(true)
+		})
+
+		it('does not show the drop overlay when user cannot request sign', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = false
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			wrapper.vm.onDragEnter(createDragEvent())
+			expect(wrapper.vm.isDraggingFiles).toBe(false)
+		})
+
+		it('ignores drags that do not carry files', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = true
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			wrapper.vm.onDragEnter(createDragEvent([], ['text/plain']))
+			expect(wrapper.vm.isDraggingFiles).toBe(false)
+		})
+
+		it('hides the overlay only after the last dragleave of nested elements', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = true
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			wrapper.vm.onDragEnter(createDragEvent())
+			wrapper.vm.onDragEnter(createDragEvent())
+			expect(wrapper.vm.isDraggingFiles).toBe(true)
+
+			wrapper.vm.onDragLeave(createDragEvent())
+			expect(wrapper.vm.isDraggingFiles).toBe(true)
+
+			wrapper.vm.onDragLeave(createDragEvent())
+			expect(wrapper.vm.isDraggingFiles).toBe(false)
+		})
+
+		it('delegates dropped files to RequestPicker.handleFilesSelected and hides the overlay', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = true
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			const file = new File(['content'], 'document.pdf', { type: 'application/pdf' })
+			wrapper.vm.onDragEnter(createDragEvent([file]))
+			await wrapper.vm.onDrop(createDragEvent([file]))
+
+			expect(handleFilesSelectedMock).toHaveBeenCalledWith([file])
+			expect(wrapper.vm.isDraggingFiles).toBe(false)
+		})
+
+		it('does not upload dropped files when user cannot request sign', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = false
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			const file = new File(['content'], 'document.pdf', { type: 'application/pdf' })
+			await wrapper.vm.onDrop(createDragEvent([file]))
+
+			expect(handleFilesSelectedMock).not.toHaveBeenCalled()
+		})
+
+		it('does not call handleFilesSelected when no files are dropped', async () => {
+			const filesStore = useFilesStore()
+			filesStore.canRequestSign = true
+			vi.spyOn(filesStore, 'getAllFiles').mockResolvedValue({})
+
+			const wrapper = mountComponent()
+			await flushPromises()
+
+			await wrapper.vm.onDrop(createDragEvent([]))
+
+			expect(handleFilesSelectedMock).not.toHaveBeenCalled()
+		})
 	})
 })

--- a/src/views/FilesList/FilesList.vue
+++ b/src/views/FilesList/FilesList.vue
@@ -11,6 +11,7 @@
 			@drop="onDrop">
 			<div v-if="isDraggingFiles" class="files-list__drop-overlay" aria-hidden="true">
 				<NcIconSvgWrapper :path="mdiUpload" :size="48" />
+				<!-- TRANSLATORS Instruction shown while dragging files over the file list. Dropping files here uploads them so they can be sent for signature. -->
 				<p>{{ t('libresign', 'Drop files here to upload') }}</p>
 			</div>
 			<div class="files-list__header">

--- a/src/views/FilesList/FilesList.vue
+++ b/src/views/FilesList/FilesList.vue
@@ -4,86 +4,96 @@
 -->
 <template>
 	<NcAppContent :page-heading="t('libresign', 'Files')">
-		<div class="files-list__header">
-			<!-- Request picker -->
-			<RequestPicker variant="primary" />
+		<div class="files-list__dropzone"
+			@dragenter="onDragEnter"
+			@dragover="onDragOver"
+			@dragleave="onDragLeave"
+			@drop="onDrop">
+			<div v-if="isDraggingFiles" class="files-list__drop-overlay" aria-hidden="true">
+				<NcIconSvgWrapper :path="mdiUpload" :size="48" />
+				<p>{{ t('libresign', 'Drop files here to upload') }}</p>
+			</div>
+			<div class="files-list__header">
+				<!-- Request picker -->
+				<RequestPicker ref="requestPickerRef" variant="primary" />
 
-			<!-- Current folder breadcrumbs -->
-			<NcBreadcrumbs class="files-list__breadcrumbs">
-				<NcBreadcrumb :name="t('libresign', 'Files')"
-					:title="t('libresign', 'Files')"
-					:force-icon-text="true"
-					:to="{ name: 'fileslist' }"
-					:aria-description="t('libresign', 'Files')"
-					:disable-drop="true"
-					force-menu
-					v-model:open="isMenuOpen">
-					<template #icon>
-						<NcIconSvgWrapper :size="20"
-							:svg="viewIcon" />
-					</template>
-					<template #menu-icon>
-						<NcIconSvgWrapper :path="isMenuOpen ? mdiChevronUp : mdiChevronDown" />
-					</template>
-					<!-- Reload button -->
-					<NcActionButton close-after-click @click="refresh()">
+				<!-- Current folder breadcrumbs -->
+				<NcBreadcrumbs class="files-list__breadcrumbs">
+					<NcBreadcrumb :name="t('libresign', 'Files')"
+						:title="t('libresign', 'Files')"
+						:force-icon-text="true"
+						:to="{ name: 'fileslist' }"
+						:aria-description="t('libresign', 'Files')"
+						:disable-drop="true"
+						force-menu
+						v-model:open="isMenuOpen">
 						<template #icon>
-							<NcIconSvgWrapper :path="mdiReload" />
+							<NcIconSvgWrapper :size="20"
+								:svg="viewIcon" />
 						</template>
-						<!-- TRANSLATORS Button inside the breadcrumb dropdown menu that reloads the file list -->
-						{{ t('libresign', 'Reload content') }}
-					</NcActionButton>
-				</NcBreadcrumb>
-			</NcBreadcrumbs>
+						<template #menu-icon>
+							<NcIconSvgWrapper :path="isMenuOpen ? mdiChevronUp : mdiChevronDown" />
+						</template>
+						<!-- Reload button -->
+						<NcActionButton close-after-click @click="refresh()">
+							<template #icon>
+								<NcIconSvgWrapper :path="mdiReload" />
+							</template>
+							<!-- TRANSLATORS Button inside the breadcrumb dropdown menu that reloads the file list -->
+							{{ t('libresign', 'Reload content') }}
+						</NcActionButton>
+					</NcBreadcrumb>
+				</NcBreadcrumbs>
 
-			<NcLoadingIcon v-if="isRefreshing"
-				class="files-list__refresh-icon"
-				:name="t('libresign', 'File list is reloading')" />
+				<NcLoadingIcon v-if="isRefreshing"
+					class="files-list__refresh-icon"
+					:name="t('libresign', 'File list is reloading')" />
 
-			<!-- Filters that can be applied to the file list -->
-			<FileListFilters />
+				<!-- Filters that can be applied to the file list -->
+				<FileListFilters />
 
-			<NcButton :aria-label="gridViewButtonLabel"
-				:title="gridViewButtonLabel"
-				class="files-list__header-grid-button"
-				variant="tertiary"
-				@click="toggleGridView">
-				<template #icon>
-					<NcIconSvgWrapper v-if="isGridView" :path="mdiFormatListBulletedSquare" />
-					<NcIconSvgWrapper v-else :path="mdiViewGridOutline" />
+				<NcButton :aria-label="gridViewButtonLabel"
+					:title="gridViewButtonLabel"
+					class="files-list__header-grid-button"
+					variant="tertiary"
+					@click="toggleGridView">
+					<template #icon>
+						<NcIconSvgWrapper v-if="isGridView" :path="mdiFormatListBulletedSquare" />
+						<NcIconSvgWrapper v-else :path="mdiViewGridOutline" />
+					</template>
+				</NcButton>
+			</div>
+			<FilesListVirtual :nodes="dirContentsSorted"
+				:loading="loading">
+				<template #empty>
+					<NcLoadingIcon
+						v-if="loading && !isRefreshing"
+						class="files-list__loading-icon"
+						:size="38"
+						:name="t('libresign', 'Loading …')" />
+
+					<NcEmptyContent
+						v-else-if="!loading && isEmptyDir && filtersStore.activeChips.length === 0"
+						:name="t('libresign', 'There are no documents')"
+						:description="canRequestSign ? t('libresign', 'Choose a file to create a signature request.') : ''">
+						<template v-if="canRequestSign" #action>
+							<RequestPicker variant="primary" />
+						</template>
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiFolder" />
+						</template>
+					</NcEmptyContent>
+
+					<NcEmptyContent
+						v-else-if="!loading && isEmptyDir && filtersStore.activeChips.length > 0"
+						:name="t('libresign', 'No documents found')">
+						<template #icon>
+							<NcIconSvgWrapper :path="mdiFolder" />
+						</template>
+					</NcEmptyContent>
 				</template>
-			</NcButton>
+			</FilesListVirtual>
 		</div>
-		<FilesListVirtual :nodes="dirContentsSorted"
-			:loading="loading">
-			<template #empty>
-				<NcLoadingIcon
-					v-if="loading && !isRefreshing"
-					class="files-list__loading-icon"
-					:size="38"
-					:name="t('libresign', 'Loading …')" />
-
-				<NcEmptyContent
-					v-else-if="!loading && isEmptyDir && filtersStore.activeChips.length === 0"
-					:name="t('libresign', 'There are no documents')"
-					:description="canRequestSign ? t('libresign', 'Choose a file to create a signature request.') : ''">
-					<template v-if="canRequestSign" #action>
-						<RequestPicker variant="primary" />
-					</template>
-					<template #icon>
-						<NcIconSvgWrapper :path="mdiFolder" />
-					</template>
-				</NcEmptyContent>
-
-				<NcEmptyContent
-					v-else-if="!loading && isEmptyDir && filtersStore.activeChips.length > 0"
-					:name="t('libresign', 'No documents found')">
-					<template #icon>
-						<NcIconSvgWrapper :path="mdiFolder" />
-					</template>
-				</NcEmptyContent>
-			</template>
-		</FilesListVirtual>
 	</NcAppContent>
 </template>
 
@@ -100,6 +110,7 @@ import {
 	mdiFolder,
 	mdiFormatListBulletedSquare,
 	mdiReload,
+	mdiUpload,
 	mdiViewGridOutline,
 } from '@mdi/js'
 
@@ -136,6 +147,9 @@ const route = useRoute()
 
 const isMenuOpen = ref(false)
 const loading = ref(true)
+const requestPickerRef = ref<InstanceType<typeof RequestPicker> | null>(null)
+const isDraggingFiles = ref(false)
+const dragDepth = ref(0)
 
 const canRequestSign = computed(() => filesStore.canRequestSign)
 const viewIcon = computed(() => HomeSvg)
@@ -155,6 +169,57 @@ function refresh() {
 
 function toggleGridView() {
 	userConfigStore.update('files_list_grid_view', !isGridView.value)
+}
+
+function isFileDrag(event: DragEvent) {
+	return Array.from(event.dataTransfer?.types ?? []).includes('Files')
+}
+
+function onDragEnter(event: DragEvent) {
+	if (!canRequestSign.value || !isFileDrag(event)) {
+		return
+	}
+	event.preventDefault()
+	dragDepth.value++
+	isDraggingFiles.value = true
+}
+
+function onDragOver(event: DragEvent) {
+	if (!canRequestSign.value || !isFileDrag(event)) {
+		return
+	}
+	event.preventDefault()
+	if (event.dataTransfer) {
+		event.dataTransfer.dropEffect = 'copy'
+	}
+}
+
+function onDragLeave(event: DragEvent) {
+	if (!canRequestSign.value || !isFileDrag(event)) {
+		return
+	}
+	event.preventDefault()
+	dragDepth.value = Math.max(0, dragDepth.value - 1)
+	if (dragDepth.value === 0) {
+		isDraggingFiles.value = false
+	}
+}
+
+async function onDrop(event: DragEvent) {
+	event.preventDefault()
+	dragDepth.value = 0
+	isDraggingFiles.value = false
+
+	if (!canRequestSign.value) {
+		return
+	}
+
+	const files = Array.from(event.dataTransfer?.files ?? [])
+	if (files.length === 0) {
+		return
+	}
+
+	await requestPickerRef.value?.handleFilesSelected?.(files)
 }
 
 async function checkAndOpenFileFromUri() {
@@ -187,12 +252,18 @@ onBeforeUnmount(() => {
 
 defineExpose({
 	isMenuOpen,
+	isDraggingFiles,
 	mdiChevronDown,
 	mdiChevronUp,
 	mdiFolder,
 	mdiFormatListBulletedSquare,
 	mdiReload,
+	mdiUpload,
 	mdiViewGridOutline,
+	onDragEnter,
+	onDragOver,
+	onDragLeave,
+	onDrop,
 })
 </script>
 
@@ -204,6 +275,39 @@ defineExpose({
 	flex-direction: column;
 	max-height: 100%;
 	position: relative !important;
+}
+
+.files-list__dropzone {
+	display: flex;
+	overflow: hidden;
+	flex-direction: column;
+	flex: 1 1 auto;
+	min-height: 0;
+	max-height: 100%;
+	position: relative;
+}
+
+.files-list__drop-overlay {
+	position: absolute;
+	inset: 8px;
+	z-index: 100;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	border: 2px dashed var(--color-primary-element);
+	border-radius: var(--border-radius-large);
+	background-color: var(--color-main-background);
+	opacity: 0.95;
+	color: var(--color-primary-element);
+	pointer-events: none;
+
+	p {
+		margin: 0;
+		font-size: 16px;
+		font-weight: bold;
+	}
 }
 
 .files-list__breadcrumbs {


### PR DESCRIPTION
Resolves: #7926

## 📝 Summary

Adds drag-and-drop as an additional input method for the existing upload flow on the LibreSign Files page. Dropped files are routed through the same validation, envelope, and upload logic as the existing "Upload" button by extracting a shared `RequestPicker.handleFilesSelected()` entry point, so there are no separate rules for drag-and-drop vs. click-to-upload.

- `FilesList.vue` gains dragenter/dragover/dragleave/drop handlers on the page content area, with a visual drop-target overlay, gated on the existing `canRequestSign` permission.
- `RequestPicker.vue`'s max-file-uploads and envelope-name-dialog logic is reused as-is; a new guard shows an error when multiple files are dropped while envelopes are disabled (previously unreachable via the single-select file picker, but reachable via drag-and-drop).

## 🧪 How to test

1. Open the LibreSign Files page as a user who can request signatures.
2. Drag a PDF from your file explorer over the file list — a dashed-border "Drop files here to upload" overlay should appear.
3. Drop it — it uploads and appears in the list, same as using the "Upload" button.
4. With envelopes enabled, drop 2+ files — the envelope-naming dialog opens, same as the existing multi-select flow.
5. With envelopes disabled, drop 2+ files — you get an "Only one file can be uploaded at a time." error and nothing uploads.
6. Confirm the existing "+ Request" → "Upload" click flow still works unchanged.

Automated coverage: `src/tests/components/Request/RequestPicker.spec.ts` and `src/tests/views/FilesList/FilesList.spec.ts` (both envelope-enabled and envelope-disabled scenarios).

Note for reviewers: this was verified visually against the real Vue component tree using a temporary local harness with a mocked backend, in addition to the automated test suite. It has not yet been exercised against a live Nextcloud instance — please do a real end-to-end pass before merging.

## 🎨 UI / Front‑end changes

- [x] Added drag-and-drop upload support to the Files page, reusing the existing upload button's validation/envelope/upload logic.
- [ ] Screenshots before/after (add images or links)

- [ ] Tested in multiple browsers (Chrome, Firefox, Safari) – *optional but appreciated*
- [x] Components, Unit (with vitest) and/or e2e (with Playwright) tests added - *Required*
- [ ] Accessibility verified (contrast, keyboard navigation, screen reader friendly) – *if applicable*
  (Existing keyboard flows are untouched; the drop overlay is `aria-hidden` + `pointer-events: none` so it can't trap focus or interfere with tab order — but no actual screen-reader pass was done.)
- [ ] Design review approved – *optional, link to feedback if available*
- [ ] Documentation updated (if applicable) – [docs repository](https://github.com/LibreSign/documentation/)

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Drag-and-drop reuses the existing upload/validate path rather than adding a separate flow
- [x] Existing click-to-upload and keyboard access preserved

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
