### PR TITLE
feat(l10n): add TRANSLATORS hint for signed event user not found

### DIFF
--- a/lib/Events/SignedEventFactory.php
+++ b/lib/Events/SignedEventFactory.php
@@ -53,6 +53,8 @@ class SignedEventFactory {
 	protected function getUser(FileEntity $libreSignFile): IUser {
 		$user = $this->userManager->get($libreSignFile->getUserId());
 		if (!$user instanceof IUser) {
+			// TRANSLATORS Error thrown when building the signed-document event if the file owner
+			// account no longer exists. Surfaces to the signing workflow after a signature is applied.
 			throw new LibresignException($this->l10n->t('User not found.'));
 		}
 		return $user;


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Events/SignedEventFactory.php`.

The “User not found” error when building the signed-document event now has LibreSign context for translators (signing workflow after a signature is applied). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Events/SignedEventFactory.php` and confirm every `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `SignedEventFactory.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)