### PR TITLE
chore(devcontainer): use version-tagged image so Dependabot can bump PHP

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-nextcloud}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-nextcloud}
   nextcloud:
-    image: ghcr.io/librecodecoop/nextcloud-dev-php${PHP_VERSION:-83}:latest
+    image: ghcr.io/librecodecoop/nextcloud-dev:8.3
     volumes:
       - ~/.composer:/var/www/.composer/
       - ~/.npm:/var/www/.npm/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+
+  # Maintain the Nextcloud image used by the devcontainer
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Follow-up to #8001 (see [review comment](https://github.com/LibreSign/libresign/pull/8001#pullrequestreview-4996678719)) and to LibreCodeCoop/nextcloud-docker-development#123.

## 📝 Summary

Make Dependabot able to keep the devcontainer PHP version updated, so bumps like the `php82` → `php83` one in #8001 happen automatically in the future:

- Reference the new version-tagged image `ghcr.io/librecodecoop/nextcloud-dev:8.3` (published by LibreCodeCoop/nextcloud-docker-development#124) with a **literal tag**, instead of interpolating `PHP_VERSION` into the image name. Dependabot only updates version-like tags — it cannot rewrite image names and cannot parse interpolated references, so the old scheme could only be bumped by hand.
- Add a `docker` package-ecosystem entry for `/.devcontainer` to `dependabot.yml`.

Once merged, when a new PHP version image (e.g. `:8.4`) is published upstream, Dependabot opens the bump PR here automatically.

To run the devcontainer with a different PHP version, edit the image tag locally (the `PHP_VERSION` env var no longer applies — keeping it would defeat Dependabot).

## 🧪 How to test

1. After LibreCodeCoop/nextcloud-docker-development#124 is merged and the `nextcloud-dev` package is public, rebuild the devcontainer from a clean setup ("Rebuild Container" without cache, or a fresh Codespace).
2. Confirm the `nextcloud` service uses `ghcr.io/librecodecoop/nextcloud-dev:8.3` and PHP is 8.3: `docker compose exec nextcloud php -v`.
3. Confirm setup completes and LibreSign is enabled as before.

Dependabot config can be validated by GitHub's checks on this PR (`dependabot.yml` schema is linted server-side).

### 🚧 Tasks

- [x] Merge LibreCodeCoop/nextcloud-docker-development#124 (publishes `ghcr.io/librecodecoop/nextcloud-dev:<version>`)
- [x] Set the new `nextcloud-dev` GHCR package visibility to public (first push creates it private by default)
- [ ] Mark this PR ready for review

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] No runtime/app code changes — devcontainer and Dependabot config only.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI (Claude Code, reviewed and submitted by the human contributor)
