### PR TITLE
fix: promote certificate validity dates to signer root

### DIFF
--- a/lib/Service/File/CertificateSignersMergeService.php
+++ b/lib/Service/File/CertificateSignersMergeService.php
@@ -352,6 +352,16 @@ class CertificateSignersMergeService {
 		if (isset($chain[0])) {
 			$this->enrichSignerWithCertificateValidation($signer, $chain[0]);
 		}
+
+		// Promote the end-entity (leaf) certificate validity dates to the signer root so the
+		// validation UI and the SignerDetail API contract can read them from a stable location.
+		// The chain still carries the full per-certificate dates for the certificate-chain view.
+		if (isset($signer->chain[0]['valid_from']) && !isset($signer->valid_from)) {
+			$signer->valid_from = $signer->chain[0]['valid_from'];
+		}
+		if (isset($signer->chain[0]['valid_to']) && !isset($signer->valid_to)) {
+			$signer->valid_to = $signer->chain[0]['valid_to'];
+		}
 	}
 
 	private function enrichSignerWithCertificateValidation(\stdClass $signer, array $endEntityCert): void {

--- a/tests/integration/features/file/validate.feature
+++ b/tests/integration/features/file/validate.feature
@@ -52,6 +52,8 @@ Feature: validate
       | (jq).ocs.data.signers[0].subject.O            | Organization                                                                             |
       | (jq).ocs.data.signers[0].signature_validation | {"id":1,"label":"Signature is valid."}                                                   |
       | (jq).ocs.data.signers[0].signatureTypeSN      | RSA-SHA256                                                                               |
+      | (jq)(.ocs.data.signers[0].valid_from \| test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}$")) | true   |
+      | (jq)(.ocs.data.signers[0].valid_to \| test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}$"))   | true   |
 
   Scenario Outline: Unauthenticated user can fetch the validation ednpoint
     Given as user "admin"

--- a/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
@@ -154,6 +154,37 @@ final class CertificateSignersMergeServiceTest extends TestCase {
 		];
 	}
 
+	public function testMergePromotesLeafCertValidityDatesToSignerRoot(): void {
+		$fileData = new \stdClass();
+		$fileData->signers = [];
+
+		$certData = [[
+			'uid' => 'email:signer@example.com',
+			'chain' => [[
+				'subject' => ['CN' => 'Signer User'],
+				'validFrom_time_t' => 1769644731,
+				'validTo_time_t' => 1769731131,
+			]],
+		]];
+
+		$this->getService()->merge(
+			$fileData,
+			$certData,
+			'example.com',
+			'Signed',
+			fn (array $cert, string $host): ?string => $cert['subject']['UID'] ?? null,
+			fn (string $method, string $value): string => $method . ':' . $value,
+			fn (string $accountId): ?string => null,
+		);
+
+		$this->assertCount(1, $fileData->signers);
+		$signer = $fileData->signers[0];
+		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->valid_from);
+		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->valid_to);
+		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->chain[0]['valid_from']);
+		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->chain[0]['valid_to']);
+	}
+
 	public function testMergeDoesNotExportTopLevelTsaWithTimestampData(): void {
 		$fileData = new \stdClass();
 		$fileData->signers = [];

--- a/tests/php/Unit/Service/File/SignersLoaderTest.php
+++ b/tests/php/Unit/Service/File/SignersLoaderTest.php
@@ -528,10 +528,12 @@ final class SignersLoaderTest extends TestCase {
 		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->chain[0]['valid_from']);
 		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->chain[0]['valid_to']);
 
-		// Root level should NOT have the formatted dates from backend
-		// These fields should only exist in the chain, not duplicated at root level
-		$this->assertObjectNotHasProperty('valid_from', $signer, 'valid_from should not be copied to root level');
-		$this->assertObjectNotHasProperty('valid_to', $signer, 'valid_to should not be copied to root level');
+		// Root level should expose the ISO UTC validity dates (from validFrom/validTo_time_t) so the
+		// validation UI and the SignerDetail API contract can read them from a stable location. The
+		// locale-formatted backend strings (e.g. 'January 28, 2026, 11:58:51 PM') must NOT leak here,
+		// but the ISO form IS promoted.
+		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->valid_from);
+		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->valid_to);
 
 		// Also verify other technical fields are not duplicated
 		$this->assertObjectNotHasProperty('validFrom_time_t', $signer);


### PR DESCRIPTION
Fixes #7825

## Problem

On the document validation panel, every signer shows **"No expiration date"** even though the signer's leaf certificate carries a valid `notAfter`.

### Root cause

The Apr-2026 refactor that extracted `CertificateSignersMergeService::processChainData()` stopped promoting the end-entity (leaf) certificate's `valid_from`/`valid_to` to the **top-level signer object**. Before that refactor, `SignersLoader` merged `chain[0]`'s fields into the signer root via `array_merge`.

The validation UI (`src/components/validation/SignerDetails.vue`) and the `SignerDetail` OpenAPI schema both read `valid_from`/`valid_to` from the **signer root**, so the panel always rendered "No expiration date".

A unit test (`testLoadSignersFromCertDataPreventsDuplicateFormattedDates`) had accidentally codified the buggy behavior by asserting root-level `valid_to` should be absent — contradicting the existing contract from Oct-2025 (`FileServiceTest` + OpenAPI).

## Fix

- **`CertificateSignersMergeService::processChainData()`**: promote the ISO UTC `valid_from`/`valid_to` from `chain[0]` to the signer root. The chain still carries the full per-certificate dates for the certificate-chain view.
- **Tests**:
  - New regression test `testMergePromotesLeafCertValidityDatesToSignerRoot`.
  - Updated `testLoadSignersFromCertDataPreventsDuplicateFormattedDates` to assert the corrected contract (ISO dates present at root, locale-formatted backend strings and technical fields still excluded).
  - Behat: `tests/integration/features/file/validate.feature` now asserts `valid_from`/`valid_to` on `signers[0]` of the validate endpoint response.

## Validation

- Full PHPUnit suite: 3518 tests / 8564 assertions OK (run before any behat/environment activity)
- Focused suites for the changed area pass (31 tests / 117 assertions)
- `php -l`, php-cs-fixer dry-run, psalm (no errors)
- Behat feature not executed locally (dev-container PHP built-in server + memcache limitation documented in AGENTS.md); the added jq assertion matches the established `test()` pattern used in `page/index.feature`