### PR TITLE
feat(l10n): add TRANSLATORS hints for footer, SMS and PDFtk

### DIFF
--- a/lib/Activity/Settings/FileSigned.php
+++ b/lib/Activity/Settings/FileSigned.php
@@ -36,6 +36,7 @@ class FileSigned extends LibresignActivitySettings {
 	 */
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Activity app setting label for LibreSign events when a document finishes being digitally signed. Keep the <strong> markup.
 		return $this->l->t('A document has been <strong>signed</strong>');
 	}
 

--- a/lib/Activity/Settings/FileToSign.php
+++ b/lib/Activity/Settings/FileToSign.php
@@ -32,6 +32,7 @@ class FileToSign extends LibresignActivitySettings {
 	 */
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Activity app setting label for LibreSign events when the current user has a pending document to sign. Keep the <strong> markup.
 		return $this->l->t('You have a <strong>file to sign</strong>');
 	}
 }

--- a/lib/Activity/Settings/SignRequestCanceled.php
+++ b/lib/Activity/Settings/SignRequestCanceled.php
@@ -34,6 +34,7 @@ class SignRequestCanceled extends LibresignActivitySettings {
 	 */
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Activity app setting label for LibreSign events when a signature request is canceled before completion. Keep the <strong> markup.
 		return $this->l->t('A signature request has been <strong>canceled</strong>');
 	}
 

