### PR TITLE
feat(l10n): add TRANSLATORS hints for PDFtk setup check

### DIFF
--- a/lib/SetupCheck/PDFtkSetupCheck.php
+++ b/lib/SetupCheck/PDFtkSetupCheck.php
@@ -71,7 +71,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!$pdftkPath) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. PDFtk is the Java tool LibreSign uses to stamp the signature footer onto PDFs; the configured path is empty.
 				$this->l10n->t('PDFtk not found'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -84,7 +86,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!file_exists($pdftkPath)) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. PDFtk stamps LibreSign's PDF footer during signing; %s is the configured filesystem path that does not exist.
 				$this->l10n->t('PDFtk binary not found: %s', [$pdftkPath]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -92,7 +96,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 		$javaPath = $this->javaHelper->getJavaPath();
 		if (!$javaPath || !file_exists($javaPath)) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. LibreSign runs PDFtk as a Java JAR to write the signed PDF footer, so a working Java runtime is required.
 				$this->l10n->t('Necessary Java to run PDFtk'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install the Java runtime LibreSign needs via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -101,7 +107,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 		exec($javaPath . ' -jar ' . $pdftkPath . ' --version 2>&1', $versionOutput, $resultCode);
 		if (empty($versionOutput) || $resultCode !== 0) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. LibreSign could not read the PDFtk version string used to stamp signed PDF footers.
 				$this->l10n->t('Failure to check PDFtk version.'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to reinstall PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -112,20 +120,26 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!$version) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. The file at %s does not look like the PDFtk JAR LibreSign expects for PDF footer stamping.
 				$this->l10n->t('PDFtk binary is invalid: %s', [$pdftkPath]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to reinstall PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
 
 		if ($version !== InstallService::PDFTK_VERSION) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. LibreSign only supports a specific PDFtk release for reliable PDF footer stamping; %s is that required version.
 				$this->l10n->t('Necessary install the version %s', [InstallService::PDFTK_VERSION]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install the supported PDFtk version for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
 
 		$messages = [
+			// TRANSLATORS Success line in Nextcloud administration overview for LibreSign. %s is the detected PDFtk version used to stamp signed PDF footers.
 			$this->l10n->t('PDFtk version: %s', [$version]),
+			// TRANSLATORS Success line in Nextcloud administration overview for LibreSign. %s is the filesystem path of the PDFtk JAR used to stamp signed PDF footers.
 			$this->l10n->t('PDFtk path: %s', [$pdftkPath]),
 		];
 		return SetupResult::success(implode("\n", $messages));


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/SetupCheck/PDFtkSetupCheck.php`.

All `$this->l10n->t(...)` calls in that file now have LibreSign context for translators (Nextcloud Administration overview; PDFtk stamps the signed PDF footer). English source strings are unchanged.

Follow-up PRs for #973 will continue **file by file** (cover every translation call in the chosen file) instead of fixed batch sizes.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/SetupCheck/PDFtkSetupCheck.php` and confirm every `$this->l10n->t(...)` in `run()` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.
3. Optional: as admin, open Nextcloud **Administration settings → Overview** and confirm LibreSign PDFtk setup check messages still render the same text.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `PDFtkSetupCheck.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI