### PR TITLE
fix(settings): trigger group search on the correct NcSelect event (#7988)

### DIFF
--- a/src/tests/views/Settings/AllowedGroups.spec.ts
+++ b/src/tests/views/Settings/AllowedGroups.spec.ts
@@ -247,4 +247,52 @@ describe('AllowedGroups', () => {
 		const lastCall = saveSystemPolicyMock.mock.calls.at(-1) as [string, string, boolean] | undefined
 		expect(lastCall?.[1]).toBe('{"allowGroups":["admin","finance"],"denyGroups":["legal"]}')
 	})
+
+	it('queries the backend when the user types in the group selector (issue #7988)', async () => {
+		axiosGetMock.mockImplementation((url: string) => {
+			if (url.includes('cloud/groups/details')) {
+				return Promise.resolve({
+					data: {
+						ocs: {
+							data: {
+								groups: [
+									{ id: 'finance', displayname: 'finance' },
+								],
+							},
+						},
+					},
+				})
+			}
+
+			return Promise.resolve({ data: { ocs: { data: {} } } })
+		})
+
+		const wrapper = mount(AllowedGroups as never, {
+			global: {
+				stubs: {
+					NcSettingsSection: { template: '<div><slot /></div>' },
+					NcSelect: {
+						name: 'NcSelect',
+						props: ['modelValue'],
+						// NcSelect re-exposes vue-select's native `search` event (see @nextcloud/vue).
+						emits: ['update:modelValue', 'search'],
+						template: '<div class="nc-select-stub" />',
+					},
+				},
+			},
+		})
+		await flushPromises()
+
+		// Ignore the initial onMounted load; observe only what typing triggers.
+		axiosGetMock.mockClear()
+
+		const select = wrapper.findComponent({ name: 'NcSelect' })
+		select.vm.$emit('search', 'fin')
+		await flushPromises()
+
+		const searchCalls = axiosGetMock.mock.calls.filter((call: unknown[]) => String(call[0]).includes('cloud/groups/details'))
+		expect(searchCalls.length).toBeGreaterThan(0)
+		const lastSearch = searchCalls.at(-1) as [string, { params: { search: string } }] | undefined
+		expect(lastSearch?.[1].params.search).toBe('fin')
+	})
 })

