### PR TITLE
Fix/id docs ldap join and approval status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ node_modules/
 /coverage
 /dist/
 /test-results/
+/playwright/.visual-output/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ node_modules/
 /coverage
 /dist/
 /test-results/
-/playwright/.visual-output/

--- a/lib/Db/IdDocsMapper.php
+++ b/lib/Db/IdDocsMapper.php
@@ -191,8 +191,7 @@ class IdDocsMapper extends QBMapper {
 			->leftJoin('id', 'libresign_sign_request', 'sr', 'id.sign_request_id = sr.id');
 
 		if ($needsUserJoin) {
-			$joinType = !empty($filter['userId']) ? 'join' : 'leftJoin';
-			$qb->$joinType('id', 'users', 'u', 'id.user_id = u.uid');
+			$qb->leftJoin('id', 'users', 'u', 'id.user_id = u.uid');
 		}
 
 		if (!empty($filter['userId'])) {

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -1079,7 +1079,7 @@ class SignFileService {
 	}
 
 	private function evaluateStatusFromSigners(): ?int {
-		$signers = $this->getSigners();
+		$signers = $this->excludeIdDocUploaderPlaceholder($this->getSigners());
 
 		$total = count($signers);
 
@@ -1098,6 +1098,41 @@ class SignFileService {
 		}
 
 		return null;
+	}
+
+	/**
+	 * @param SignRequestEntity[] $signers
+	 * @return SignRequestEntity[]
+	 */
+	private function excludeIdDocUploaderPlaceholder(array $signers): array {
+		$placeholderId = $this->getIdDocUploaderSignRequestId();
+		if ($placeholderId === null) {
+			return $signers;
+		}
+
+		return array_values(array_filter(
+			$signers,
+			static fn (SignRequestEntity $signer): bool => $signer->getId() !== $placeholderId,
+		));
+	}
+
+	private function getIdDocUploaderSignRequestId(): ?int {
+		$fileId = $this->signRequest->getFileId();
+		if ($fileId === null) {
+			return null;
+		}
+
+		try {
+			$idDocs = $this->idDocsMapper->getByFileId($fileId);
+		} catch (\Throwable) {
+			return null;
+		}
+
+		if (!$idDocs instanceof IdDocs) {
+			return null;
+		}
+
+		return $idDocs->getSignRequestId();
 	}
 
 	private function getOrGeneratePfxContent(SignEngineHandler $engine): string {

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -1124,7 +1124,7 @@ class SignFileService {
 
 		try {
 			$idDocs = $this->idDocsMapper->getByFileId($fileId);
-		} catch (\Throwable) {
+		} catch (DoesNotExistException) {
 			return null;
 		}
 

--- a/playwright/e2e/id-docs-visual.spec.ts
+++ b/playwright/e2e/id-docs-visual.spec.ts
@@ -3,21 +3,59 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { expect, test, type Locator, type Page } from '@playwright/test'
 import { mkdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
-import { login } from '../support/nc-login'
+import { expect, test, type APIRequestContext, type Locator, type Page } from '@playwright/test'
 
+import { login } from '../support/nc-login'
+import {
+	createAuthenticatedRequestContext,
+	getSystemPolicySnapshot,
+	policyRequest,
+	restoreSystemPolicySnapshot,
+	type SystemPolicySnapshot,
+} from '../support/policy-api'
+
+const POLICY_KEY = 'identification_documents'
 const SCREENSHOT_DIR = resolve(process.cwd(), 'playwright/.visual-output')
 
 test.describe.configure({ mode: 'serial', timeout: 180000 })
 
-async function shot(page: Page, name: string): Promise<string> {
+let adminContext: APIRequestContext
+let originalPolicy: SystemPolicySnapshot
+
+test.beforeEach(async () => {
+	const adminUser = process.env.NEXTCLOUD_ADMIN_USER ?? 'admin'
+	const adminPassword = process.env.NEXTCLOUD_ADMIN_PASSWORD ?? 'admin'
+	adminContext = await createAuthenticatedRequestContext(adminUser, adminPassword)
+	originalPolicy = await getSystemPolicySnapshot(adminContext, POLICY_KEY)
+
+	const response = await policyRequest(
+		adminContext,
+		'POST',
+		`/apps/libresign/api/v1/policies/system/${POLICY_KEY}`,
+		{
+			value: { enabled: true, approvers: [adminUser] },
+			allowChildOverride: true,
+		},
+	)
+	expect(response.httpStatus, response.message).toBe(200)
+})
+
+test.afterEach(async () => {
+	try {
+		if (adminContext && originalPolicy) {
+			await restoreSystemPolicySnapshot(adminContext, POLICY_KEY, originalPolicy)
+		}
+	} finally {
+		await adminContext?.dispose()
+	}
+})
+
+async function shot(page: Page, name: string): Promise<void> {
 	await mkdir(SCREENSHOT_DIR, { recursive: true })
-	const path = resolve(SCREENSHOT_DIR, `${name}.png`)
-	await page.screenshot({ path, fullPage: true })
-	return path
+	await page.screenshot({ path: resolve(SCREENSHOT_DIR, `${name}.png`), fullPage: true })
 }
 
 function emptyStatus(page: Page): Locator {
@@ -59,25 +97,9 @@ test('identification documents appear on the account page after upload', async (
 		process.env.NEXTCLOUD_ADMIN_PASSWORD ?? 'admin',
 	)
 
-	const policyResponse = await page.request.post(
-		'./ocs/v2.php/apps/libresign/api/v1/policies/system/identification_documents?format=json',
-		{
-			headers: {
-				'OCS-ApiRequest': 'true',
-				Accept: 'application/json',
-				Authorization: 'Basic ' + Buffer.from('admin:admin').toString('base64'),
-				'Content-Type': 'application/json',
-			},
-			data: {
-				value: { enabled: true, approvers: ['admin'] },
-			},
-		},
-	)
-	expect(policyResponse.ok(), await policyResponse.text()).toBeTruthy()
-
 	await page.goto('./apps/libresign')
 	await expect(page.getByRole('button', { name: /Upload from URL|Carregar do URL/i })).toBeVisible({ timeout: 20_000 })
-	await expect(page.getByText(/Document Validation|Validação de Documentos/i).first()).toBeVisible()
+	await expect(page.getByRole('link', { name: /Documents Validation|Validação de Documentos/i })).toBeVisible({ timeout: 20_000 })
 	await shot(page, '01-libresign-home')
 
 	await page.goto('./apps/libresign/f/account')

--- a/playwright/e2e/id-docs-visual.spec.ts
+++ b/playwright/e2e/id-docs-visual.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test, type Locator, type Page } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { login } from '../support/nc-login'
+
+const SCREENSHOT_DIR = resolve(process.cwd(), 'playwright/.visual-output')
+
+test.describe.configure({ mode: 'serial', timeout: 180000 })
+
+async function shot(page: Page, name: string): Promise<string> {
+	await mkdir(SCREENSHOT_DIR, { recursive: true })
+	const path = resolve(SCREENSHOT_DIR, `${name}.png`)
+	await page.screenshot({ path, fullPage: true })
+	return path
+}
+
+function emptyStatus(page: Page): Locator {
+	return page.getByText(/Not sent yet|Ainda não enviado/i)
+}
+
+function deleteButton(page: Page): Locator {
+	return page.getByRole('button', { name: /Delete file|Excluir arquivo/i })
+}
+
+function uploadButton(page: Page): Locator {
+	return page.getByRole('button', { name: /Upload file|Enviar arquivo/i })
+}
+
+async function waitForIdDocsCard(page: Page): Promise<void> {
+	await expect(emptyStatus(page).or(deleteButton(page))).toBeVisible({ timeout: 20_000 })
+}
+
+async function clearExistingIdDocument(page: Page): Promise<void> {
+	await waitForIdDocsCard(page)
+	for (let attempt = 0; attempt < 5; attempt++) {
+		if (!(await deleteButton(page).isVisible().catch(() => false))) {
+			break
+		}
+		await deleteButton(page).click()
+		await expect(page.getByText(/File was deleted\.|Arquivo foi apagado\./i)).toBeVisible({ timeout: 20_000 })
+		await waitForIdDocsCard(page)
+	}
+	await expect(emptyStatus(page)).toBeVisible({ timeout: 20_000 })
+	await expect(uploadButton(page)).toBeVisible()
+}
+
+test('identification documents appear on the account page after upload', async ({ page }) => {
+	test.slow()
+
+	await login(
+		page.request,
+		process.env.NEXTCLOUD_ADMIN_USER ?? 'admin',
+		process.env.NEXTCLOUD_ADMIN_PASSWORD ?? 'admin',
+	)
+
+	const policyResponse = await page.request.post(
+		'./ocs/v2.php/apps/libresign/api/v1/policies/system/identification_documents?format=json',
+		{
+			headers: {
+				'OCS-ApiRequest': 'true',
+				Accept: 'application/json',
+				Authorization: 'Basic ' + Buffer.from('admin:admin').toString('base64'),
+				'Content-Type': 'application/json',
+			},
+			data: {
+				value: { enabled: true, approvers: ['admin'] },
+			},
+		},
+	)
+	expect(policyResponse.ok(), await policyResponse.text()).toBeTruthy()
+
+	await page.goto('./apps/libresign')
+	await expect(page.getByRole('button', { name: /Upload from URL|Carregar do URL/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByText(/Document Validation|Validação de Documentos/i).first()).toBeVisible()
+	await shot(page, '01-libresign-home')
+
+	await page.goto('./apps/libresign/f/account')
+	await expect(page.getByRole('heading', { name: /Identification documents|Documentos de identificação/i })).toBeVisible({ timeout: 20_000 })
+	await clearExistingIdDocument(page)
+	await shot(page, '02-account-id-docs-empty')
+
+	const [fileChooser] = await Promise.all([
+		page.waitForEvent('filechooser'),
+		uploadButton(page).click(),
+	])
+	await fileChooser.setFiles(resolve(process.cwd(), 'tests/php/fixtures/pdfs/small_valid.pdf'))
+
+	await expect(page.getByText(/File was sent\.|Arquivo foi enviado\./i)).toBeVisible({ timeout: 20_000 })
+	await expect(deleteButton(page)).toBeVisible({ timeout: 20_000 })
+	await expect(emptyStatus(page)).toHaveCount(0)
+	await shot(page, '03-account-id-doc-uploaded')
+
+	await page.goto('./apps/libresign/f/docs/id-docs/validation')
+	await expect(page.getByRole('columnheader', { name: /Owner|Proprietário/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByRole('cell', { name: /^admin$/i }).first()).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByText(/waiting for approval|aguardando aprovação/i).first()).toBeVisible()
+	await expect(page.getByRole('button', { name: /Sign|Assinar/i }).first()).toBeVisible()
+	await shot(page, '04-id-docs-approval-list')
+
+	await page.goto('./settings/admin/libresign')
+	const catalogSearch = page.locator('.policy-workbench__catalog-search').getByRole('textbox').first()
+	await expect(catalogSearch).toBeVisible({ timeout: 20_000 })
+
+	const collapseButton = page.getByRole('button', {
+		name: /Collapse settings categories|Recolher categorias de configurações|Expand settings categories|Expandir categorias de configurações/i,
+	}).first()
+	if (/Expand|Expandir/i.test((await collapseButton.getAttribute('aria-label')) ?? '')) {
+		await collapseButton.click()
+	}
+
+	await catalogSearch.fill('identifica')
+	await expect(page.getByRole('button', {
+		name: /Identification documents flow|Fluxo de documentos de identificação/i,
+	}).first()).toBeVisible({ timeout: 20_000 })
+	await shot(page, '05-settings-identification-documents')
+})

--- a/playwright/e2e/id-docs-visual.spec.ts
+++ b/playwright/e2e/id-docs-visual.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../support/policy-api'
 
 const POLICY_KEY = 'identification_documents'
-const SCREENSHOT_DIR = resolve(process.cwd(), 'playwright/.visual-output')
+const SCREENSHOT_DIR = resolve(process.cwd(), 'build/playwright/visual-output')
 
 test.describe.configure({ mode: 'serial', timeout: 180000 })
 
@@ -59,15 +59,15 @@ async function shot(page: Page, name: string): Promise<void> {
 }
 
 function emptyStatus(page: Page): Locator {
-	return page.getByText(/Not sent yet|Ainda não enviado/i)
+	return page.getByText(/Not sent yet/i)
 }
 
 function deleteButton(page: Page): Locator {
-	return page.getByRole('button', { name: /Delete file|Excluir arquivo/i })
+	return page.getByRole('button', { name: /Delete file/i })
 }
 
 function uploadButton(page: Page): Locator {
-	return page.getByRole('button', { name: /Upload file|Enviar arquivo/i })
+	return page.getByRole('button', { name: /Upload file/i })
 }
 
 async function waitForIdDocsCard(page: Page): Promise<void> {
@@ -81,7 +81,7 @@ async function clearExistingIdDocument(page: Page): Promise<void> {
 			break
 		}
 		await deleteButton(page).click()
-		await expect(page.getByText(/File was deleted\.|Arquivo foi apagado\./i)).toBeVisible({ timeout: 20_000 })
+		await expect(page.getByText(/File was deleted\./i)).toBeVisible({ timeout: 20_000 })
 		await waitForIdDocsCard(page)
 	}
 	await expect(emptyStatus(page)).toBeVisible({ timeout: 20_000 })
@@ -98,12 +98,12 @@ test('identification documents appear on the account page after upload', async (
 	)
 
 	await page.goto('./apps/libresign')
-	await expect(page.getByRole('button', { name: /Upload from URL|Carregar do URL/i })).toBeVisible({ timeout: 20_000 })
-	await expect(page.getByRole('link', { name: /Documents Validation|Validação de Documentos/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByRole('button', { name: /Upload from URL/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByRole('link', { name: /Documents Validation/i })).toBeVisible({ timeout: 20_000 })
 	await shot(page, '01-libresign-home')
 
 	await page.goto('./apps/libresign/f/account')
-	await expect(page.getByRole('heading', { name: /Identification documents|Documentos de identificação/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByRole('heading', { name: /Identification documents/i })).toBeVisible({ timeout: 20_000 })
 	await clearExistingIdDocument(page)
 	await shot(page, '02-account-id-docs-empty')
 
@@ -113,16 +113,16 @@ test('identification documents appear on the account page after upload', async (
 	])
 	await fileChooser.setFiles(resolve(process.cwd(), 'tests/php/fixtures/pdfs/small_valid.pdf'))
 
-	await expect(page.getByText(/File was sent\.|Arquivo foi enviado\./i)).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByText(/File was sent\./i)).toBeVisible({ timeout: 20_000 })
 	await expect(deleteButton(page)).toBeVisible({ timeout: 20_000 })
 	await expect(emptyStatus(page)).toHaveCount(0)
 	await shot(page, '03-account-id-doc-uploaded')
 
 	await page.goto('./apps/libresign/f/docs/id-docs/validation')
-	await expect(page.getByRole('columnheader', { name: /Owner|Proprietário/i })).toBeVisible({ timeout: 20_000 })
+	await expect(page.getByRole('columnheader', { name: /Owner/i })).toBeVisible({ timeout: 20_000 })
 	await expect(page.getByRole('cell', { name: /^admin$/i }).first()).toBeVisible({ timeout: 20_000 })
-	await expect(page.getByText(/waiting for approval|aguardando aprovação/i).first()).toBeVisible()
-	await expect(page.getByRole('button', { name: /Sign|Assinar/i }).first()).toBeVisible()
+	await expect(page.getByText(/waiting for approval/i).first()).toBeVisible()
+	await expect(page.getByRole('button', { name: /Sign/i }).first()).toBeVisible()
 	await shot(page, '04-id-docs-approval-list')
 
 	await page.goto('./settings/admin/libresign')
@@ -130,15 +130,15 @@ test('identification documents appear on the account page after upload', async (
 	await expect(catalogSearch).toBeVisible({ timeout: 20_000 })
 
 	const collapseButton = page.getByRole('button', {
-		name: /Collapse settings categories|Recolher categorias de configurações|Expand settings categories|Expandir categorias de configurações/i,
+		name: /Collapse settings categories|Expand settings categories/i,
 	}).first()
-	if (/Expand|Expandir/i.test((await collapseButton.getAttribute('aria-label')) ?? '')) {
+	if (/Expand/i.test((await collapseButton.getAttribute('aria-label')) ?? '')) {
 		await collapseButton.click()
 	}
 
 	await catalogSearch.fill('identifica')
 	await expect(page.getByRole('button', {
-		name: /Identification documents flow|Fluxo de documentos de identificação/i,
+		name: /Identification documents flow/i,
 	}).first()).toBeVisible({ timeout: 20_000 })
 	await shot(page, '05-settings-identification-documents')
 })

--- a/tests/php/Unit/Db/IdDocsMapperTest.php
+++ b/tests/php/Unit/Db/IdDocsMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Db;
+
+use OCA\Libresign\Db\File;
+use OCA\Libresign\Db\FileMapper;
+use OCA\Libresign\Db\IdDocsMapper;
+use OCA\Libresign\Db\SignRequest;
+use OCA\Libresign\Db\SignRequestMapper;
+use OCA\Libresign\Enum\FileStatus;
+use OCP\Server;
+
+/**
+ * @group DB
+ */
+final class IdDocsMapperTest extends \OCA\Libresign\Tests\Unit\TestCase {
+	private FileMapper $fileMapper;
+	private IdDocsMapper $idDocsMapper;
+	private SignRequestMapper $signRequestMapper;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->fileMapper = Server::get(FileMapper::class);
+		$this->idDocsMapper = Server::get(IdDocsMapper::class);
+		$this->signRequestMapper = Server::get(SignRequestMapper::class);
+	}
+
+	public function testListByUserIdReturnsDocumentsWhenAccountIsMissingFromUsersTable(): void {
+		$ldapUserId = 'ldap-user-without-oc-users-row';
+
+		$file = new File();
+		$file->setNodeId(80808);
+		$file->setUserId($ldapUserId);
+		$file->setUuid('c3333333-3333-4333-8333-333333333333');
+		$file->setCreatedAt(new \DateTime('now', new \DateTimeZone('UTC')));
+		$file->setName('passport.pdf');
+		$file->setStatus(FileStatus::ABLE_TO_SIGN->value);
+		$insertedFile = $this->fileMapper->insert($file);
+
+		$signRequest = new SignRequest();
+		$signRequest->setFileId($insertedFile->getId());
+		$signRequest->setDisplayName('LDAP User');
+		$signRequest->setUuid('d4444444-4444-4444-8444-444444444444');
+		$signRequest->setCreatedAt(new \DateTime('now', new \DateTimeZone('UTC')));
+		$insertedSignRequest = $this->signRequestMapper->insert($signRequest);
+
+		$this->idDocsMapper->save(
+			$insertedFile->getId(),
+			$insertedSignRequest->getId(),
+			$ldapUserId,
+			'IDENTIFICATION',
+		);
+
+		$result = $this->idDocsMapper->list(
+			['userId' => $ldapUserId],
+			page: 1,
+			length: 10,
+		);
+
+		$this->assertCount(1, $result['data']);
+		$this->assertSame($insertedFile->getUuid(), $result['data'][0]['file']['uuid']);
+		$this->assertSame('LDAP User', $result['data'][0]['account']['displayName']);
+	}
+}

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -27,6 +27,7 @@ use OCA\Libresign\Db\UserElementMapper;
 use OCA\Libresign\Enum\DocMdpLevel;
 use OCA\Libresign\Enum\FileStatus;
 use OCA\Libresign\Enum\FileStatus as FileStatusEnum;
+use OCA\Libresign\Enum\SignRequestStatus;
 use OCA\Libresign\Events\SignedEvent;
 use OCA\Libresign\Events\SignedEventFactory;
 use OCA\Libresign\Exception\LibresignException;
@@ -985,6 +986,58 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$signers[$i]->setSigned(new DateTime());
 		}
 		return $signers;
+	}
+
+	public function testIdDocApprovalReachesSignedWhenUploaderPlaceholderIsUnsigned(): void {
+		$uploader = new SignRequest();
+		$uploader->setId(10);
+		$uploader->setStatus(SignRequestStatus::DRAFT->value);
+
+		$approver = new SignRequest();
+		$approver->setId(20);
+		$approver->setSigned(new DateTime());
+		$approver->setStatus(SignRequestStatus::SIGNED->value);
+
+		$idDocs = new IdDocs();
+		$idDocs->setSignRequestId(10);
+		$this->idDocsMapper
+			->method('getByFileId')
+			->with(1)
+			->willReturn($idDocs);
+
+		$service = $this->getService(['getSigners']);
+		$service->method('getSigners')->willReturn([$uploader, $approver]);
+
+		$signRequest = new SignRequest();
+		$signRequest->setFileId(1);
+		$service->setSignRequest($signRequest);
+
+		$status = self::invokePrivate($service, 'evaluateStatusFromSigners');
+		$this->assertSame(FileStatus::SIGNED->value, $status);
+	}
+
+	public function testDraftSignersStillCountWhenFileIsNotAnIdentificationDocument(): void {
+		$this->idDocsMapper
+			->method('getByFileId')
+			->willThrowException(new DoesNotExistException('no identification document'));
+
+		$signed = new SignRequest();
+		$signed->setId(1);
+		$signed->setSigned(new DateTime());
+
+		$draft = new SignRequest();
+		$draft->setId(2);
+		$draft->setStatus(SignRequestStatus::DRAFT->value);
+
+		$service = $this->getService(['getSigners']);
+		$service->method('getSigners')->willReturn([$signed, $draft]);
+
+		$signRequest = new SignRequest();
+		$signRequest->setFileId(99);
+		$service->setSignRequest($signRequest);
+
+		$status = self::invokePrivate($service, 'evaluateStatusFromSigners');
+		$this->assertSame(FileStatus::PARTIAL_SIGNED->value, $status);
 	}
 
 	#[DataProvider('providerGetEngineWillWorkWithLazyLoadedEngine')]


### PR DESCRIPTION
Resolves: #7861
Resolves: #7860

## 📝 Summary

Identification documents from LDAP/SSO accounts disappeared from the account page because `IdDocsMapper` used an inner join on `oc_users`. Those backends do not create a row there, so `list()` dropped the files even when filtering by `userId`.

Approving an identification document also never reached `SIGNED`. The uploader gets a DRAFT `SignRequest` so the account page can show a display name; `evaluateStatusFromSigners()` counted that placeholder as a required signature, so the file stayed `PARTIAL_SIGNED` after the approver signed.

This change left-joins `users` when listing identification documents, and excludes only that uploader placeholder from status evaluation. Sequential-signing DRAFT signers on normal files are unchanged.

## 🧪 How to test

1. Enable **Identification documents flow** in LibreSign admin settings and set `admin` as an approver.
2. Open the LibreSign account page (`/apps/libresign/f/account`) and confirm the **Identification documents** section is visible.
3. Upload a test PDF with **Upload file** (`tests/php/fixtures/pdfs/small_valid.pdf`).
4. Confirm the card no longer shows **Not sent yet** and that **Delete file** is available. Reload the page: the document must still be listed.
5. Open **Document Validation** (`/apps/libresign/f/docs/id-docs/validation`). The row should show **waiting for approval** and a **Sign** action.
6. Create a certificate for `admin` if needed, then click **Sign** and complete the signature.
7. After signing, the list status must become **approved** (not stuck as partially signed). The **Sign** action is replaced by **Validate**.
8. LDAP-specific check for #7861: repeat steps 2–4 as an LDAP user who has no row in `oc_users`. The uploaded document must remain visible on that account.

```bash
composer test:unit -- --filter IdDocsMapperTest
composer test:unit -- --filter testIdDocApprovalReachesSignedWhenUploaderPlaceholderIsUnsigned
composer test:unit -- --filter testDraftSignersStillCountWhenFileIsNotAnIdentificationDocument
npx playwright test playwright/e2e/id-docs-visual.spec.ts
```

## ⚙️ API / Back‑end changes

- [x] `IdDocsMapper::getQueryBuilder()` always `leftJoin`s `users`, so listing by `userId` still returns documents when the account is missing from `oc_users`.
- [x] `SignFileService::evaluateStatusFromSigners()` ignores the identification-document uploader placeholder (`id_docs.sign_request_id`) so approval can reach `SIGNED`.
- [x] Unit and/or integration tests added – *required for backend changes*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Focused PHPUnit coverage added for the LDAP list join and ID-doc approval status.
- [x] Playwright coverage added for upload, account listing, and the approval queue.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
