### PR TITLE
fix: correct iOS Safari viewport height on sign request

### DIFF
--- a/src/ExternalApp.vue
+++ b/src/ExternalApp.vue
@@ -32,6 +32,7 @@ html body #content {
 	margin: 0;
 	width: 100vw;
 	height: 100vh;
+	height: 100dvh;
 	border-radius: 0;
 }
 
@@ -44,6 +45,7 @@ html body #content {
 		width: 100vw !important;
 		max-width: 100vw !important;
 		height: 100vh;
+		height: 100dvh;
 		z-index: 2000;
 	}
 }


### PR DESCRIPTION
## 📝 Summary

Fixes the external signing page being cut off at the bottom on iOS Safari.

`ExternalApp.vue` sizes `html body #content` — and, under `max-width: 512px`, `#app-sidebar` — to `height: 100vh` with `position: fixed`. iOS Safari resolves `100vh` against the **large viewport** i.e. as though the browser chrome were hidden. The element therefore extends behind the bottom toolbar, and its lower edge cannot be scrolled into view / is inaccessible.

On the signing page that lower edge is the action bar, so a signer on an iPhone sees it clipped and cannot reliably tap it. Signing is effectively blocked on mobile Safari.

This pairs each `100vh` with a following `100dvh`. The dynamic viewport unit tracks the browser chrome as it shows and hides, which is the intended behaviour here.

**Why it is paired with `100vh`**

The `100vh` declaration is kept first, so a browser without `dvh` support simply drops the second declaration and behaves exactly as it does today. From my understanding, no `@supports` guard is needed and there is no regression risk for older clients.

Note: I did test on other browsers, but the before/after is the same for desktop.

## 🧪 How to test
1. Open signature request page on iOS with Safari or other mobile browser
2. The bottom `<aside>` allowing signature defining is no longer obscured by UI elements

## 🎨 UI / Front‑end changes

🏚️ Before | 🏡 After
--- | ---
<img width="598" height="1294" alt="2026-08-02_10-47" src="https://github.com/user-attachments/assets/c2ded690-ee83-43f5-87fe-a95c0687a9ec" /> | <img width="600" height="1314" alt="2026-08-02_10-47_1" src="https://github.com/user-attachments/assets/0d030d90-3dc6-4673-962b-ada7b36f838f" />


<!-- ☀️ Light theme | 🌑 Dark theme → Please test and document both themes -->

- [x] Tested in multiple browsers (Chrome, Firefox, Safari) – *optional but appreciated*
- [n/a] Components, Unit (with vitest) and/or e2e (with Playwright) tests added - *Required*
- [x] Accessibility verified (contrast, keyboard navigation, screen reader friendly) – *if applicable*
- [n/a] Design review approved – *optional, link to feedback if available*
- [n/a] Documentation updated (if applicable) – [docs repository](https://github.com/LibreSign/documentation/)

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
