### PR TITLE
fix: do not hide the signature position step when the stamp still renders

### DIFF
--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -227,6 +227,10 @@ class ValidateHelper {
 		if (!is_array($visibleElements)) {
 			throw new LibresignException($this->l10n->t('Visible elements need to be an array'));
 		}
+		if ($visibleElements && !$this->signerElementsService->isSignElementsAvailable()) {
+			// TRANSLATORS Validation error shown when visible signature elements are sent while the feature is disabled by the administrator.
+			throw new LibresignException($this->l10n->t('Visible elements are disabled.'));
+		}
 		foreach ($visibleElements as $element) {
 			$this->validateVisibleElement($element, $type);
 		}

--- a/lib/Service/SignerElementsService.php
+++ b/lib/Service/SignerElementsService.php
@@ -136,7 +136,9 @@ class SignerElementsService {
 	}
 
 	public function isSignElementsAvailable(): bool {
-		return $this->signatureBackgroundService->isEnabled() || $this->signatureTextService->isEnabled();
+		return $this->signatureBackgroundService->isEnabled()
+			|| $this->signatureTextService->isEnabled()
+			|| $this->signatureTextService->getRenderMode() !== self::RENDER_MODE_DESCRIPTION_ONLY;
 	}
 
 	public function canCreateSignature(): bool {

--- a/src/components/Request/VisibleElements.vue
+++ b/src/components/Request/VisibleElements.vue
@@ -554,7 +554,10 @@ const pdfEditorSigners = computed<SignerSummaryRecord[]>(() => (Array.isArray(do
 	.filter((signer): signer is SignerSummaryRecord => signer !== null))
 const status = computed(() => Number(document.value.status))
 const isDraft = computed(() => status.value === FILE_STATUS.DRAFT)
-const canSave = computed(() => ([FILE_STATUS.DRAFT, FILE_STATUS.ABLE_TO_SIGN, FILE_STATUS.PARTIAL_SIGNED] as number[]).includes(status.value))
+const signElementsAvailable = computed(() => signElementsConfig?.['is-available'] !== false)
+const hasVisibleElements = computed(() => getVisibleElementsFromDocument(document.value as DocumentLike).length > 0)
+const canSave = computed(() => signElementsAvailable.value
+	&& ([FILE_STATUS.DRAFT, FILE_STATUS.ABLE_TO_SIGN, FILE_STATUS.PARTIAL_SIGNED] as number[]).includes(status.value))
 const canSign = computed(() => status.value === FILE_STATUS.ABLE_TO_SIGN && !!getSigningRouteUuid(document.value))
 const variantOfSaveButton = computed(() => canSave.value ? 'primary' : 'secondary')
 const variantOfSignButton = computed(() => canSave.value ? 'secondary' : 'primary')
@@ -651,7 +654,7 @@ async function showModal() {
 	if (!canRequestSign.value) {
 		return
 	}
-	if (signElementsConfig?.['is-available'] === false) {
+	if (!signElementsAvailable.value && !hasVisibleElements.value) {
 		return
 	}
 	modal.value = true
@@ -833,6 +836,9 @@ function onSelectSigner(signer: SignerSummaryRecord) {
 }
 
 function handleSignerSelect(signer: unknown) {
+	if (!signElementsAvailable.value) {
+		return
+	}
 	const normalizedSigner = normalizeEditableRequestSigner(signer)
 	const pdfEditorSigner = toSignerSummaryRecord(normalizedSigner)
 	if (!pdfEditorSigner) {

--- a/src/components/RightSidebar/RequestSignatureTab.vue
+++ b/src/components/RightSidebar/RequestSignatureTab.vue
@@ -141,10 +141,9 @@
 				@click="save()">
 				<template #icon>
 					<NcLoadingIcon v-if="hasLoading" :size="20" />
-					<NcIconSvgWrapper v-else-if="isSignElementsAvailable()" :path="mdiPencil" :size="20" />
+					<NcIconSvgWrapper v-else-if="showsPositionEditor" :path="mdiPencil" :size="20" />
 				</template>
-				<!-- TRANSLATORS Button label used to enter visual signature position editor before sending requests. -->
-				{{ isSignElementsAvailable() ? t('libresign', 'Setup signature positions') : t('libresign', 'Save') }}
+				{{ saveButtonLabel }}
 			</NcButton>
 			<NcButton v-if="showRequestButton"
 				wide
@@ -354,6 +353,7 @@ import { useSidebarStore } from '../../store/sidebar.js'
 import { useSignStore } from '../../store/sign.js'
 import { useUserConfigStore } from '../../store/userconfig.js'
 import { startLongPolling } from '../../services/longPolling'
+import { getVisibleElementsFromDocument, type DocumentLike } from '../../services/visibleElementsService'
 import { useSigningOrder } from '../../composables/useSigningOrder.js'
 import {
 	normalizeIdentifyMethodsPolicy,
@@ -846,7 +846,7 @@ const showSaveButton = computed(() => {
 	if (shouldLoadDetail.value && !isCurrentFileDetailed.value) {
 		return false
 	}
-	if (isOriginalFileDeleted.value || !filesStore.canSave() || !isSignElementsAvailable()) {
+	if (isOriginalFileDeleted.value || !filesStore.canSave() || !showsPositionEditor.value) {
 		return false
 	}
 	const file = filesStore.getFile()
@@ -1072,8 +1072,20 @@ function getSvgIcon(name: string) {
 }
 
 function isSignElementsAvailable() {
-	return capabilities.libresign?.config['sign-elements']['is-available'] === true
+	return capabilities.libresign?.config['sign-elements']?.['is-available'] === true
 }
+
+const showsPositionEditor = computed(() => isSignElementsAvailable()
+	|| getVisibleElementsFromDocument(filesStore.getFile() as DocumentLike).length > 0)
+
+const saveButtonLabel = computed(() => {
+	if (showsPositionEditor.value) {
+		// TRANSLATORS Button label used to enter the visual signature position editor before sending requests.
+		return t('libresign', 'Setup signature positions')
+	}
+	// TRANSLATORS Button label used to store the signature request without sending it to the signers.
+	return t('libresign', 'Save')
+})
 
 function closeModal() {
 	modalSrc.value = ''
@@ -1568,6 +1580,7 @@ defineExpose({
 	getCurrentSigningOrder,
 	hasOrderDraftSigners,
 	isSignElementsAvailable,
+	saveButtonLabel,
 	closeModal,
 	getValidationFileUuid,
 	getSignRouteUuid,

--- a/src/tests/components/Request/VisibleElements.spec.ts
+++ b/src/tests/components/Request/VisibleElements.spec.ts
@@ -742,6 +742,58 @@ describe('VisibleElements Component - Business Rules', () => {
 			expect(wrapper.vm.modal).toBe(false)
 		})
 
+		it('opens modal to review elements placed before the capability was disabled', async () => {
+			vi.mocked(getCapabilities).mockReturnValueOnce({
+				libresign: {
+					config: {
+						'sign-elements': {
+							'is-available': false,
+							'full-signature-width': 200,
+							'full-signature-height': 100,
+						},
+					},
+				},
+			})
+			filesStore.files[1].visibleElements = [{
+				elementId: 7,
+				fileId: 1,
+				signRequestId: 3,
+				coordinates: { page: 1, width: 10, height: 10, left: 0, top: 0 },
+			}]
+			filesStore.files[1].uuid = 'uuid-123'
+			filesStore.files[1].metadata = { extension: 'pdf', p: 1 }
+			wrapper.unmount()
+			wrapper = createWrapper()
+
+			await wrapper.vm.showModal()
+
+			expect(wrapper.vm.modal).toBe(true)
+		})
+
+		it('does not allow saving while reviewing with the capability disabled', async () => {
+			vi.mocked(getCapabilities).mockReturnValueOnce({
+				libresign: {
+					config: {
+						'sign-elements': {
+							'is-available': false,
+							'full-signature-width': 200,
+							'full-signature-height': 100,
+						},
+					},
+				},
+			})
+			filesStore.files[1].visibleElements = [{
+				elementId: 7,
+				fileId: 1,
+				signRequestId: 3,
+				coordinates: { page: 1, width: 10, height: 10, left: 0, top: 0 },
+			}]
+			wrapper.unmount()
+			wrapper = createWrapper()
+
+			expect(wrapper.vm.canSave).toBe(false)
+		})
+
 		it('loads files when opening modal with empty file list', async () => {
 			filesStore.files[1].files = []
 			;(vi.mocked(axios).get as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/src/tests/components/RightSidebar/RequestSignatureTab.spec.ts
+++ b/src/tests/components/RightSidebar/RequestSignatureTab.spec.ts
@@ -8,6 +8,7 @@ import { flushPromises, shallowMount } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import axios from '@nextcloud/axios'
+import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import type { useFilesStore as useFilesStoreType } from '../../../store/files.js'
 import { usePoliciesStore } from '../../../store/policies'
@@ -15,7 +16,8 @@ import RequestSignatureTab from '../../../components/RightSidebar/RequestSignatu
 import { useFilesStore } from '../../../store/files.js'
 import { FILE_STATUS } from '../../../constants.js'
 
-const { generateUrlMock } = vi.hoisted(() => ({
+const { capabilitiesState, generateUrlMock } = vi.hoisted(() => ({
+	capabilitiesState: { signElementsAvailable: true },
 	generateUrlMock: vi.fn((path: string, params?: Record<string, string | number>) => {
 		if (!params) {
 			return path
@@ -80,7 +82,7 @@ vi.mock('@nextcloud/capabilities', () => ({
 	getCapabilities: vi.fn(() => ({
 		libresign: {
 			config: {
-				'sign-elements': { 'is-available': true },
+				'sign-elements': { 'is-available': capabilitiesState.signElementsAvailable },
 			},
 		},
 	})),
@@ -226,9 +228,41 @@ describe('RequestSignatureTab - Critical Business Rules', () => {
 		await wrapper.vm.$nextTick()
 	}
 
+	const mountComponent = () => shallowMount(RequestSignatureTab, {
+		mocks: {
+			t: (_app: string, text: string) => text,
+		},
+		global: {
+			stubs: {
+				EnvelopeFilesList: { name: 'EnvelopeFilesList', template: '<div><slot /></div>' },
+				NcButton: true,
+				NcCheckboxRadioSwitch: true,
+				NcNoteCard: true,
+				NcActionInput: true,
+				NcActionButton: true,
+				NcFormBox: true,
+				NcLoadingIcon: true,
+				Signers: true,
+				SigningProgress: true,
+				AccountPlus: true,
+				ChartGantt: true,
+				FileMultiple: true,
+				Send: true,
+				Delete: true,
+				Bell: true,
+				Draw: true,
+				Pencil: true,
+				MessageText: true,
+				OrderNumericAscending: true,
+			},
+		},
+	}) as VueWrapper<any>
+
 	beforeEach(async () => {
 		setActivePinia(createPinia())
+		capabilitiesState.signElementsAvailable = true
 		generateUrlMock.mockClear()
+		vi.mocked(emit).mockClear()
 		vi.mocked(axios.get).mockImplementation(async (url: string) => {
 			if (url.includes('/apps/libresign/api/v1/policies/effective')) {
 				return createEffectivePoliciesResponse() as Awaited<ReturnType<typeof axios.get>>
@@ -251,35 +285,7 @@ describe('RequestSignatureTab - Critical Business Rules', () => {
 		filesStore.selectFile(1)
 		filesStore.canRequestSign = true
 
-		wrapper = shallowMount(RequestSignatureTab, {
-			mocks: {
-				t: (_app: string, text: string) => text,
-			},
-			global: {
-				stubs: {
-					EnvelopeFilesList: { name: 'EnvelopeFilesList', template: '<div><slot /></div>' },
-					NcButton: true,
-					NcCheckboxRadioSwitch: true,
-					NcNoteCard: true,
-					NcActionInput: true,
-					NcActionButton: true,
-					NcFormBox: true,
-					NcLoadingIcon: true,
-					Signers: true,
-					SigningProgress: true,
-					AccountPlus: true,
-					ChartGantt: true,
-					FileMultiple: true,
-					Send: true,
-					Delete: true,
-					Bell: true,
-					Draw: true,
-					Pencil: true,
-					MessageText: true,
-					OrderNumericAscending: true,
-				},
-			},
-		}) as VueWrapper<any>
+		wrapper = mountComponent()
 		await flushPromises()
 	})
 
@@ -628,6 +634,40 @@ describe('RequestSignatureTab - Critical Business Rules', () => {
 			await updateFile({ status: FILE_STATUS.DRAFT, signers: [] })
 
 			expect(wrapper.vm.showSaveButton).toBe(false)
+		})
+	})
+
+	describe('RULE: signature positioning entry point follows sign-elements capability', () => {
+		const draftWithSigner = {
+			status: FILE_STATUS.DRAFT,
+			signatureFlow: 'parallel',
+			signers: [{ email: 'test@example.com', signed: [], status: 0 }],
+		}
+
+		it('offers the positioning step while the capability is available', async () => {
+			await updateFile(draftWithSigner)
+
+			expect(wrapper.vm.isSignElementsAvailable()).toBe(true)
+			expect(wrapper.vm.showSaveButton).toBe(true)
+		})
+
+		it('hides only the positioning step when the capability is unavailable', async () => {
+			capabilitiesState.signElementsAvailable = false
+			wrapper = mountComponent()
+			await flushPromises()
+			await updateFile(draftWithSigner)
+
+			expect(wrapper.vm.showSaveButton).toBe(false)
+			expect(wrapper.vm.showRequestButton).toBe(true)
+		})
+
+		it('opens the visible elements editor after saving the draft', async () => {
+			await updateFile(draftWithSigner)
+			vi.spyOn(filesStore, 'saveOrUpdateSignatureRequest').mockResolvedValue({ message: 'ok' })
+
+			await wrapper.vm.save()
+
+			expect(vi.mocked(emit)).toHaveBeenCalledWith('libresign:show-visible-elements', expect.anything())
 		})
 	})
 

--- a/src/tests/components/RightSidebar/RequestSignatureTab.spec.ts
+++ b/src/tests/components/RightSidebar/RequestSignatureTab.spec.ts
@@ -661,6 +661,34 @@ describe('RequestSignatureTab - Critical Business Rules', () => {
 			expect(wrapper.vm.showRequestButton).toBe(true)
 		})
 
+		it('keeps the positioning step reachable to review elements placed before the capability was disabled', async () => {
+			capabilitiesState.signElementsAvailable = false
+			wrapper = mountComponent()
+			await flushPromises()
+			await updateFile({
+				...draftWithSigner,
+				visibleElements: [{
+					elementId: 7,
+					signRequestId: 3,
+					coordinates: { page: 1, width: 10, height: 10, left: 0, top: 0 },
+				}],
+			})
+
+			expect(wrapper.vm.showSaveButton).toBe(true)
+		})
+
+		it('labels the button after the action it performs', async () => {
+			await updateFile(draftWithSigner)
+			expect(wrapper.vm.saveButtonLabel).toBe('Setup signature positions')
+
+			capabilitiesState.signElementsAvailable = false
+			wrapper = mountComponent()
+			await flushPromises()
+			await updateFile(draftWithSigner)
+
+			expect(wrapper.vm.saveButtonLabel).toBe('Save')
+		})
+
 		it('opens the visible elements editor after saving the draft', async () => {
 			await updateFile(draftWithSigner)
 			vi.spyOn(filesStore, 'saveOrUpdateSignatureRequest').mockResolvedValue({ message: 'ok' })

--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -675,21 +675,66 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->getValidateHelper()->validateIsSignerOfFile(1, 1);
 	}
 
-	public function testValidateVisibleElementsWithInvalidElementType():void {
-		$this->expectExceptionMessage('Visible elements need to be an array');
-		$actual = $this->getValidateHelper()->validateVisibleElements(null, ValidateHelper::TYPE_TO_SIGN);
-		$this->assertNull($actual);
+	#[DataProvider('providerValidateVisibleElements')]
+	public function testValidateVisibleElements(bool $isSignElementsAvailable, ?array $elements, int $type, string $expectedException):void {
+		$this->signerElementsService->method('isSignElementsAvailable')->willReturn($isSignElementsAvailable);
+		if ($expectedException) {
+			$this->expectExceptionMessage($expectedException);
+		}
+		$this->assertNull($this->getValidateHelper()->validateVisibleElements($elements, $type));
 	}
 
-	public function testValidateVisibleElementsWithSuccess():void {
-		$elements = [[
+	public static function providerValidateVisibleElements(): array {
+		$validElement = [
 			'type' => 'signature',
 			'file' => [
 				'base64' => base64_encode(file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid.pdf'))
 			]
-		]];
-		$actual = $this->getValidateHelper()->validateVisibleElements($elements, ValidateHelper::TYPE_TO_SIGN);
-		$this->assertNull($actual);
+		];
+		return [
+			'rejects a non array value' => [
+				true,
+				null,
+				ValidateHelper::TYPE_TO_SIGN,
+				'Visible elements need to be an array',
+			],
+			'accepts a valid element' => [
+				true,
+				[$validElement],
+				ValidateHelper::TYPE_TO_SIGN,
+				'',
+			],
+			'validates every element of the list' => [
+				true,
+				[$validElement, ['type' => 'INVALID']],
+				ValidateHelper::TYPE_TO_SIGN,
+				'Invalid element type',
+			],
+			'accepts an empty list when available' => [
+				true,
+				[],
+				ValidateHelper::TYPE_TO_SIGN,
+				'',
+			],
+			'rejects document elements when the feature is unavailable' => [
+				false,
+				[['type' => 'signature']],
+				ValidateHelper::TYPE_VISIBLE_ELEMENT_PDF,
+				'Visible elements are disabled.',
+			],
+			'rejects profile elements when the feature is unavailable' => [
+				false,
+				[['type' => 'signature']],
+				ValidateHelper::TYPE_VISIBLE_ELEMENT_USER,
+				'Visible elements are disabled.',
+			],
+			'accepts an empty list when the feature is unavailable' => [
+				false,
+				[],
+				ValidateHelper::TYPE_VISIBLE_ELEMENT_PDF,
+				'',
+			],
+		];
 	}
 
 	public function testValidateElementSignRequestIdRequiresAssociation(): void {

--- a/tests/php/Unit/Service/SignatureBackgroundServiceTest.php
+++ b/tests/php/Unit/Service/SignatureBackgroundServiceTest.php
@@ -9,9 +9,13 @@ namespace OCA\Libresign\Tests\Unit\Service;
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OCA\Libresign\Service\Policy\Model\ResolvedPolicy;
 use OCA\Libresign\Service\Policy\PolicyService;
+use OCA\Libresign\Service\Policy\Provider\SignatureText\SignatureTextPolicy;
+use OCA\Libresign\Service\Policy\Provider\SignatureText\SignatureTextPolicyValue;
 use OCA\Libresign\Service\SignatureBackgroundService;
 use OCA\Libresign\Service\SignatureTextService;
+use OCA\Libresign\Service\SignerElementsService;
 use OCP\Files\IAppData;
 use OCP\IAppConfig;
 use OCP\IConfig;
@@ -107,6 +111,38 @@ final class SignatureBackgroundServiceTest extends \OCA\Libresign\Tests\Unit\Tes
 				=> [2000, 1600, 200, 100, 375, 300],
 			'every return integer'
 				=> [2000, 1600, 200.7, 100.5, 376, 301],
+		];
+	}
+
+	#[DataProvider('providerIsEnabled')]
+	public function testIsEnabled(mixed $backgroundType, bool $expected): void {
+		$this->policyService
+			->method('resolve')
+			->willReturn((new ResolvedPolicy())
+				->setPolicyKey(SignatureTextPolicy::KEY)
+				->setEffectiveValue(SignatureTextPolicyValue::encode([
+					'template' => '',
+					'template_font_size' => SignatureTextPolicyValue::DEFAULT_TEMPLATE_FONT_SIZE,
+					'signature_font_size' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
+					'signature_width' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_WIDTH,
+					'signature_height' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_HEIGHT,
+					'background_type' => $backgroundType,
+					'render_mode' => SignerElementsService::RENDER_MODE_DEFAULT,
+				])));
+
+		$this->assertSame($expected, $this->getClass()->isEnabled());
+	}
+
+	/**
+	 * @return array<string, array{mixed, bool}>
+	 */
+	public static function providerIsEnabled(): array {
+		return [
+			'default background is enabled' => ['default', true],
+			'custom background is enabled' => ['custom', true],
+			'deleted background is disabled' => ['deleted', false],
+			'unknown value falls back to default' => ['whatever', true],
+			'non string value falls back to default' => [null, true],
 		];
 	}
 

--- a/tests/php/Unit/Service/SignatureTextServiceTest.php
+++ b/tests/php/Unit/Service/SignatureTextServiceTest.php
@@ -162,6 +162,31 @@ final class SignatureTextServiceTest extends \OCA\Libresign\Tests\Unit\TestCase 
 		$this->assertStringContainsString('{{SignerUserAgent}}', $template);
 	}
 
+	#[DataProvider('providerIsEnabled')]
+	public function testIsEnabled(string $template, bool $expected): void {
+		$this->policyValues[SignatureTextPolicyProvider::KEY] = SignatureTextPolicyValue::encode([
+			'template' => $template,
+			'template_font_size' => SignatureTextPolicyValue::DEFAULT_TEMPLATE_FONT_SIZE,
+			'signature_font_size' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
+			'signature_width' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_WIDTH,
+			'signature_height' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_HEIGHT,
+			'background_type' => 'default',
+			'render_mode' => SignerElementsService::RENDER_MODE_DEFAULT,
+		]);
+
+		$this->assertSame($expected, $this->getClass()->isEnabled());
+	}
+
+	/**
+	 * @return array<string, array{string, bool}>
+	 */
+	public static function providerIsEnabled(): array {
+		return [
+			'empty template disables the signature stamp' => ['', false],
+			'defined template enables the signature stamp' => ['Signed by {{SignerCommonName}}', true],
+		];
+	}
+
 	#[DataProvider('providerSave')]
 	public function testSave($template, $context, $parsed): void {
 		$fromSave = $this->getClass()->save($template);

--- a/tests/php/Unit/Service/SignerElementsServiceTest.php
+++ b/tests/php/Unit/Service/SignerElementsServiceTest.php
@@ -51,19 +51,26 @@ final class SignerElementsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase
 	}
 
 	#[DataProvider('providerIsSignElementsAvailable')]
-	public function testIsSignElementsAvailable(bool $background, bool $text, bool $expected): void {
+	public function testIsSignElementsAvailable(bool $background, bool $text, string $renderMode, bool $expected): void {
 		$this->signatureBackgroundService->method('isEnabled')->willReturn($background);
 		$this->signatureTextService->method('isEnabled')->willReturn($text);
+		$this->signatureTextService->method('getRenderMode')->willReturn($renderMode);
 		$available = $this->getClass()->isSignElementsAvailable();
 		$this->assertEquals($expected, $available);
 	}
 
+	/**
+	 * @return array<string, array{bool, bool, string, bool}>
+	 */
 	public static function providerIsSignElementsAvailable(): array {
 		return [
-			[false, false, false],
-			[false, true, true],
-			[true, true, true],
-			[true, false, true],
+			'background only' => [true, false, SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY, true],
+			'text only' => [false, true, SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY, true],
+			'background and text' => [true, true, SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY, true],
+			'drawn signature and description' => [false, false, SignerElementsService::RENDER_MODE_GRAPHIC_AND_DESCRIPTION, true],
+			'drawn signature only' => [false, false, SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, true],
+			'signer name rendered as image' => [false, false, SignerElementsService::RENDER_MODE_SIGNAME_AND_DESCRIPTION, true],
+			'nothing to render' => [false, false, SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY, false],
 		];
 	}
 }


### PR DESCRIPTION
Removing the signature background image and clearing the signature text template made the "Setup signature positions" step disappear completely, even when signers could still draw their signature, which LibreSign does render.

This was reported by a user whose administrator had changed the stamp appearance: the whole positioning step vanished, with no warning and no way to get it back other than restoring the old settings.

What changes:

- the step stays available whenever the stamp still has something to render;
- the backend now rejects visible elements when the feature really is unavailable, instead of trusting the interface alone;
- requesters can review and remove elements placed before the feature was turned off.