### PR TITLE
feat(l10n): add TRANSLATORS hints for services and setup checks

### DIFF
--- a/lib/Service/Certificate/ValidateService.php
+++ b/lib/Service/Certificate/ValidateService.php
@@ -26,12 +26,14 @@ class ValidateService {
 
 		if ($expectedType === 'array' && !is_array($value)) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when generating a signing certificate and a required subject field has the wrong type. %s is the field name such as CN or O.
 				$this->l10n->t("Parameter '%s' is required!", [$fieldName])
 			);
 		}
 
 		if ($expectedType === 'string' && !is_string($value)) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when generating a signing certificate and a required subject field has the wrong type. %s is the field name such as CN or O.
 				$this->l10n->t("Parameter '%s' is required!", [$fieldName])
 			);
 		}
@@ -48,11 +50,13 @@ class ValidateService {
 		$length = strlen($value);
 		if (!$length && isset($rule['required']) && $rule['required']) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when generating a signing certificate and a required subject field is empty. %s is the field name such as CN or O.
 				$this->l10n->t("Parameter '%s' is required!", [$fieldName])
 			);
 		}
 		if ($length > $rule['max'] || $length < $rule['min']) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when a certificate subject field length is outside the allowed range. %s is the field name; the next values are the minimum and maximum length.
 				$this->l10n->t("Parameter '%s' should be betweeen %s and %s.", [$fieldName, $rule['min'], $rule['max']])
 			);
 		}
@@ -62,11 +66,13 @@ class ValidateService {
 		$arrayLength = count($values);
 		if (isset($rule['minItems']) && $arrayLength < $rule['minItems']) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when a certificate subject field has too few values. %s is the field name with "items"; the next values are the allowed minimum and maximum counts.
 				$this->l10n->t("Parameter '%s' should be betweeen %s and %s.", [$fieldName . ' items', $rule['minItems'], $rule['maxItems'] ?? '∞'])
 			);
 		}
 		if (isset($rule['maxItems']) && $arrayLength > $rule['maxItems']) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when a certificate subject field has too many values. %s is the field name with "items"; the next values are the allowed minimum and maximum counts.
 				$this->l10n->t("Parameter '%s' should be betweeen %s and %s.", [$fieldName . ' items', $rule['minItems'] ?? 0, $rule['maxItems']])
 			);
 		}
