### PR TITLE
feat(l10n): add TRANSLATORS hints for signing engine strings

### DIFF
--- a/lib/Handler/SignEngine/Pkcs12Handler.php
+++ b/lib/Handler/SignEngine/Pkcs12Handler.php
@@ -69,6 +69,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		preg_match_all('/\/Contents\s*<([0-9a-fA-F]+)>/', $content, $contents, PREG_OFFSET_CAPTURE);
 
 		if (empty($contents[1])) {
+			// TRANSLATORS Error while LibreSign reads a PDF for signature validation: the file has no embedded PKCS#12/PDF signature bytes yet.
 			throw new LibresignException($this->l10n->t('Unsigned file.'));
 		}
 
@@ -155,6 +156,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		if (!$signature) {
 			$result['chain'][0]['signature_validation'] = [
 				'id' => 3,
+				// TRANSLATORS Status label on LibreSign's public/document validation UI when the PDF signature hash does not match the document bytes (tamper or corrupt signature).
 				'label' => $this->l10n->t('Digest mismatch.'),
 			];
 			return $result;
@@ -187,6 +189,7 @@ class Pkcs12Handler extends SignEngineHandler {
 			) {
 				$signer['chain'][$key]['certificate_validation'] = [
 					'id' => 1,
+					// TRANSLATORS Status label on LibreSign signature validation when the signer certificate chains to LibreSign's own root CA and is accepted.
 					'label' => $this->l10n->t('Certificate is trusted.'),
 				];
 			}
@@ -239,6 +242,7 @@ class Pkcs12Handler extends SignEngineHandler {
 			if ($parsed) {
 				$parsed['signature_validation'] = [
 					'id' => 1,
+					// TRANSLATORS Status label on LibreSign signature validation when the cryptographic PDF signature checks out successfully.
 					'label' => $this->l10n->t('Signature is valid.'),
 				];
 				if (!$isLibreSignRootCA) {
@@ -347,6 +351,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		if (!isset($leaf['certificate_validation'])) {
 			$leaf['certificate_validation'] = [
 				'id' => 3,
+				// TRANSLATORS Status label on LibreSign signature validation when the signer certificate's issuing CA is not in the trusted store.
 				'label' => $this->l10n->t('Certificate issuer is unknown.'),
 			];
 		}
@@ -413,6 +418,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		$sign_engine = $this->appConfig->getValueString(Application::APP_ID, 'signature_engine', 'JSignPdf');
 		$property = lcfirst($sign_engine) . 'Handler';
 		if (!property_exists($this, $property)) {
+			// TRANSLATORS API/config error when LibreSign's signature_engine setting names a backend that is not available (for example a mistyped JSignPdf/native engine).
 			throw new LibresignException($this->l10n->t('Invalid Sign engine.'), 400);
 		}
 		$classHandler = 'OCA\\Libresign\\Handler\\SignEngine\\' . ucfirst($property);

--- a/lib/Handler/SignEngine/SignEngineHandler.php
+++ b/lib/Handler/SignEngine/SignEngineHandler.php
@@ -144,13 +144,17 @@ abstract class SignEngineHandler implements ISignEngineHandler {
 		} catch (LibresignException $e) {
 			throw $e;
 		} catch (EmptyCertificateException) {
+			// TRANSLATORS Error while LibreSign creates a user's signing certificate (PFX): the instance root CA material is missing or empty.
 			throw new LibresignException($this->l10n->t('Empty root certificate data'));
 		} catch (InvalidArgumentException) {
+			// TRANSLATORS Error while LibreSign creates a user's signing certificate: the identity fields or password payload sent to the certificate engine are invalid.
 			throw new LibresignException($this->l10n->t('Invalid data to generate certificate'));
 		} catch (\Throwable) {
+			// TRANSLATORS Error while LibreSign creates a user's signing certificate: the certificate engine failed unexpectedly during generation.
 			throw new LibresignException($this->l10n->t('Failure on generate certificate'));
 		}
 		if (!$content) {
+			// TRANSLATORS Error while LibreSign creates a user's signing certificate: generation finished without returning a PFX/certificate payload.
 			throw new LibresignException($this->l10n->t('Failure to generate certificate'));
 		}
 		$this->setCertificate($content);
@@ -164,6 +168,7 @@ abstract class SignEngineHandler implements ISignEngineHandler {
 		try {
 			$folder->newFile($this->pfxFilename, $content);
 		} catch (NotPermittedException) {
+			// TRANSLATORS Permission error when LibreSign tries to store the user's signing certificate (PFX) in their Nextcloud home folder.
 			throw new LibresignException($this->l10n->t('You do not have permission for this action.'));
 		}
 
@@ -177,6 +182,7 @@ abstract class SignEngineHandler implements ISignEngineHandler {
 			$file = $folder->get($this->pfxFilename);
 			$file->delete();
 		} catch (NotPermittedException) {
+			// TRANSLATORS Permission error when LibreSign tries to delete the user's signing certificate (PFX) from their Nextcloud home folder.
 			throw new LibresignException($this->l10n->t('You do not have permission for this action.'));
 		} catch (NotFoundException|InvalidPathException) {
 		}
@@ -196,16 +202,19 @@ abstract class SignEngineHandler implements ISignEngineHandler {
 			$node = $folder->get($this->pfxFilename);
 			$this->certificate = $node->getContent();
 		} catch (GenericFileException|NotFoundException) {
+			// TRANSLATORS Error shown to the signer when LibreSign has no stored signing certificate/password yet; they must create a signing password before signing.
 			throw new LibresignException($this->l10n->t('Password to sign not defined. Create a password to sign.'), 400);
 		} catch (\Throwable) {
 		}
 		if (empty($this->certificate)) {
+			// TRANSLATORS Error shown to the signer when LibreSign has no stored signing certificate/password yet; they must create a signing password before signing.
 			throw new LibresignException($this->l10n->t('Password to sign not defined. Create a password to sign.'), 400);
 		}
 		if ($this->getPassword()) {
 			try {
 				$this->getCertificateEngine()->readCertificate($this->certificate, $this->getPassword());
 			} catch (InvalidPasswordException) {
+				// TRANSLATORS Error shown to the signer when the password entered to unlock their LibreSign signing certificate (PFX) is wrong.
 				throw new LibresignException($this->l10n->t('Invalid password'));
 			}
 		}


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Adds 15 `// TRANSLATORS` comments for PHP signing-engine strings in:

- `lib/Handler/SignEngine/Pkcs12Handler.php` (signature validation labels and engine errors)
- `lib/Handler/SignEngine/SignEngineHandler.php` (certificate generation, PFX storage, signing password errors)

Hints give LibreSign context for translators (validation UI / signer certificate workflow) without changing English source strings. This is a 15-hint batch for #973.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Open the two files above and confirm each changed `$this->l10n->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff is comments only — no English source strings changed.
3. Optional: open LibreSign document validation for a signed PDF and confirm status labels still read the same in English.

## ⚙️ API / Back‑end changes

- [x] Added PHP `TRANSLATORS` hints for signing-engine validation and certificate/password errors
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to about 15 PHP translation hints as suggested in #973
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)