### PR TITLE
feat(l10n): add TRANSLATORS hints for PolicyService

### DIFF
--- a/lib/Service/Policy/PolicyService.php
+++ b/lib/Service/Policy/PolicyService.php
@@ -333,6 +333,7 @@ class PolicyService {
 			return;
 		}
 
+		// TRANSLATORS Error shown in the Policy Workbench when a group admin tries to delete a group rule that was created by a system administrator.
 		throw new \DomainException($this->l10n->t('Only system administrators can delete group rules created by a system administrator'));
 	}
 
@@ -360,6 +361,7 @@ class PolicyService {
 			return;
 		}
 
+		// TRANSLATORS Error shown in the Policy Workbench when a group admin tries to edit a group access rule that was created by a system administrator.
 		throw new \DomainException($this->l10n->t('Only system administrators can edit group access rules created by a system administrator'));
 	}
 
@@ -383,6 +385,7 @@ class PolicyService {
 
 		$definition = $this->registry->get($policyKey);
 		if (!$this->canCurrentActorManageGroupPolicy($definition, $context)) {
+			// TRANSLATORS Error shown when a group admin tries to manage group policies without system-admin delegation for that policy.
 			throw new \DomainException($this->l10n->t('Group policy management requires explicit delegation from the system administrator'));
 		}
 	}
@@ -407,6 +410,7 @@ class PolicyService {
 			default => ucfirst($scope),
 		};
 
+		// TRANSLATORS Error when saving a policy at an unsupported scope. %s is the scope label such as System, Group, or User.
 		throw new \InvalidArgumentException($this->l10n->t('%s-level scope is not supported for this policy', [$scopeLabel]));
 	}
 
@@ -418,6 +422,7 @@ class PolicyService {
 		$definition->validateValue($normalizedValue, $context);
 		$resolved = $this->resolver->resolve($definition, $context);
 		if (!$resolved->canSaveAsUserDefault()) {
+			// TRANSLATORS Error when a signer or end user tries to save a personal preference for a policy that does not allow user defaults. {policyKey} is the policy identifier.
 			throw new \InvalidArgumentException($this->l10n->t('Saving a user preference is not allowed for {policyKey}', [
 				'policyKey' => $definition->key(),
 			]));


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Service/Policy/PolicyService.php`.

All `->t(...)` calls in that file now have LibreSign context for translators (where the string appears, who sees it, and its role in the signing workflow). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Service/Policy/PolicyService.php` and confirm every `->t(...)` has a `// TRANSLATORS` comment immediately above (or in the prior contiguous comment block).
2. Confirm the diff touches only that file and is comments only.
3. Spot-check that English source strings were not modified.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `PolicyService.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI