### PR TITLE
feat(l10n): add TRANSLATORS hint for PDFtk footer setup wait message

### DIFF
--- a/lib/Handler/PdfTk/Pdf.php
+++ b/lib/Handler/PdfTk/Pdf.php
@@ -54,6 +54,8 @@ class Pdf extends BasePdf {
 		}
 
 		if (!file_exists($this->javaPath) || !file_exists($this->pdftkPath)) {
+			// TRANSLATORS Error shown to signers when LibreSign cannot stamp the PDF footer because
+			// the admin has not finished installing Java or PDFtk used in the signing pipeline.
 			throw new FooterStampUnavailableException($this->l10n->t('The admin hasn\'t set up LibreSign yet, please wait.'));
 		}
 


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Handler/PdfTk/Pdf.php`.

The “admin hasn’t set up LibreSign yet” error during PDF footer stamping now has LibreSign context for translators (signers waiting while Java/PDFtk are missing). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Handler/PdfTk/Pdf.php` and confirm every `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `Pdf.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)