### PR TITLE
feat(l10n): add TRANSLATORS hint for ID docs approval permission error

### DIFF
--- a/lib/Service/IdDocsPolicyService.php
+++ b/lib/Service/IdDocsPolicyService.php
@@ -102,6 +102,8 @@ class IdDocsPolicyService {
 		$userGroups = $this->groupManager->getUserGroupIds($user);
 		if (!array_intersect($userGroups, $authorized)) {
 			if ($throw) {
+				// TRANSLATORS Error shown when a user tries to approve identification documents
+				// but is not in the LibreSign approval groups configured for the ID docs policy.
 				throw new LibresignException($this->l10n->t('You are not allowed to approve user profile documents.'));
 			}
 			return false;


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Completes `TRANSLATORS` hints for **one PHP file**: `lib/Service/IdDocsPolicyService.php`.

The identification-documents approval permission error now has LibreSign context for translators (users outside the configured approval groups). English source strings are unchanged.

Follow-up PRs for #973 continue **file by file**.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open `lib/Service/IdDocsPolicyService.php` and confirm every `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff touches only that file and is comments only.

## ⚙️ API / Back‑end changes

- [x] Completed PHP `TRANSLATORS` hints for `IdDocsPolicyService.php`
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to a single PHP file for #973 follow-ups
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)