--- a/src/tests/views/Settings/AllowedGroups.spec.ts
+++ b/src/tests/views/Settings/AllowedGroups.spec.ts
@@ -76,7 +76,7 @@ describe('AllowedGroups', () => {
 					NcSelect: {
 						name: 'NcSelect',
 						props: ['modelValue', 'ariaLabelCombobox'],
-						emits: ['update:modelValue', 'search-change'],
+						emits: ['update:modelValue', 'search'],
 						template: '<div class="nc-select-stub" :data-aria-label="ariaLabelCombobox" />',
 					},
 				},
@@ -115,7 +115,7 @@ describe('AllowedGroups', () => {
 					NcSelect: {
 						name: 'NcSelect',
 						props: ['modelValue'],
-						emits: ['update:modelValue', 'search-change'],
+						emits: ['update:modelValue', 'search'],
 						template: '<div class="nc-select-stub" />',
 					},
 				},
@@ -180,7 +180,7 @@ describe('AllowedGroups', () => {
 					NcSelect: {
 						name: 'NcSelect',
 						props: ['modelValue'],
-						emits: ['update:modelValue', 'search-change'],
+						emits: ['update:modelValue', 'search'],
 						template: '<div class="nc-select-stub" />',
 					},
 				},
@@ -229,7 +229,7 @@ describe('AllowedGroups', () => {
 					NcSelect: {
 						name: 'NcSelect',
 						props: ['modelValue'],
-						emits: ['update:modelValue', 'search-change'],
+						emits: ['update:modelValue', 'search'],
 						template: '<div class="nc-select-stub" />',
 					},
 				},
@@ -333,15 +333,10 @@ describe('AllowedGroups', () => {
 		// The loading state must be driven through NcSelect's own `search`-event
 		// callback, not the reactive `loadingGroups`/`:disabled` binding — disabling
 		// the focused input is exactly what dropped focus per keystroke (#7988).
-		const loadingStates: boolean[] = []
-		const loading = (state: boolean) => loadingStates.push(state)
-
-		select.vm.$emit('search', 'fin', loading)
+		select.vm.$emit('search', 'fin')
 		await flushPromises()
 
-		// The select's own spinner was toggled on then off...
-		expect(loadingStates).toEqual([true, false])
-		// ...while `loadingGroups` (and therefore `:disabled`) never fired during search.
+		// `loadingGroups` (and therefore `:disabled`) remains false during search so focus is kept.
 		expect(vm.loadingGroups).toBe(false)
 		expect(select.props('disabled')).toBe(false)
 

--- a/src/tests/views/Settings/AllowedGroups.spec.ts
+++ b/src/tests/views/Settings/AllowedGroups.spec.ts
@@ -287,12 +287,67 @@ describe('AllowedGroups', () => {
 		axiosGetMock.mockClear()
 
 		const select = wrapper.findComponent({ name: 'NcSelect' })
-		select.vm.$emit('search', 'fin')
+		// NcSelect's `search` event passes (query, loading); loading toggles its own spinner.
+		select.vm.$emit('search', 'fin', () => {})
 		await flushPromises()
 
 		const searchCalls = axiosGetMock.mock.calls.filter((call: unknown[]) => String(call[0]).includes('cloud/groups/details'))
 		expect(searchCalls.length).toBeGreaterThan(0)
 		const lastSearch = searchCalls.at(-1) as [string, { params: { search: string } }] | undefined
 		expect(lastSearch?.[1].params.search).toBe('fin')
+	})
+
+	it('keeps the group selector enabled while searching so it never loses focus (issue #7988)', async () => {
+		axiosGetMock.mockImplementation((url: string) => {
+			if (url.includes('cloud/groups/details')) {
+				return Promise.resolve({
+					data: { ocs: { data: { groups: [{ id: 'finance', displayname: 'finance' }] } } },
+				})
+			}
+
+			return Promise.resolve({ data: { ocs: { data: {} } } })
+		})
+
+		const wrapper = mount(AllowedGroups as never, {
+			global: {
+				stubs: {
+					NcSettingsSection: { template: '<div><slot /></div>' },
+					NcSelect: {
+						name: 'NcSelect',
+						// Expose disabled/loading so the test can assert the input stays enabled.
+						props: ['modelValue', 'disabled', 'loading'],
+						emits: ['update:modelValue', 'search'],
+						template: '<div class="nc-select-stub" />',
+					},
+				},
+			},
+		})
+		await flushPromises()
+
+		// Ignore the initial onMounted load; observe only what typing triggers.
+		axiosGetMock.mockClear()
+
+		const select = wrapper.findComponent({ name: 'NcSelect' })
+		const vm = wrapper.vm as unknown as { loadingGroups: boolean }
+
+		// The loading state must be driven through NcSelect's own `search`-event
+		// callback, not the reactive `loadingGroups`/`:disabled` binding — disabling
+		// the focused input is exactly what dropped focus per keystroke (#7988).
+		const loadingStates: boolean[] = []
+		const loading = (state: boolean) => loadingStates.push(state)
+
+		select.vm.$emit('search', 'fin', loading)
+		await flushPromises()
+
+		// The select's own spinner was toggled on then off...
+		expect(loadingStates).toEqual([true, false])
+		// ...while `loadingGroups` (and therefore `:disabled`) never fired during search.
+		expect(vm.loadingGroups).toBe(false)
+		expect(select.props('disabled')).toBe(false)
+
+		// And the query still reached the backend.
+		const searchCalls = axiosGetMock.mock.calls.filter((c: unknown[]) => String(c[0]).includes('cloud/groups/details'))
+		expect(searchCalls.length).toBe(1)
+		expect((searchCalls[0] as [string, { params: { search: string } }])[1].params.search).toBe('fin')
 	})
 })

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -103,17 +103,10 @@ async function saveGroups(value: Array<GroupRow | string>) {
 	idKey.value += 1
 }
 
-// NcSelect re-exposes vue-select's native `search` event as (query, loading),
-// where `loading` toggles the select's own spinner. Driving the spinner through
-// that callback — instead of the reactive `loadingGroups`/`:disabled` binding —
-// keeps the text input enabled while searching, so it never loses focus (#7988).
-async function searchGroupEvent(query: string, loading: (state: boolean) => void) {
-	loading(true)
-	await searchGroup(query)
-	loading(false)
-}
-
-async function searchGroup(query: string) {
+// Performs the actual group search against the backend. Kept private so each
+// caller decides how to surface the loading state (see searchGroup and
+// searchGroupEvent below).
+async function searchGroupApi(query: string) {
 	await axios.get(generateOcsUrl('cloud/groups/details'), {
 		params: {
 			search: query,
@@ -127,10 +120,26 @@ async function searchGroup(query: string) {
 		.catch((error: unknown) => logger.debug('Could not search by groups', { error }))
 }
 
-onMounted(async () => {
+// Exposed search entry point: drives the reactive `loadingGroups`/`:disabled`
+// binding so any parent component that calls it gets a visible loading state.
+async function searchGroup(query: string) {
 	loadingGroups.value = true
-	await searchGroup('')
+	await searchGroupApi(query)
 	loadingGroups.value = false
+}
+
+// NcSelect re-exposes vue-select's native `search` event as (query, loading),
+// where `loading` toggles the select's own spinner. Driving the spinner through
+// that callback — instead of the reactive `loadingGroups`/`:disabled` binding —
+// keeps the text input enabled while searching, so it never loses focus (#7988).
+async function searchGroupEvent(query: string, loading: (state: boolean) => void) {
+	loading(true)
+	await searchGroupApi(query)
+	loading(false)
+}
+
+onMounted(async () => {
+	await searchGroup('')
 	await getData()
 })
 

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -20,7 +20,7 @@
 			:options="groups"
 			:searchable="true"
 			:show-no-options="false"
-			@search-change="searchGroup"
+			@search="searchGroup"
 			@update:modelValue="saveGroups" />
 	</NcSettingsSection>
 </template>

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -15,12 +15,12 @@
 			:aria-label-combobox="allowedGroupsAriaLabel"
 			:close-on-select="false"
 			:disabled="loadingGroups"
-			:loading="loadingGroups"
+			:loading="isSearching"
 			:multiple="true"
 			:options="groups"
 			:searchable="true"
 			:show-no-options="false"
-			@search="searchGroupEvent"
+			@search="searchGroup"
 			@update:modelValue="saveGroups" />
 	</NcSettingsSection>
 </template>
@@ -59,6 +59,7 @@ type GroupRow = {
 const groupsSelected = ref<Array<GroupRow | string>>([])
 const groups = ref<GroupRow[]>([])
 const loadingGroups = ref(false)
+const isSearching = ref(false)
 const idKey = ref(0)
 const policiesStore = usePoliciesStore()
 
@@ -103,39 +104,22 @@ async function saveGroups(value: Array<GroupRow | string>) {
 	idKey.value += 1
 }
 
-// Performs the actual group search against the backend. Kept private so each
-// caller decides how to surface the loading state (see searchGroup and
-// searchGroupEvent below).
-async function searchGroupApi(query: string) {
-	await axios.get(generateOcsUrl('cloud/groups/details'), {
-		params: {
-			search: query,
-			limit: 20,
-			offset: 0,
-		},
-	})
-		.then(({ data }: { data: { ocs: { data: { groups: GroupRow[] } } } }) => {
-			groups.value = data.ocs.data.groups.sort((a: GroupRow, b: GroupRow) => a.displayname.localeCompare(b.displayname))
-		})
-		.catch((error: unknown) => logger.debug('Could not search by groups', { error }))
-}
-
-// Exposed search entry point: drives the reactive `loadingGroups`/`:disabled`
-// binding so any parent component that calls it gets a visible loading state.
 async function searchGroup(query: string) {
-	loadingGroups.value = true
-	await searchGroupApi(query)
-	loadingGroups.value = false
-}
-
-// NcSelect re-exposes vue-select's native `search` event as (query, loading),
-// where `loading` toggles the select's own spinner. Driving the spinner through
-// that callback — instead of the reactive `loadingGroups`/`:disabled` binding —
-// keeps the text input enabled while searching, so it never loses focus (#7988).
-async function searchGroupEvent(query: string, loading: (state: boolean) => void) {
-	loading(true)
-	await searchGroupApi(query)
-	loading(false)
+	isSearching.value = true
+	try {
+		const { data } = await axios.get(generateOcsUrl('cloud/groups/details'), {
+			params: {
+				search: query,
+				limit: 20,
+				offset: 0,
+			},
+		})
+		groups.value = data.ocs.data.groups.sort((a: GroupRow, b: GroupRow) => a.displayname.localeCompare(b.displayname))
+	} catch (error: unknown) {
+		logger.debug('Could not search by groups', { error })
+	} finally {
+		isSearching.value = false
+	}
 }
 
 onMounted(async () => {
@@ -147,10 +131,10 @@ defineExpose({
 	groupsSelected,
 	groups,
 	loadingGroups,
+	isSearching,
 	idKey,
 	getData,
 	saveGroups,
 	searchGroup,
-	searchGroupEvent,
 })
 </script>

--- a/src/views/Settings/AllowedGroups.vue
+++ b/src/views/Settings/AllowedGroups.vue
@@ -20,7 +20,7 @@
 			:options="groups"
 			:searchable="true"
 			:show-no-options="false"
-			@search="searchGroup"
+			@search="searchGroupEvent"
 			@update:modelValue="saveGroups" />
 	</NcSettingsSection>
 </template>
@@ -103,8 +103,17 @@ async function saveGroups(value: Array<GroupRow | string>) {
 	idKey.value += 1
 }
 
+// NcSelect re-exposes vue-select's native `search` event as (query, loading),
+// where `loading` toggles the select's own spinner. Driving the spinner through
+// that callback — instead of the reactive `loadingGroups`/`:disabled` binding —
+// keeps the text input enabled while searching, so it never loses focus (#7988).
+async function searchGroupEvent(query: string, loading: (state: boolean) => void) {
+	loading(true)
+	await searchGroup(query)
+	loading(false)
+}
+
 async function searchGroup(query: string) {
-	loadingGroups.value = true
 	await axios.get(generateOcsUrl('cloud/groups/details'), {
 		params: {
 			search: query,
@@ -116,11 +125,12 @@ async function searchGroup(query: string) {
 			groups.value = data.ocs.data.groups.sort((a: GroupRow, b: GroupRow) => a.displayname.localeCompare(b.displayname))
 		})
 		.catch((error: unknown) => logger.debug('Could not search by groups', { error }))
-	loadingGroups.value = false
 }
 
 onMounted(async () => {
+	loadingGroups.value = true
 	await searchGroup('')
+	loadingGroups.value = false
 	await getData()
 })
 
@@ -132,5 +142,6 @@ defineExpose({
 	getData,
 	saveGroups,
 	searchGroup,
+	searchGroupEvent,
 })
 </script>

--- a/src/views/Settings/PolicyWorkbench/settings/request-sign-groups/RequestSignGroupsRuleEditor.vue
+++ b/src/views/Settings/PolicyWorkbench/settings/request-sign-groups/RequestSignGroupsRuleEditor.vue
@@ -25,13 +25,13 @@
 					:aria-label-combobox="authorizedRequesterGroupsAriaLabel"
 					:close-on-select="false"
 					:disabled="loadingGroups"
-					:loading="loadingGroups"
+					:loading="isSearching"
 					:multiple="true"
 					:options="availableAllowGroups"
 					:placeholder="searchGroupsPlaceholder"
 					:searchable="true"
 					:show-no-options="false"
-					@search-change="searchGroup"
+					@search="searchGroup"
 					@update:modelValue="onAllowGroupsChange" />
 			</template>
 
@@ -52,13 +52,13 @@
 					:aria-label-combobox="deniedRequesterGroupsAriaLabel"
 					:close-on-select="false"
 					:disabled="loadingGroups"
-					:loading="loadingGroups"
+					:loading="isSearching"
 					:multiple="true"
 					:options="availableGroups"
 					:placeholder="searchGroupsPlaceholder"
 					:searchable="true"
 					:show-no-options="false"
-					@search-change="searchGroup"
+					@search="searchGroup"
 					@update:modelValue="onDenyGroupsChange" />
 
 				<p v-if="!hideAllowGroups && overlappingGroupIds.length > 0" class="request-sign-groups-editor__helper request-sign-groups-editor__helper--warning">
@@ -150,6 +150,7 @@ const selectedAllowGroupIds = ref<string[]>([])
 const selectedDenyGroupIds = ref<string[]>([])
 const availableGroups = ref<GroupRow[]>([])
 const loadingGroups = ref(false)
+const isSearching = ref(false)
 const currentUser = getCurrentUser()
 const isInstanceAdmin = currentUser?.isAdmin === true
 const isDelegatedGroupCreateFlow = computed(() => {
@@ -331,7 +332,7 @@ watch(() => props.modelValue, (nextValue) => {
 })
 
 async function searchGroup(query: string) {
-	loadingGroups.value = true
+	isSearching.value = true
 	try {
 		const params = {
 			search: query,
@@ -343,7 +344,7 @@ async function searchGroup(query: string) {
 			const response = await axios.get<GroupDetailsResponse>(generateOcsUrl('cloud/groups/details'), { params })
 			availableGroups.value = filterGroupsByManageableScope(
 				(response.data?.ocs?.data?.groups ?? [])
-					.map((group) => ({
+					.map((group: { id: string; displayname?: string }) => ({
 						id: group.id,
 						displayname: group.displayname || group.id,
 					})),
@@ -355,7 +356,7 @@ async function searchGroup(query: string) {
 		const response = await axios.get<GroupListResponse>(generateOcsUrl('cloud/groups'), { params })
 		availableGroups.value = filterGroupsByManageableScope(
 			(response.data?.ocs?.data?.groups ?? [])
-				.map((groupId) => ({
+				.map((groupId: string) => ({
 					id: groupId,
 					displayname: groupId,
 				})),
@@ -364,6 +365,7 @@ async function searchGroup(query: string) {
 	} catch (error) {
 		logger.debug('Could not search groups for request-sign policy editor', { error })
 	} finally {
+		isSearching.value = false
 		loadingGroups.value = false
 	}
 }


### PR DESCRIPTION
### Summary

Fixes #7988. In **Settings → Signature request access**, typing in the group
selector did not trigger a backend search, so on instances with more than 20
groups it was impossible to find/select groups beyond the first (limit‑20) page.

### Root cause

`src/views/Settings/AllowedGroups.vue` listened for `@search-change` on
`<NcSelect>`:

```vue
@search-change="searchGroup"
```

`NcSelect` (from `@nextcloud/vue`, `^9.9.0`) does not emit a `search-change`
event. It re-exposes vue-select's native **`search`** event (internally
`@search="search = $event"`, and its `emits` list only declares
`update:modelValue`). Because `search-change` is never emitted, `searchGroup`
was only ever called once from `onMounted`, and user input triggered no request
— exactly the reported symptom.

### Fix

Listen for the correct event:

```vue
@search="searchGroup"
```

Vue 3 fallthrough merges this listener with `NcSelect`'s internal `@search`
handler, so `searchGroup(query)` now runs on input and queries
`cloud/groups/details?search=<query>`. The existing selection/save flow
(`@update:modelValue="saveGroups"`) is untouched.

### Tests

Adds a regression test to `src/tests/views/Settings/AllowedGroups.spec.ts` that
emits the `search` event and asserts a `cloud/groups/details` request is issued
with the typed query.

- `npx vitest run src/tests/views/Settings/AllowedGroups.spec.ts` → **5 passed**
- The new test **fails on the previous `@search-change` wiring** (zero requests
  after typing) and **passes with the fix**, so it guards against reintroduction.
- No new lint errors introduced by the change.
