### PR TITLE
feat(l10n): add TRANSLATORS hint for file signed activity setting

### DIFF
--- a/lib/Activity/Settings/FileSigned.php
+++ b/lib/Activity/Settings/FileSigned.php
@@ -36,6 +36,8 @@ class FileSigned extends LibresignActivitySettings {
 	 */
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Activity setting label in Nextcloud Personal settings → Activity.
+		// Shown when users choose which LibreSign signing events trigger activity or email notifications.
 		return $this->l->t('A document has been <strong>signed</strong>');
 	}
 


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Activity/Settings/FileSigned.php`.

The Activity settings label for completed signatures now has LibreSign context for translators (Nextcloud Personal settings → Activity; users choosing which signing events notify them). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Activity/Settings/FileSigned.php` and confirm every `$this->l->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `FileSigned.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)