--- a/lib/Handler/FooterHandler.php
+++ b/lib/Handler/FooterHandler.php
@@ -153,6 +153,7 @@ class FooterHandler {
 
 		if (!$this->templateVars->getSignedBy()) {
 			$this->templateVars->setSignedBy(
+				// TRANSLATORS Default PDF footer sentence stamped after LibreSign applies a digital signature; readers see this on the finished document.
 				$this->appConfig->getValueString(Application::APP_ID, 'footer_signed_by', $this->l10n->t('Digitally signed by LibreSign.'))
 			);
 		}
@@ -187,6 +188,7 @@ class FooterHandler {
 		if (!$this->templateVars->getValidateIn()) {
 			$validateIn = $this->appConfig->getValueString(Application::APP_ID, 'footer_validate_in', 'Validate in %s.');
 			if ($validateIn === 'Validate in %s.') {
+				// TRANSLATORS Default PDF footer line after signing. "Validate" means check that the digital signature is authentic on LibreSign's public validation page, not approve a document. %s is the validation site URL or name.
 				$this->templateVars->setValidateIn($this->l10n->t('Validate in %s.', ['%s']));
 			} else {
 				$this->templateVars->setValidateIn($validateIn);

--- a/lib/Handler/PdfTk/Pdf.php
+++ b/lib/Handler/PdfTk/Pdf.php
@@ -54,6 +54,7 @@ class Pdf extends BasePdf {
 		}
 
 		if (!file_exists($this->javaPath) || !file_exists($this->pdftkPath)) {
+			// TRANSLATORS Error while LibreSign tries to stamp the signed PDF footer with PDFtk: Java or PDFtk is not installed yet on the server.
 			throw new FooterStampUnavailableException($this->l10n->t('The admin hasn\'t set up LibreSign yet, please wait.'));
 		}
 

--- a/lib/Listener/TwofactorGatewayListener.php
+++ b/lib/Listener/TwofactorGatewayListener.php
@@ -87,8 +87,10 @@ class TwofactorGatewayListener implements IEventListener {
 			}
 
 			if ($isFirstNotification) {
+				// TRANSLATORS SMS/gateway body sent via Nextcloud Twofactor Gateway when LibreSign first asks someone to sign a document; a signing link follows this sentence.
 				$message .= $this->l10n->t('There is a document for you to sign. Access the link below:');
 			} else {
+				// TRANSLATORS SMS/gateway body sent via Nextcloud Twofactor Gateway when a pending LibreSign signing request was updated and the signer must open the link again.
 				$message .= $this->l10n->t('Changes have been made in a file that you have to sign. Access the link below:');
 			}
 			$message .= "\n";
@@ -133,6 +135,7 @@ class TwofactorGatewayListener implements IEventListener {
 				return;
 			}
 
+			// TRANSLATORS SMS/gateway subject line sent via Nextcloud Twofactor Gateway after a LibreSign document was signed; details and a validation link follow.
 			$message = $this->l10n->t('LibreSign: A file has been signed');
 			$message .= "\n";
 			// TRANSLATORS The text in the message that is sent after a document has been signed by a user. %s will be replaced with the name of the user who signed the document.

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -33,6 +33,7 @@ class AdminSettings implements IIconSection {
 	 */
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Nextcloud Administration settings section name for the LibreSign digital signature app.
 		return $this->l->t('LibreSign');
 	}
 

--- a/lib/SetupCheck/PDFtkSetupCheck.php
+++ b/lib/SetupCheck/PDFtkSetupCheck.php
@@ -71,7 +71,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!$pdftkPath) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. PDFtk is the Java tool LibreSign uses to stamp the signature footer onto PDFs; the configured path is empty.
 				$this->l10n->t('PDFtk not found'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -84,7 +86,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!file_exists($pdftkPath)) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. PDFtk stamps LibreSign's PDF footer during signing; %s is the configured filesystem path that does not exist.
 				$this->l10n->t('PDFtk binary not found: %s', [$pdftkPath]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -92,7 +96,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 		$javaPath = $this->javaHelper->getJavaPath();
 		if (!$javaPath || !file_exists($javaPath)) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. LibreSign runs PDFtk as a Java JAR to write the signed PDF footer, so a working Java runtime is required.
 				$this->l10n->t('Necessary Java to run PDFtk'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to install the Java runtime LibreSign needs via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -101,7 +107,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 		exec($javaPath . ' -jar ' . $pdftkPath . ' --version 2>&1', $versionOutput, $resultCode);
 		if (empty($versionOutput) || $resultCode !== 0) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. LibreSign could not read the PDFtk version string used to stamp signed PDF footers.
 				$this->l10n->t('Failure to check PDFtk version.'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to reinstall PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}
@@ -112,7 +120,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 
 		if (!$version) {
 			return SetupResult::error(
+				// TRANSLATORS Nextcloud administration overview warning. The file at %s does not look like the PDFtk JAR LibreSign expects for PDF footer stamping.
 				$this->l10n->t('PDFtk binary is invalid: %s', [$pdftkPath]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the server administrator to reinstall PDFtk for LibreSign via the Nextcloud occ CLI.
 				$this->l10n->t('Run occ libresign:install --pdftk')
 			);
 		}


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Adds 20 `// TRANSLATORS` comments for PHP strings across LibreSign footer stamping, signer SMS/gateway notifications, Activity settings, admin settings section naming, and PDFtk administration overview checks:

- `lib/Handler/FooterHandler.php`
- `lib/Listener/TwofactorGatewayListener.php`
- `lib/Handler/PdfTk/Pdf.php`
- `lib/Activity/Settings/FileSigned.php`
- `lib/Activity/Settings/FileToSign.php`
- `lib/Activity/Settings/SignRequestCanceled.php`
- `lib/Settings/AdminSettings.php`
- `lib/SetupCheck/PDFtkSetupCheck.php`

Hints give LibreSign context for translators without changing English source strings. This is a 20-hint batch for #973.

Comments will appear in Transifex after the next extraction sync.

## 🧪 How to test

1. Review the files listed above and confirm each changed `$this->l10n->t(...)` / `$this->l->t(...)` has a `// TRANSLATORS` comment on the line above.
2. Confirm the diff is comments only — no English source strings changed.
3. Optional:
   - Open Nextcloud **Administration settings → Overview** and confirm PDFtk LibreSign messages still render the same English text.
   - Open **Personal settings → Activity** and confirm LibreSign activity setting labels still look the same.

## ⚙️ API / Back‑end changes

- [x] Added PHP `TRANSLATORS` hints for footer defaults, Twofactor Gateway messages, Activity settings, admin section name, and PDFtk setup-check strings
- [ ] Unit and/or integration tests added – *N/A: comment-only change; no behavior change*
- [ ] Capabilities updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] API documentation updated with `composer openapi` – *N/A*

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Scoped to about 20 PHP translation hints as a follow-up batch of #973
- [x] No runtime behavior or source strings changed
- [x] Conventional commit type uses an allowed prefix (`feat`)

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI

Made with [Cursor](https://cursor.com)