### PR TITLE
feat(l10n): add TRANSLATORS hint for admin binary download error

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -275,6 +275,8 @@ class AdminController extends AEnvironmentAwareController {
 			}
 		} catch (\Exception $exception) {
 			$this->eventSource->send('errors', json_encode([
+				// TRANSLATORS Error shown to admins in LibreSign admin settings while installing
+				// Java, JSignPdf, PDFtk, or CFSSL binaries over the install-and-validate SSE stream.
 				$this->l10n->t('Could not download binaries.'),
 				$exception->getMessage(),
 			]));


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Controller/AdminController.php`.

The admin binary-download error in the install-and-validate SSE stream now has LibreSign context for translators (LibreSign admin settings while installing Java/JSignPdf/PDFtk/CFSSL). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Controller/AdminController.php` and confirm every `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `AdminController.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)