@@ -75,6 +81,7 @@ class ValidateService {
 
 		if (empty($nonEmptyValues) && isset($rule['required']) && $rule['required']) {
 			throw new InvalidArgumentException(
+				// TRANSLATORS Error shown when generating a signing certificate and a required subject field list is empty. %s is the field name.
 				$this->l10n->t("Parameter '%s' is required!", [$fieldName])
 			);
 		}
@@ -82,6 +89,7 @@ class ValidateService {
 		foreach ($values as $index => $value) {
 			if (!is_string($value)) {
 				throw new InvalidArgumentException(
+					// TRANSLATORS Error shown when generating a signing certificate and a required subject field value is invalid. %s is the field name.
 					$this->l10n->t("Parameter '%s' is required!", [$fieldName])
 				);
 			}

--- a/lib/Service/DocMdp/Validator.php
+++ b/lib/Service/DocMdp/Validator.php
@@ -38,12 +38,14 @@ class Validator {
 		if ($docMdpLevel === 1) {
 			if ($file && $file->getSignedHash()) {
 				throw new LibresignException(
+					// TRANSLATORS Error shown when trying to add more signers to a document certified with DocMDP level that forbids further changes.
 					$this->l10n->t('This document has been certified with no changes allowed. You cannot add more signers to this document.')
 				);
 			}
 
 			if (count($data['signers']) > 1) {
 				throw new LibresignException(
+					// TRANSLATORS Error shown when trying to add more signers to a document certified with DocMDP level that forbids further changes.
 					$this->l10n->t('This document has been certified with no changes allowed. You cannot add more signers to this document.')
 				);
 			}
@@ -57,11 +59,13 @@ class Validator {
 
 		$node = $this->root->getById($file->getNodeId());
 		if (empty($node)) {
+			// TRANSLATORS Error shown when validating DocMDP certification and the document file cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'));
 		}
 
 		$firstNode = current($node);
 		if (!$firstNode instanceof \OCP\Files\File) {
+			// TRANSLATORS Error shown when validating DocMDP certification and the file is not a supported document type.
 			throw new LibresignException($this->l10n->t('Invalid file type'));
 		}
 

--- a/lib/Service/Envelope/EnvelopeService.php
+++ b/lib/Service/Envelope/EnvelopeService.php
@@ -42,12 +42,14 @@ class EnvelopeService {
 	 */
 	public function validateEnvelopeConstraints(int $fileCount): void {
 		if (!$this->isEnabled()) {
+			// TRANSLATORS Error shown when the multi-document envelope feature is disabled by the administrator.
 			throw new LibresignException($this->l10n->t('Envelope feature is disabled'));
 		}
 
 		$maxFiles = $this->getMaxFilesPerEnvelope();
 		if ($fileCount > $maxFiles) {
 			throw new LibresignException(
+				// TRANSLATORS Error shown when adding documents would exceed the configured envelope size limit. %s is the maximum number of files allowed.
 				$this->l10n->t('Maximum number of files per envelope (%s) exceeded', [$maxFiles])
 			);
 		}
@@ -91,10 +93,12 @@ class EnvelopeService {
 		$envelope = $this->fileMapper->getById($envelopeId);
 
 		if (!$envelope->isEnvelope()) {
+			// TRANSLATORS Error shown when the given identifier does not refer to a signature envelope.
 			throw new LibresignException($this->l10n->t('The specified ID is not an envelope'));
 		}
 
 		if ($envelope->getStatus() > FileStatus::DRAFT->value) {
+			// TRANSLATORS Error shown when trying to add documents to an envelope that already started the signing process.
 			throw new LibresignException($this->l10n->t('Cannot add files to an envelope that is already in signing process'));
 		}
 
@@ -102,6 +106,7 @@ class EnvelopeService {
 		$currentCount = $this->fileMapper->countChildrenFiles($envelopeId);
 		if ($currentCount >= $maxFiles) {
 			throw new LibresignException(
+				// TRANSLATORS Error shown when adding documents would exceed the configured envelope size limit. %s is the maximum number of files allowed.
 				$this->l10n->t('Maximum number of files per envelope (%s) exceeded', [$maxFiles])
 			);
 		}

--- a/lib/Service/EnvelopeService.php
+++ b/lib/Service/EnvelopeService.php
@@ -41,12 +41,14 @@ class EnvelopeService {
 	 */
 	public function validateEnvelopeConstraints(int $fileCount): void {
 		if (!$this->isEnabled()) {
+			// TRANSLATORS Error shown when the multi-document envelope feature is disabled by the administrator.
 			throw new LibresignException($this->l10n->t('Envelope feature is disabled'));
 		}
 
 		$maxFiles = $this->getMaxFilesPerEnvelope();
 		if ($fileCount > $maxFiles) {
 			throw new LibresignException(
+				// TRANSLATORS Error shown when adding documents would exceed the configured envelope size limit. %s is the maximum number of files allowed.
 				$this->l10n->t('Maximum number of files per envelope (%s) exceeded', [$maxFiles])
 			);
 		}
@@ -90,10 +92,12 @@ class EnvelopeService {
 		$envelope = $this->fileMapper->getById($envelopeId);
 
 		if (!$envelope->isEnvelope()) {
+			// TRANSLATORS Error shown when the given identifier does not refer to a signature envelope.
 			throw new LibresignException($this->l10n->t('The specified ID is not an envelope'));
 		}
 
 		if ($envelope->getStatus() > FileStatus::DRAFT->value) {
+			// TRANSLATORS Error shown when trying to add documents to an envelope that already started the signing process.
 			throw new LibresignException($this->l10n->t('Cannot add files to an envelope that is already in signing process'));
 		}
 
@@ -101,6 +105,7 @@ class EnvelopeService {
 		$currentCount = $this->fileMapper->countChildrenFiles($envelopeId);
 		if ($currentCount >= $maxFiles) {
 			throw new LibresignException(
+				// TRANSLATORS Error shown when adding documents would exceed the configured envelope size limit. %s is the maximum number of files allowed.
 				$this->l10n->t('Maximum number of files per envelope (%s) exceeded', [$maxFiles])
 			);
 		}

--- a/lib/Service/File/FileContentProvider.php
+++ b/lib/Service/File/FileContentProvider.php
@@ -32,18 +32,21 @@ class FileContentProvider {
 	 */
 	public function getContentFromUrl(string $url): string {
 		if (!filter_var($url, FILTER_VALIDATE_URL)) {
+			// TRANSLATORS Error shown when a document URL provided for signing is invalid.
 			throw new LibresignException($this->l10n->t('Invalid URL file'), 422);
 		}
 
 		try {
 			$response = $this->client->newClient()->get($url);
 		} catch (\Throwable) {
+			// TRANSLATORS Error shown when a document URL provided for signing is invalid.
 			throw new LibresignException($this->l10n->t('Invalid URL file'), 422);
 		}
 
 		$content = (string)$response->getBody();
 
 		if (!$content) {
+			// TRANSLATORS Error shown when the downloaded or provided document content is empty.
 			throw new LibresignException($this->l10n->t('Empty file'), 422);
 		}
 
@@ -57,6 +60,7 @@ class FileContentProvider {
 
 		// application/octet-stream is a generic fallback — trust content detection
 		if ($mimetypeFromHeader !== 'application/octet-stream' && $mimetypeFromHeader !== $mimeTypeFromContent) {
+			// TRANSLATORS Error shown when a document URL provided for signing is invalid.
 			throw new LibresignException($this->l10n->t('Invalid URL file'), 422);
 		}
 
@@ -82,6 +86,7 @@ class FileContentProvider {
 			$mimeTypeFromContent = $this->mimeService->getMimeType($content);
 
 			if ($mimeTypeFromType !== $mimeTypeFromContent) {
+				// TRANSLATORS Error shown when a document URL provided for signing is invalid.
 				throw new LibresignException($this->l10n->t('Invalid URL file'), 422);
 			}
 
@@ -110,6 +115,7 @@ class FileContentProvider {
 			return $this->getContentFromBase64($data['file']['base64']);
 		}
 
+		// TRANSLATORS Error shown when creating a signature request without any document source (upload, path, URL, or file id).
 		throw new LibresignException($this->l10n->t('No file source provided'), 422);
 	}
 
@@ -129,6 +135,7 @@ class FileContentProvider {
 			$fileNode = $this->root->getUserFolder($file->getUserId())->getFirstNodeById($nodeId);
 
 			if (!$fileNode instanceof \OCP\Files\File) {
+				// TRANSLATORS Error shown when the requested document cannot be found.
 				throw new LibresignException($this->l10n->t('File not found'), 404);
 			}
 
@@ -140,6 +147,7 @@ class FileContentProvider {
 				'fileId' => $file->getId(),
 				'exception' => $e,
 			]);
+			// TRANSLATORS Error shown when LibreSign cannot validate the uploaded or referenced document for signing.
 			throw new LibresignException($this->l10n->t('Invalid data to validate file'), 404, $e);
 		}
 	}

--- a/lib/Service/File/FileListService.php
+++ b/lib/Service/File/FileListService.php
@@ -631,6 +631,7 @@ class FileListService {
 
 		/** @var LibresignDetailedFileResponse */
 		$response = [
+			// TRANSLATORS Success message shown after a LibreSign file action completes successfully.
 			'message' => $this->l10n->t('Success'),
 			'id' => $mainEntity->getId(),
 			'nodeId' => $mainEntity->getNodeId(),
@@ -884,6 +885,7 @@ class FileListService {
 					], array_values($identifyMethodsOfSigner)),
 					'signed' => $signer->getSigned()?->format(\DateTimeInterface::ATOM),
 					'status' => $signer->getSigned() ? 1 : 0,
+					// TRANSLATORS Signer status labels on a document list: "Signed" when the person finished signing, "Pending" when their signature is still awaited.
 					'statusText' => $signer->getSigned() ? $this->l10n->t('Signed') : $this->l10n->t('Pending'),
 				];
 			}, $signers);

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -291,10 +291,12 @@ class FileService {
 		try {
 			$file = $resolver();
 		} catch (\Throwable) {
+			// TRANSLATORS Error shown when LibreSign cannot validate the uploaded or referenced document for signing.
 			throw new LibresignException($this->l10n->t('Invalid data to validate file'), 404);
 		}
 
 		if (!$file instanceof File) {
+			// TRANSLATORS Error shown when the document identifier used in a signing flow is invalid.
 			throw new LibresignException($this->l10n->t('Invalid file identifier'), 404);
 		}
 
@@ -323,6 +325,7 @@ class FileService {
 
 	public function setFileFromRequest(?array $file): self {
 		if ($file === null) {
+			// TRANSLATORS Error shown when an action expected an uploaded document and none was provided.
 			throw new InvalidArgumentException($this->l10n->t('No file provided'));
 		}
 		$this->initializeFileData();
@@ -333,6 +336,7 @@ class FileService {
 		if ($mimeType !== 'application/pdf') {
 			$this->fileContent = '';
 			unlink($file['tmp_name']);
+			// TRANSLATORS Error shown when the uploaded document is invalid for LibreSign.
 			throw new InvalidArgumentException($this->l10n->t('Invalid file provided'));
 		}
 		$this->fileData->size = $file['size'];
@@ -364,6 +368,7 @@ class FileService {
 		}
 		$fileToValidate = $this->root->getUserFolder($this->file->getUserId())->getFirstNodeById($nodeId);
 		if (!$fileToValidate instanceof \OCP\Files\File) {
+			// TRANSLATORS Error shown when the requested document cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'), 404);
 		}
 		return $fileToValidate;

--- a/lib/Service/FolderService.php
+++ b/lib/Service/FolderService.php
@@ -186,6 +186,7 @@ class FolderService {
 		if (isset($data['settings']['envelopeFolderId'])) {
 			$envelopeFolder = $userFolder->getFirstNodeById($data['settings']['envelopeFolderId']);
 			if ($envelopeFolder === null || !$envelopeFolder instanceof Folder) {
+				// TRANSLATORS Error shown when the Nextcloud folder that stores envelope documents cannot be found.
 				throw new LibresignException($this->l10n->t('Envelope folder not found'));
 			}
 			return $envelopeFolder;
@@ -246,6 +247,7 @@ class FolderService {
 		try {
 			return $userFolder->get($path);
 		} catch (NotFoundException) {
+			// TRANSLATORS Error shown when LibreSign cannot validate the uploaded or referenced document for signing.
 			throw new LibresignException($this->l10n->t('Invalid data to validate file'), 404);
 		}
 	}
@@ -286,6 +288,7 @@ class FolderService {
 				if ($isLastSegment) {
 					$contents = $folder->getDirectoryListing();
 					if (count($contents) > 0) {
+						// TRANSLATORS Error shown when creating a folder for LibreSign documents and the path already exists with content. %s is the folder path.
 						throw new LibresignException($this->l10n->t('Folder already exists and is not empty: %s', [$path]));
 					}
 				}

--- a/lib/Service/IdDocsPolicyService.php
+++ b/lib/Service/IdDocsPolicyService.php
@@ -102,6 +102,7 @@ class IdDocsPolicyService {
 		$userGroups = $this->groupManager->getUserGroupIds($user);
 		if (!array_intersect($userGroups, $authorized)) {
 			if ($throw) {
+				// TRANSLATORS Permission error shown when the current user is not allowed to approve identity documents uploaded for signing.
 				throw new LibresignException($this->l10n->t('You are not allowed to approve user profile documents.'));
 			}
 			return false;

--- a/lib/Service/IdDocsService.php
+++ b/lib/Service/IdDocsService.php
@@ -48,6 +48,7 @@ class IdDocsService {
 			throw new LibresignException(json_encode([
 				'type' => 'danger',
 				'file' => $fileIndex,
+				// TRANSLATORS Error shown when an uploaded identity document has an unsupported file type.
 				'message' => $this->l10n->t('Invalid file type.')
 			]));
 		}
@@ -59,6 +60,7 @@ class IdDocsService {
 			throw new LibresignException(json_encode([
 				'type' => 'danger',
 				'file' => $fileIndex,
+				// TRANSLATORS Error shown when an uploaded identity document has an unsupported file type.
 				'message' => $this->l10n->t('Invalid file type.')
 			]));
 		}

--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -210,6 +210,7 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 			if (!is_int($fileInfo['nodeId'])) {
 				throw new LibresignException(json_encode([
 					'action' => JSActions::ACTION_DO_NOTHING,
+					// TRANSLATORS Error shown during signer identification when the related document cannot be found.
 					'errors' => [['message' => $this->identifyService->getL10n()->t('File not found')]],
 				]), AppFrameworkHttp::STATUS_NOT_FOUND);
 			}
@@ -224,6 +225,7 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 			} catch (NotFoundException) {
 				throw new LibresignException(json_encode([
 					'action' => JSActions::ACTION_DO_NOTHING,
+					// TRANSLATORS Error shown during signer identification when the related document cannot be found.
 					'errors' => [['message' => $this->identifyService->getL10n()->t('File not found')]],
 				]), AppFrameworkHttp::STATUS_NOT_FOUND);
 			} finally {
@@ -244,6 +246,7 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		if ($expirationDate < $now) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_DO_NOTHING,
+				// TRANSLATORS Error shown when the one-time signing link has expired and can no longer be used.
 				'errors' => [['message' => $this->identifyService->getL10n()->t('Link expired.')]],
 			]));
 		}
@@ -253,11 +256,13 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		$code = $this->getEntity()->getCode();
 		if ($code === null || $code === '') {
 			if ($this->codeSentByUser !== null) {
+				// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
 				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'));
 			}
 			return;
 		}
 		if (empty($this->codeSentByUser) || !$this->identifyService->getHasher()->verify($this->codeSentByUser, $code)) {
+			// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
 			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'));
 		}
 	}
@@ -348,6 +353,7 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_REDIRECT,
+				// TRANSLATORS Error shown when the signer tries to sign a document that is already signed.
 				'errors' => [['message' => $this->identifyService->getL10n()->t('File already signed.')]],
 				'redirect' => $this->identifyService->getUrlGenerator()->linkToRoute(
 					'libresign.page.validationFilePublic',

--- a/lib/Service/IdentifyMethod/Account.php
+++ b/lib/Service/IdentifyMethod/Account.php
@@ -73,6 +73,7 @@ class Account extends AbstractIdentifyMethod {
 		$email = $signer->getEMailAddress();
 		if (empty($email) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
 			throw new LibresignException(
+				// TRANSLATORS Error shown when a signer identified by Nextcloud account has no valid email address for notifications.
 				$this->identifyService->getL10n()->t('Signer without valid email address')
 			);
 		}
@@ -113,6 +114,7 @@ class Account extends AbstractIdentifyMethod {
 			if (empty($signer) || count($signer) > 1) {
 				throw new LibresignException(json_encode([
 					'action' => JSActions::ACTION_DO_NOTHING,
+					// TRANSLATORS Error shown when the Nextcloud account used to identify the signer is invalid.
 					'errors' => [['message' => $this->identifyService->getL10n()->t('Invalid user')]],
 				]));
 			}
@@ -125,6 +127,7 @@ class Account extends AbstractIdentifyMethod {
 		if ($this->userSession->getUser() !== $signer) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_DO_NOTHING,
+				// TRANSLATORS Error shown when the Nextcloud account used to identify the signer is invalid.
 				'errors' => [['message' => $this->identifyService->getL10n()->t('Invalid user')]],
 			]));
 		}
@@ -135,6 +138,7 @@ class Account extends AbstractIdentifyMethod {
 			$signRequest = $this->identifyService->getSignRequestMapper()->getById($this->getEntity()->getSignRequestId());
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_REDIRECT,
+				// TRANSLATORS Error shown when signing requires a logged-in Nextcloud account and the visitor is anonymous.
 				'errors' => [$this->identifyService->getL10n()->t('You are not logged in. Please log in.')],
 				'redirect' => $this->urlGenerator->linkToRoute('core.login.showLoginForm', [
 					'redirect_url' => $this->urlGenerator->linkToRoute(

--- a/lib/Service/IdentifyMethod/Email.php
+++ b/lib/Service/IdentifyMethod/Email.php
@@ -103,12 +103,15 @@ class Email extends AbstractIdentifyMethod {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_CREATE_ACCOUNT,
 				'settings' => ['accountHash' => md5($email)],
+				// TRANSLATORS Message inviting a guest signer identified by email to create a Nextcloud account before signing.
 				'message' => $this->identifyService->getL10n()->t('You need to create an account to sign this file.'),
 			]));
 		}
 		$signRequest = $this->identifyService->getSignRequestMapper()->getById($this->getEntity()->getSignRequestId());
+		// TRANSLATORS Error shown when the email already belongs to an existing account and the guest must log in to sign.
 		$errors = [$this->identifyService->getL10n()->t('User already exists. Please login.')];
 		if ($this->userSession->isLoggedIn()) {
+			// TRANSLATORS Error shown when the logged-in user tries to sign a document that was not requested for them.
 			$errors[] = $this->identifyService->getL10n()->t('This is not your file');
 			$this->userSession->logout();
 		}
@@ -170,8 +173,10 @@ class Email extends AbstractIdentifyMethod {
 			}
 		}
 		$signRequest = $this->identifyService->getSignRequestMapper()->getById($this->getEntity()->getSignRequestId());
+		// TRANSLATORS Error shown when the email already belongs to an existing account and the guest must log in to sign.
 		$errors = [$this->identifyService->getL10n()->t('User already exists. Please login.')];
 		if ($this->userSession->isLoggedIn()) {
+			// TRANSLATORS Error shown when the logged-in user tries to sign a document that was not requested for them.
 			$errors[] = $this->identifyService->getL10n()->t('This is not your file');
 			$this->userSession->logout();
 		}
@@ -192,9 +197,11 @@ class Email extends AbstractIdentifyMethod {
 		$this->throwIfInvalidEmail();
 		$this->throwIfNotAllowedToCreateAccount();
 		if ($this->identifyService->getUserManager()->userExists($value)) {
+			// TRANSLATORS Error shown when creating a guest account for signing and that email is already registered.
 			throw new LibresignException($this->identifyService->getL10n()->t('User already exists'));
 		}
 		if ($this->getEntity()->getIdentifierValue() !== $value) {
+			// TRANSLATORS Error shown when the logged-in user tries to sign a document that was not requested for them.
 			throw new LibresignException($this->identifyService->getL10n()->t('This is not your file'));
 		}
 	}
@@ -204,6 +211,7 @@ class Email extends AbstractIdentifyMethod {
 		if (!$settings['can_create_account']) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_SHOW_ERROR,
+				// TRANSLATORS Error shown when guest account creation is disabled and the signer cannot register to sign.
 				'errors' => [['message' => $this->identifyService->getL10n()->t('It is not possible to create new accounts.')]],
 			]));
 		}
@@ -211,6 +219,7 @@ class Email extends AbstractIdentifyMethod {
 
 	private function throwIfInvalidEmail(): void {
 		if (!filter_var($this->entity->getIdentifierValue(), FILTER_VALIDATE_EMAIL)) {
+			// TRANSLATORS Error shown when the email address used to identify the signer is invalid.
 			throw new LibresignException($this->identifyService->getL10n()->t('Invalid email'));
 		}
 	}

--- a/lib/Service/IdentifyMethod/SignatureMethod/Password.php
+++ b/lib/Service/IdentifyMethod/SignatureMethod/Password.php
@@ -37,6 +37,7 @@ class Password extends AbstractSignatureMethod {
 				->setPassword($this->codeSentByUser)
 				->readCertificate();
 		} catch (InvalidPasswordException) {
+			// TRANSLATORS Error shown when the password used to unlock the signing certificate is incorrect.
 			throw new LibresignException($this->identifyService->getL10n()->t('Invalid user or password'));
 		}
 
@@ -53,6 +54,7 @@ class Password extends AbstractSignatureMethod {
 			return;
 		}
 		if ($status === CrlValidationStatus::REVOKED) {
+			// TRANSLATORS Error shown when signing is blocked because the signer certificate was revoked.
 			throw new LibresignException($this->identifyService->getL10n()->t('Certificate has been revoked'), 422);
 		}
 		// Admin explicitly disabled external CRL validation – allow signing.
@@ -90,10 +92,12 @@ class Password extends AbstractSignatureMethod {
 		if (array_key_exists('validTo_time_t', $certificateData)) {
 			$validTo = $certificateData['validTo_time_t'];
 			if (!is_int($validTo)) {
+				// TRANSLATORS Error shown when the signing certificate data is invalid.
 				throw new LibresignException($this->identifyService->getL10n()->t('Invalid certificate'), 422);
 			}
 			$now = (new \DateTime())->getTimestamp();
 			if ($validTo <= $now) {
+				// TRANSLATORS Error shown when signing is blocked because the signer certificate has expired.
 				throw new LibresignException($this->identifyService->getL10n()->t('Certificate has expired'), 422);
 			}
 		}
@@ -104,6 +108,7 @@ class Password extends AbstractSignatureMethod {
 		$this->pkcs12Handler->setPassword($this->codeSentByUser);
 		$pfx = $this->pkcs12Handler->getPfxOfCurrentSigner($this->userSession->getUser()?->getUID());
 		if (empty($pfx)) {
+			// TRANSLATORS Error shown when the signing certificate file for the current user is missing or invalid.
 			throw new LibresignException($this->identifyService->getL10n()->t('Invalid certificate'));
 		}
 	}

--- a/lib/Service/IdentifyMethod/SignatureMethod/TokenService.php
+++ b/lib/Service/IdentifyMethod/SignatureMethod/TokenService.php
@@ -30,6 +30,7 @@ class TokenService {
 	public function sendCodeByGateway(string $identifier, string $gatewayName): string {
 		$this->twofactorGatewayService->ensureAvailable($gatewayName);
 		if (!$this->twofactorGatewayService->isGatewayComplete($gatewayName)) {
+			// TRANSLATORS Error shown to the administrator when a two-factor gateway needed to send signing codes is not configured. %s is the gateway name.
 			throw new OCSForbiddenException($this->l10n->t('Gateway %s not configured on Two-Factor Gateway.', $gatewayName));
 		}
 
@@ -37,6 +38,7 @@ class TokenService {
 		$this->twofactorGatewayService->send(
 			$gatewayName,
 			$identifier,
+			// TRANSLATORS Text of the verification code message sent to the signer. %s is the one-time code.
 			$this->l10n->t('%s is your LibreSign verification code.', $code)
 		);
 		return $this->hasher->hash($code);

--- a/lib/Service/IdentifyMethodService.php
+++ b/lib/Service/IdentifyMethodService.php
@@ -302,6 +302,7 @@ class IdentifyMethodService {
 			return $firstMethod;
 		}
 
+		// TRANSLATORS Error shown when the chosen method to identify the signer (account, email, SMS, etc.) is invalid.
 		throw new LibresignException($this->l10n->t('Invalid identification method'), 1);
 	}
 

--- a/lib/Service/NotifyService.php
+++ b/lib/Service/NotifyService.php
@@ -111,8 +111,11 @@ class NotifyService {
 		$error = $this->signerNotificationPolicy->getValidationError($signer, $signRequestIndex);
 		if ($error !== null) {
 			$message = match ($error['code']) {
+				// TRANSLATORS Error shown when notifying a person who was never asked to sign. %s is the signer identifier.
 				'not_requested' => $this->l10n->t('No signature was requested to %s', $error['params']),
+				// TRANSLATORS Error shown when notifying a signer who already completed their signature. %s is the signer name.
 				'already_signed' => $this->l10n->t('%s already signed this file', $error['params']),
+				// TRANSLATORS Error shown when the signer data used for a notification is invalid.
 				default => $this->l10n->t('Invalid signer data'),
 			};
 			throw new \OCA\Libresign\Exception\LibresignException($message);

--- a/lib/Service/Policy/AbstractFilePolicyApplier.php
+++ b/lib/Service/Policy/AbstractFilePolicyApplier.php
@@ -69,6 +69,7 @@ abstract class AbstractFilePolicyApplier implements IFilePolicyApplier {
 
 		$blockedBy = $resolvedPolicy->getBlockedBy() ?? $resolvedPolicy->getSourceScope();
 		$translatedMessage = $this->l10n instanceof IL10N
+			// TRANSLATORS Error shown when a signature-request setting is blocked by a higher-level LibreSign policy. The placeholder receives the scope that blocked the override.
 			? $this->l10n->t($message, [$blockedBy])
 			: vsprintf($message, [$blockedBy]);
 

--- a/lib/Service/Policy/PolicyService.php
+++ b/lib/Service/Policy/PolicyService.php
@@ -333,6 +333,7 @@ class PolicyService {
 			return;
 		}
 
+		// TRANSLATORS Permission error shown when a non-admin tries to delete a group policy rule created by a system administrator.
 		throw new \DomainException($this->l10n->t('Only system administrators can delete group rules created by a system administrator'));
 	}
 
@@ -360,6 +361,7 @@ class PolicyService {
 			return;
 		}
 
+		// TRANSLATORS Permission error shown when a non-admin tries to edit a group access rule created by a system administrator.
 		throw new \DomainException($this->l10n->t('Only system administrators can edit group access rules created by a system administrator'));
 	}
 
@@ -383,6 +385,7 @@ class PolicyService {
 
 		$definition = $this->registry->get($policyKey);
 		if (!$this->canCurrentActorManageGroupPolicy($definition, $context)) {
+			// TRANSLATORS Permission error shown when managing group policies without an explicit delegation from a system administrator.
 			throw new \DomainException($this->l10n->t('Group policy management requires explicit delegation from the system administrator'));
 		}
 	}
@@ -407,6 +410,7 @@ class PolicyService {
 			default => ucfirst($scope),
 		};
 
+		// TRANSLATORS Error shown when saving a LibreSign policy with an unsupported scope. %s is the scope label such as user or group.
 		throw new \InvalidArgumentException($this->l10n->t('%s-level scope is not supported for this policy', [$scopeLabel]));
 	}
 
@@ -418,6 +422,7 @@ class PolicyService {
 		$definition->validateValue($normalizedValue, $context);
 		$resolved = $this->resolver->resolve($definition, $context);
 		if (!$resolved->canSaveAsUserDefault()) {
+			// TRANSLATORS Error shown when saving a user preference for a policy that does not allow personal overrides. {policyKey} is the policy identifier.
 			throw new \InvalidArgumentException($this->l10n->t('Saving a user preference is not allowed for {policyKey}', [
 				'policyKey' => $definition->key(),
 			]));

--- a/lib/Service/Policy/Provider/RequestSignGroups/RequestSignGroupsPolicyGuard.php
+++ b/lib/Service/Policy/Provider/RequestSignGroups/RequestSignGroupsPolicyGuard.php
@@ -31,6 +31,7 @@ final class RequestSignGroupsPolicyGuard {
 			return;
 		}
 
+		// TRANSLATORS Error shown when trying to save the request-sign-groups policy at user scope, which is not supported.
 		throw new \InvalidArgumentException($this->l10n->t('User-level scope is not supported for this policy'));
 	}
 
@@ -45,6 +46,7 @@ final class RequestSignGroupsPolicyGuard {
 
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
+			// TRANSLATORS Permission error shown when the current user is not allowed to manage the request-sign-groups policy.
 			throw new \InvalidArgumentException($this->l10n->t('Not allowed to manage this policy'));
 		}
 
@@ -53,6 +55,7 @@ final class RequestSignGroupsPolicyGuard {
 		$denyGroupIds = $decodedPolicy['denyGroups'];
 
 		if ($allowGroupIds === []) {
+			// TRANSLATORS Validation error shown when saving the request-sign-groups policy without any authorized group.
 			throw new \InvalidArgumentException($this->l10n->t('At least one authorized group is required'));
 		}
 
@@ -61,6 +64,7 @@ final class RequestSignGroupsPolicyGuard {
 			&& is_string($requiredGroupId)
 			&& trim($requiredGroupId) !== ''
 			&& !in_array($requiredGroupId, $allowGroupIds, true)) {
+			// TRANSLATORS Validation error shown when a group administrator tries to remove their own managed group from the request-sign-groups rule.
 			throw new \InvalidArgumentException($this->l10n->t('You cannot remove your managed group from this rule'));
 		}
 
@@ -68,6 +72,7 @@ final class RequestSignGroupsPolicyGuard {
 		$groupsToValidate = array_values(array_unique(array_merge($allowGroupIds, $denyGroupIds)));
 		$unknownGroupIds = array_values(array_diff($groupsToValidate, $allowedGroupIds));
 		if ($unknownGroupIds !== []) {
+			// TRANSLATORS Permission error shown when selected groups are outside the current administrator scope for the request-sign-groups policy.
 			throw new \InvalidArgumentException($this->l10n->t('One or more selected groups are not allowed for your administration scope'));
 		}
 

--- a/lib/Service/Policy/Runtime/PolicySource.php
+++ b/lib/Service/Policy/Runtime/PolicySource.php
@@ -1067,6 +1067,7 @@ class PolicySource implements IPolicySource {
 	public function saveUserPreference(string $policyKey, PolicyContext $context, mixed $value): void {
 		$userId = $context->getUserId();
 		if ($userId === null || $userId === '') {
+			// TRANSLATORS Error shown when saving a LibreSign policy preference without a signed-in user.
 			throw new \InvalidArgumentException($this->l10n->t('A signed-in user is required to save a policy preference.'));
 		}
 
@@ -1079,6 +1080,7 @@ class PolicySource implements IPolicySource {
 	public function saveUserPolicy(string $policyKey, PolicyContext $context, mixed $value, bool $allowChildOverride): void {
 		$userId = $context->getUserId();
 		if ($userId === null || $userId === '') {
+			// TRANSLATORS Error shown when saving a user-scoped LibreSign policy without a target user.
 			throw new \InvalidArgumentException($this->l10n->t('A target user is required to save a user policy.'));
 		}
 

--- a/lib/Service/RequestSignatureService.php
+++ b/lib/Service/RequestSignatureService.php
@@ -165,6 +165,7 @@ class RequestSignatureService {
 	public function saveEnvelope(array $data): array {
 		$this->envelopeService->validateEnvelopeConstraints(count($data['files']));
 
+		// TRANSLATORS Default name for a new multi-document envelope when the requester did not provide one. %s is the creation date and time.
 		$envelopeName = $data['name'] ?: $this->l10n->t('Envelope %s', [date('Y-m-d H:i:s')]);
 		$userManager = $data['userManager'] ?? null;
 		$userId = $userManager instanceof IUser ? $userManager->getUID() : null;
@@ -248,6 +249,7 @@ class RequestSignatureService {
 	private function requireFileName(array $fileData): string {
 		$name = trim((string)($fileData['name'] ?? ''));
 		if ($name === '') {
+			// TRANSLATORS Error shown when creating a signature request without a document file name.
 			throw new LibresignException($this->l10n->t('File name is required'));
 		}
 		return $name;
@@ -543,6 +545,7 @@ class RequestSignatureService {
 
 	public function validateNewFile(array $data): void {
 		if (empty($data['name'])) {
+			// TRANSLATORS Error shown when creating a signature request without a document file name.
 			throw new \Exception($this->l10n->t('File name is required'));
 		}
 		$this->validateHelper->validateNewFile($data);
@@ -553,10 +556,12 @@ class RequestSignatureService {
 			if (($data['status'] ?? FileStatus::ABLE_TO_SIGN->value) === FileStatus::DRAFT->value) {
 				return;
 			}
+			// TRANSLATORS Error shown when creating a signature request without any signers.
 			throw new \Exception($this->l10n->t('Empty signers list'));
 		}
 		if (!is_array($data['signers'])) {
 			// TRANSLATION This message will be displayed when the request to API with the key signers has a value that is not an array
+			// TRANSLATORS Error shown when the signers list in a signature request is not provided as a list.
 			throw new \Exception($this->l10n->t('Signers list needs to be an array'));
 		}
 
@@ -664,6 +669,7 @@ class RequestSignatureService {
 			$fileData = $this->fileMapper->getById($data['file']['fileId']);
 			$signatures = $this->signRequestMapper->getByFileId($fileData->getId());
 		} else {
+			// TRANSLATORS Error shown when a signature-request action is missing both the document identifier and the file object.
 			throw new \Exception($this->l10n->t('Please provide either UUID or File object'));
 		}
 		foreach ($signatures as $signRequest) {

--- a/lib/Service/RequestSignatureWorkflowService.php
+++ b/lib/Service/RequestSignatureWorkflowService.php
@@ -58,6 +58,7 @@ final class RequestSignatureWorkflowService {
 		?array $visibleElements = null,
 	): array {
 		if ($file === [] && $files === []) {
+			// TRANSLATORS Error shown when starting a signature request without providing any documents.
 			throw new LibresignException($this->l10n->t('File or files parameter is required'));
 		}
 

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -140,10 +140,12 @@ class SignFileService {
 		} elseif (!empty($data['file']['nodeId'])) {
 			$signatures = $this->signRequestMapper->getByNodeId($data['file']['nodeId']);
 		} else {
+			// TRANSLATORS Error shown when a signing action is missing both the document identifier and the file object.
 			throw new \Exception($this->l10n->t('Please provide either UUID or File object'));
 		}
 		$signed = array_filter($signatures, fn ($s) => $s->getSigned());
 		if ($signed) {
+			// TRANSLATORS Error shown when trying to sign a document that is already fully signed.
 			throw new \Exception($this->l10n->t('Document already signed'));
 		}
 		array_walk($data['signers'], function ($signer) use ($signatures): void {
@@ -155,6 +157,7 @@ class SignFileService {
 				return false;
 			});
 			if (!$exists) {
+				// TRANSLATORS Error shown when notifying or signing for a person who was never asked to sign. %s is their email.
 				throw new \Exception($this->l10n->t('No signature was requested to %s', $signer['email']));
 			}
 		});
@@ -278,6 +281,7 @@ class SignFileService {
 		}
 
 		if ($fileId === null || $signRequestId === null) {
+			// TRANSLATORS Error shown when the document to sign cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'));
 		}
 
@@ -333,6 +337,7 @@ class SignFileService {
 			return true;
 		}
 		$this->logger->error('Invalid data provided for signing file.', ['element' => $element]);
+		// TRANSLATORS Error shown when the data required to apply a digital signature is missing or invalid.
 		throw new LibresignException($this->l10n->t('Invalid data to sign file'), 1);
 	}
 
@@ -346,6 +351,7 @@ class SignFileService {
 				'type' => $fileElement->getType(),
 			]);
 		} catch (MultipleObjectsReturnedException|DoesNotExistException|Exception) {
+			// TRANSLATORS Error shown when signing requires a visible signature or initials image and the signer has not defined one yet.
 			throw new LibresignException($this->l10n->t('You need to define a visible signature or initials to sign this document.'));
 		}
 		return $userElement->getNodeId();
@@ -358,6 +364,7 @@ class SignFileService {
 				throw new \Exception('Node content is empty or unavailable.');
 			}
 		} catch (\Throwable) {
+			// TRANSLATORS Error shown when signing requires a visible signature or initials image and the signer has not defined one yet.
 			throw new LibresignException($this->l10n->t('You need to define a visible signature or initials to sign this document.'));
 		}
 
@@ -365,6 +372,7 @@ class SignFileService {
 		$content = $node->getContent();
 		if (empty($content)) {
 			$this->logger->error('Failed to retrieve content for node.', ['nodeId' => $nodeId, 'fileElement' => $fileElement]);
+			// TRANSLATORS Error shown when signing requires a visible signature or initials image and the signer has not defined one yet.
 			throw new LibresignException($this->l10n->t('You need to define a visible signature or initials to sign this document.'));
 		}
 		file_put_contents($tempFile, $content);
@@ -826,6 +834,7 @@ class SignFileService {
 		try {
 			if (!$this->docMdpHandler->allowsAdditionalSignatures($resource)) {
 				throw new LibresignException(
+					// TRANSLATORS Error shown when trying to add more signers to a document certified with DocMDP level that forbids further changes.
 					$this->l10n->t('This document has been certified with no changes allowed. You cannot add more signers to this document.'),
 					AppFrameworkHttp::STATUS_UNPROCESSABLE_ENTITY
 				);
@@ -1171,6 +1180,7 @@ class SignFileService {
 		$nodeId = $this->libreSignFile->getNodeId();
 
 		if ($userId === null) {
+			// TRANSLATORS Error shown when the data required to apply a digital signature is missing or invalid.
 			throw new LibresignException($this->l10n->t('Invalid data to sign file'), 1);
 		}
 
@@ -1236,6 +1246,7 @@ class SignFileService {
 
 			throw new \Exception('Invalid arguments');
 		} catch (DoesNotExistException) {
+			// TRANSLATORS Error shown when the document to sign cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'), 1);
 		}
 	}
@@ -1243,6 +1254,7 @@ class SignFileService {
 	public function renew(SignRequestEntity $signRequest, string $method): void {
 		$identifyMethods = $this->identifyMethodService->getIdentifyMethodsFromSignRequestId($signRequest->getId());
 		if (empty($identifyMethods[$method])) {
+			// TRANSLATORS Error shown when the chosen method to identify the signer (account, email, SMS, etc.) is invalid.
 			throw new LibresignException($this->l10n->t('Invalid identification method'));
 		}
 
@@ -1265,6 +1277,7 @@ class SignFileService {
 	): void {
 		$identifyMethods = $this->identifyMethodService->getIdentifyMethodsFromSignRequestId($signRequest->getId());
 		if (empty($identifyMethods[$identifyMethodName])) {
+			// TRANSLATORS Error shown when the chosen method to identify the signer (account, email, SMS, etc.) is invalid.
 			throw new LibresignException($this->l10n->t('Invalid identification method'));
 		}
 		foreach ($identifyMethods[$identifyMethodName] as $identifyMethod) {
@@ -1279,6 +1292,7 @@ class SignFileService {
 			$signatureMethod->requestCode($identifier, $identifyMethod->getEntity()->getIdentifierKey());
 			return;
 		}
+		// TRANSLATORS Error shown when sending a signing verification code is disabled by configuration.
 		throw new LibresignException($this->l10n->t('Sending authorization code not enabled.'));
 	}
 
@@ -1383,14 +1397,17 @@ class SignFileService {
 			) {
 				throw new LibresignException(json_encode([
 					'action' => JSActions::ACTION_DO_NOTHING,
+					// TRANSLATORS Error shown when the signer tries to sign before they are allowed to (for example, earlier steps are incomplete).
 					'errors' => [['message' => $this->l10n->t('You are not allowed to sign this document yet')]],
 				]));
 			}
 			if ($signRequest->getSigned()) {
+				// TRANSLATORS Error shown when the current user already signed this document.
 				throw new LibresignException($this->l10n->t('File already signed by you'), 1);
 			}
 			return $signRequest;
 		} catch (DoesNotExistException) {
+			// TRANSLATORS Error shown when the data required to apply a digital signature is missing or invalid.
 			throw new LibresignException($this->l10n->t('Invalid data to sign file'), 1);
 		}
 	}
@@ -1486,9 +1503,11 @@ class SignFileService {
 			$userFolder = $this->root->getUserFolder($uid);
 		} catch (NoUserException $e) {
 			$this->logger->error('[file-access] NoUserException for uid={uid}', ['uid' => $uid]);
+			// TRANSLATORS Error shown when the Nextcloud user linked to the signer cannot be found.
 			throw new LibresignException($this->l10n->t('User not found.'));
 		} catch (NotPermittedException $e) {
 			$this->logger->error('[file-access] NotPermittedException for uid={uid}', ['uid' => $uid]);
+			// TRANSLATORS Permission error shown when the current user cannot perform the requested signing action.
 			throw new LibresignException($this->l10n->t('You do not have permission for this action.'));
 		}
 
@@ -1507,6 +1526,7 @@ class SignFileService {
 				'nodeId' => $nodeId,
 				'type' => $fileToSign ? $fileToSign::class : 'NULL',
 			]);
+			// TRANSLATORS Error shown when the document to sign cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'));
 		}
 		return $fileToSign;
@@ -1555,6 +1575,7 @@ class SignFileService {
 	private function createSignedFile(File $originalFile, string $content): File {
 		$filename = preg_replace(
 			'/' . $originalFile->getExtension() . '$/',
+			// TRANSLATORS Filename suffix used when saving the signed document copy. Appears before the original file extension.
 			$this->l10n->t('signed') . '.' . $originalFile->getExtension(),
 			basename($originalFile->getPath())
 		);
@@ -1576,6 +1597,7 @@ class SignFileService {
 
 			return $this->createdSignedFile;
 		} catch (NotPermittedException) {
+			// TRANSLATORS Permission error shown when the current user cannot perform the requested signing action.
 			throw new LibresignException($this->l10n->t('You do not have permission for this action.'));
 		} catch (\Exception $e) {
 			throw $e;
@@ -1620,6 +1642,7 @@ class SignFileService {
 				if ($nodeId === null) {
 					throw new LibresignException(json_encode([
 						'action' => JSActions::ACTION_DO_NOTHING,
+						// TRANSLATORS Error shown when the document to sign cannot be found.
 						'errors' => [['message' => $this->l10n->t('File not found')]],
 					]), AppFrameworkHttp::STATUS_NOT_FOUND);
 				}
@@ -1635,6 +1658,7 @@ class SignFileService {
 		if ($nodeId === null) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_DO_NOTHING,
+				// TRANSLATORS Error shown when the document to sign cannot be found.
 				'errors' => [['message' => $this->l10n->t('File not found')]],
 			]), AppFrameworkHttp::STATUS_NOT_FOUND);
 		}
@@ -1644,6 +1668,7 @@ class SignFileService {
 		if (!$fileToSign instanceof File) {
 			throw new LibresignException(json_encode([
 				'action' => JSActions::ACTION_DO_NOTHING,
+				// TRANSLATORS Error shown when the document to sign cannot be found.
 				'errors' => [['message' => $this->l10n->t('File not found')]],
 			]), AppFrameworkHttp::STATUS_NOT_FOUND);
 		}

--- a/lib/Service/SignRequest/SignRequestService.php
+++ b/lib/Service/SignRequest/SignRequestService.php
@@ -53,6 +53,7 @@ class SignRequestService {
 	): SignRequestEntity {
 		$identifyMethodsInstances = $this->identifyMethodService->getByUserData($identifyMethods);
 		if (empty($identifyMethodsInstances)) {
+			// TRANSLATORS Error shown when the chosen method to identify the signer (account, email, SMS, etc.) is invalid.
 			throw new \Exception($this->l10n->t('Invalid identification method'));
 		}
 

--- a/lib/SetupCheck/CertificateEngineSetupCheck.php
+++ b/lib/SetupCheck/CertificateEngineSetupCheck.php
@@ -29,6 +29,7 @@ class CertificateEngineSetupCheck implements ISetupCheck {
 
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Name of the Nextcloud administration overview check for the LibreSign certificate engine used to issue signing certificates.
 		return $this->l10n->t('Certificate engine');
 	}
 
@@ -45,7 +46,9 @@ class CertificateEngineSetupCheck implements ISetupCheck {
 		} catch (LibresignException $e) {
 			$engineName = $this->certificateEngineFactory->getEngine()->getName() ?? 'unknown';
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when LibreSign has no certificate engine configured.
 				$this->l10n->t('Define the certificate engine to use'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the administrator to configure the certificate engine with occ. %s is the engine name.
 				$this->l10n->t('Run occ libresign:configure:%s --help', [$engineName])
 			);
 		}
@@ -87,6 +90,7 @@ class CertificateEngineSetupCheck implements ISetupCheck {
 		} elseif ($hasWarning) {
 			return SetupResult::warning(implode("\n", $messages), $tip);
 		} else {
+			// TRANSLATORS Success message in Nextcloud administration overview when the LibreSign certificate engine is configured correctly.
 			return SetupResult::success(implode("\n", $messages) ?: $this->l10n->t('Certificate engine is configured correctly'));
 		}
 	}

--- a/lib/SetupCheck/ImagickSetupCheck.php
+++ b/lib/SetupCheck/ImagickSetupCheck.php
@@ -21,6 +21,7 @@ class ImagickSetupCheck implements ISetupCheck {
 
 	#[\Override]
 	public function getName(): string {
+		// TRANSLATORS Name of the Nextcloud administration overview check for the Imagick library used to render visible signatures.
 		return $this->l10n->t('Imagick PHP extension');
 	}
 
@@ -33,10 +34,13 @@ class ImagickSetupCheck implements ISetupCheck {
 	public function run(): SetupResult {
 		if (!extension_loaded('imagick')) {
 			return SetupResult::info(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when the Imagick library is not available.
 				$this->l10n->t('Imagick extension is not loaded'),
+				// TRANSLATORS Tip under a Nextcloud administration overview warning. Explains installing Imagick to enable visible signatures and related image rendering.
 				$this->l10n->t('Install php-imagick to enable visible signatures, background images, and signature element rendering.')
 			);
 		}
+		// TRANSLATORS Success message in Nextcloud administration overview when the Imagick library is available.
 		return SetupResult::success($this->l10n->t('Imagick extension is loaded'));
 	}
 }

--- a/lib/SetupCheck/JSignPdfSetupCheck.php
+++ b/lib/SetupCheck/JSignPdfSetupCheck.php
@@ -75,6 +75,7 @@ class JSignPdfSetupCheck implements ISetupCheck {
 
 		if (!$jsignpdfJarPath) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when the optional JSignPdf signing backend is not found.
 				$this->l10n->t('JSignPdf not found'),
 				// TRANSLATORS Command to run into terminal using Nextcloud occ to configure LibreSign using CLI when the sysadmin want to do this by CLI.
 				$this->l10n->t('Run %s', ['occ libresign:install --jsignpdf'])

--- a/lib/SetupCheck/JavaSetupCheck.php
+++ b/lib/SetupCheck/JavaSetupCheck.php
@@ -66,7 +66,9 @@ class JavaSetupCheck implements ISetupCheck {
 
 		if (!$javaPath) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when Java required by LibreSign is not installed.
 				$this->l10n->t('Java not installed'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the administrator to install Java for LibreSign via occ.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -79,7 +81,9 @@ class JavaSetupCheck implements ISetupCheck {
 
 		if (!file_exists($javaPath)) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when the configured Java path does not exist. %s is the path.
 				$this->l10n->t('Java binary not found: %s', [$javaPath]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the administrator to install Java for LibreSign via occ.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -88,13 +92,16 @@ class JavaSetupCheck implements ISetupCheck {
 		exec($javaPath . ' -version 2>&1', $output, $returnCode);
 		if (empty($output)) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when Java cannot be executed, often because the operating system blocks it.
 				$this->l10n->t('Failed to execute Java. Sounds that your operational system is blocking the JVM.'),
 				'https://github.com/LibreSign/libresign/issues/2327#issuecomment-1961988790'
 			);
 		}
 		if ($returnCode !== 0) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when LibreSign cannot read the installed Java version.
 				$this->l10n->t('Failure to check Java version.'),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the administrator to install Java for LibreSign via occ.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -102,7 +109,9 @@ class JavaSetupCheck implements ISetupCheck {
 		$javaVersion = trim($output[0] ?? '');
 		if ($javaVersion !== InstallService::JAVA_VERSION) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when the installed Java version does not match the required one. First %s is found; second %s is expected.
 				$this->l10n->t('Invalid java version. Found: %s expected: %s', [$javaVersion, InstallService::JAVA_VERSION]),
+				// TRANSLATORS Tip under a Nextcloud administration overview error. Instructs the administrator to install Java for LibreSign via occ.
 				$this->l10n->t('Run occ libresign:install --java')
 			);
 		}
@@ -114,6 +123,7 @@ class JavaSetupCheck implements ISetupCheck {
 
 		if (!$encoding) {
 			return SetupResult::error(
+				// TRANSLATORS Warning shown in Nextcloud administration overview when LibreSign cannot detect the Java character encoding.
 				$this->l10n->t('Java encoding not found.'),
 				sprintf('The command %s need to have native.encoding', $javaPath . ' -XshowSettings:properties -version')
 			);
@@ -142,12 +152,15 @@ class JavaSetupCheck implements ISetupCheck {
 				$phpLang
 			);
 			return SetupResult::info(
+				// TRANSLATORS Info shown in Nextcloud administration overview when Java is not using UTF-8, which can break accented characters. %s is the detected encoding.
 				$this->l10n->t('Non-UTF-8 encoding detected: %s. This may cause issues with accented or special characters', [$detectedEncoding]),
 				$tip
 			);
 		}
 
+		// TRANSLATORS Success detail in Nextcloud administration overview showing the detected Java version. %s is the version string.
 		$message = $this->l10n->t('Java version: %s', [$javaVersion]) . "\n"
+		  // TRANSLATORS Success detail in Nextcloud administration overview showing the Java executable path. %s is the filesystem path.
 		  . $this->l10n->t('Java binary: %s', [$javaPath]);
 		return SetupResult::success($message);
 	}

--- a/lib/SetupCheck/PDFtkSetupCheck.php
+++ b/lib/SetupCheck/PDFtkSetupCheck.php
@@ -135,7 +135,9 @@ class PDFtkSetupCheck implements ISetupCheck {
 		}
 
 		$messages = [
+			// TRANSLATORS Success detail in Nextcloud administration overview showing the detected PDFtk version. %s is the version string.
 			$this->l10n->t('PDFtk version: %s', [$version]),
+			// TRANSLATORS Success detail in Nextcloud administration overview showing the PDFtk path. %s is the filesystem path.
 			$this->l10n->t('PDFtk path: %s', [$pdftkPath]),
 		];
 		return SetupResult::success(implode("\n", $messages));


### PR DESCRIPTION
Resolves: #973

## 📝 Summary

Adds 143 `TRANSLATORS` comments above PHP `->t()` calls in LibreSign services and setup checks (`lib/Service/**`, `lib/SetupCheck/**`) so Transifex translators get context about where the text appears, who sees it, and what happens in the signing workflow.

This continues #973 after [#8043](https://github.com/LibreSign/libresign/pull/8043). Hints follow the review guidance from that PR: avoid technical terms such as `API`, `UI`, `PHP`, or `SSE` when they do not help translators.

`SignatureTextTemplate.php` already had multi-line `TRANSLATORS` blocks and was left unchanged. Together with #8043, this covers the remaining outstanding PHP translation hints in `lib/`.

## 🧪 How to test

1. Review the new `// TRANSLATORS ...` comments in the changed PHP files.
2. Confirm each hint sits directly above the related `->t()` call.
3. Confirm hints explain LibreSign context and do not only restate the English string.
4. Confirm hints avoid unnecessary technical jargon (`API`, `UI`, `PHP`, `SSE`), consistent with the #8043 review.
5. Optionally run:
   ```bash
   grep -Rn -e "->t(" lib/ | wc -l
   ```
   and spot-check that previously missing strings in this batch now have hints.

## ⚙️ API / Back‑end changes

- [x] Added translator hints only; no runtime API or behavior changes
- [ ] Unit and/or integration tests added – *required for backend changes*
- [ ] Capabilities updated (if applicable) – if adding/modifying Nextcloud capabilities
- [ ] Documentation updated (if applicable) - [docs repository](https://github.com/LibreSign/documentation)
- [ ] API documentation updated with the command `composer openapi` if necessary

### 🚧 Tasks

- [ ] Rebase onto current `main` if needed (depends on [#8043](https://github.com/LibreSign/libresign/pull/8043) already merged)

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Hints follow `AGENTS.md` guidance (useful context for translators, not restating the text).
- [x] Hints follow the #8043 review feedback (avoid unnecessary technical jargon).
- [x] Scope limited to translator comments (no logic or string changes).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI