### PR TITLE
fix: [BUG] Devcontainer does not produce a working environment on a clean set...

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-nextcloud}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-nextcloud}
   nextcloud:
-    image: ghcr.io/librecodecoop/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/librecodecoop/nextcloud-dev-php${PHP_VERSION:-83}:latest
     volumes:
       - ~/.composer:/var/www/.composer/
       - ~/.npm:/var/www/.npm/

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,20 +9,6 @@
 
 )
 
-set -Eeo pipefail
-
-reportFailure() {
-	local exitCode=$1
-	local failedLine=$2
-	local failedCommand=$3
-	echo >&2
-	echo "❌ LibreSign setup failed at ${BASH_SOURCE[0]}:${failedLine} (exit ${exitCode})" >&2
-	echo "   Failed command: ${failedCommand}" >&2
-	echo "   The environment is NOT ready to use. Fix the error above and run this script again." >&2
-	exit "${exitCode}"
-}
-trap 'reportFailure "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
-
 git config --global --add safe.directory /var/www/html
 git config --global --add safe.directory /var/www/html/apps-extra/libresign
 cd /var/www/html/apps-extra/libresign

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,6 +9,20 @@
 
 )
 
+set -Eeo pipefail
+
+reportFailure() {
+	local exitCode=$1
+	local failedLine=$2
+	local failedCommand=$3
+	echo >&2
+	echo "❌ LibreSign setup failed at ${BASH_SOURCE[0]}:${failedLine} (exit ${exitCode})" >&2
+	echo "   Failed command: ${failedCommand}" >&2
+	echo "   The environment is NOT ready to use. Fix the error above and run this script again." >&2
+	exit "${exitCode}"
+}
+trap 'reportFailure "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
+
 git config --global --add safe.directory /var/www/html
 git config --global --add safe.directory /var/www/html/apps-extra/libresign
 cd /var/www/html/apps-extra/libresign


### PR DESCRIPTION
Fixes #7985

## Root cause

Devcontainer defaults to PHP 8.2 and setup.sh swallows step failures

## Changes

- Default the devcontainer image to PHP 8.3 (matching composer.json platform 8.3, psalm phpVersion 8.3 and the Nextcloud 35 requirement), and make setup.sh strict (set -Eeo pipefail plus an ERR trap) so any failing step reports the exact file/line/command and exits non-zero instead of falsely printing success.