### PR TITLE
feat(l10n): add TRANSLATORS hint for signing error dialog title

### DIFF
--- a/lib/Handler/SigningErrorHandler.php
+++ b/lib/Handler/SigningErrorHandler.php
@@ -106,6 +106,7 @@ class SigningErrorHandler {
 					$message,
 				],
 			),
+			// TRANSLATORS Dialog title shown to the signer when LibreSign fails unexpectedly while applying a digital signature.
 			'title' => $this->l10n->t('Internal Server Error'),
 		]];
 	}


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Handler/SigningErrorHandler.php`.

The remaining call (`Internal Server Error`) now has LibreSign context for translators: dialog title shown when signing fails unexpectedly. Other strings in this file already had hints. English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Handler/SigningErrorHandler.php` and confirm every `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above (including the dialog `title`).
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `SigningErrorHandler.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)