### PR TITLE
test: improve policy authorization mutation coverage

### DIFF
--- a/tests/php/Unit/Service/Policy/PolicyAuthorizationServiceTest.php
+++ b/tests/php/Unit/Service/Policy/PolicyAuthorizationServiceTest.php
@@ -104,9 +104,8 @@ final class PolicyAuthorizationServiceTest extends TestCase {
 			->with('instance-admin')
 			->willReturn(true);
 
-		// Instance admins don't need a restricted group list, so getUserGroupIds should never be called
-		$this->groupManager->expects($this->never())
-			->method('getUserGroupIds');
+		$this->subAdmin->expects($this->never())
+			->method('isSubAdmin');
 
 		$result = $this->service->getManageablePolicyGroupIds($user);
 
@@ -144,6 +143,40 @@ final class PolicyAuthorizationServiceTest extends TestCase {
 		$this->assertSame(['finance', 'legal'], $result);
 	}
 
+	public function testGetManageablePolicyGroupIdsNormalizesManagedGroupIds(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('subadmin-user');
+
+		$this->groupManager->method('isAdmin')
+			->with('subadmin-user')
+			->willReturn(false);
+		$this->subAdmin->method('isSubAdmin')
+			->with($user)
+			->willReturn(true);
+
+		$financeWithWhitespace = $this->createMock(IGroup::class);
+		$financeWithWhitespace->method('getGID')->willReturn(' finance ');
+		$emptyGroup = $this->createMock(IGroup::class);
+		$emptyGroup->method('getGID')->willReturn('');
+		$finance = $this->createMock(IGroup::class);
+		$finance->method('getGID')->willReturn('finance');
+		$legal = $this->createMock(IGroup::class);
+		$legal->method('getGID')->willReturn('legal');
+
+		$this->subAdmin->method('getSubAdminsGroups')
+			->with($user)
+			->willReturn([$financeWithWhitespace, $emptyGroup, $finance, $legal]);
+
+		$resolved = (new ResolvedPolicy())
+			->setEditableByCurrentActor(true);
+		$this->policyService->method('resolveForUser')
+			->willReturn($resolved);
+
+		$result = $this->service->getManageablePolicyGroupIds($user);
+
+		$this->assertSame(['finance', 'legal'], $result);
+	}
+
 	public function testGetManageablePolicyGroupIdsReturnsEmptyForRegularUser(): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('regular-user');
@@ -154,6 +187,8 @@ final class PolicyAuthorizationServiceTest extends TestCase {
 		$this->subAdmin->method('isSubAdmin')
 			->with($user)
 			->willReturn(false);
+		$this->subAdmin->expects($this->never())
+			->method('getSubAdminsGroups');
 
 		$result = $this->service->getManageablePolicyGroupIds($user);
 


### PR DESCRIPTION
Related to #8053

## 📝 Summary

Improves mutation coverage for `PolicyAuthorizationService` by strengthening tests around authorization short-circuiting and managed group ID normalization.

The change is test-only and does not modify production behavior.

The added and strengthened tests verify that:

- Instance admins return before subadmin authorization is consulted.
- Regular users return before managed group lookup is attempted.
- Managed group IDs are trimmed.
- Empty managed group IDs are discarded.
- Duplicate managed group IDs are removed.
- The result is re-indexed as a `list<string>`.

### Mutation testing results

| Metric | Before | After |
| --- | ---: | ---: |
| PHPUnit tests | 11 | 12 |
| Assertions | 14 | 16 |
| Mutants generated | 30 | 30 |
| Mutants killed | 24 | 30 |
| Escaped mutants | 6 | 0 |
| Mutation Code Coverage | 100% | 100% |
| Covered Code MSI | 80% | 100% |

## 🧪 How to test

Run the focused PHPUnit test:

```bash
composer test:unit -- --filter PolicyAuthorizationServiceTest
```

Expected result:

```text
OK (12 tests, 16 assertions)
```

Run the focused Infection mutation test:

```bash
composer mutation:test -- \
  lib/Service/Policy/PolicyAuthorizationService.php \
  --test-framework-options="--filter PolicyAuthorizationServiceTest" \
  --show-mutations \
  --no-progress \
  --no-interaction
```

Expected result:

```text
30 mutations were generated:
      30 mutants were killed by Test Framework

Mutation Code Coverage: 100%
Covered Code MSI: 100%
```

## ⚙️ API / Back-end changes

- [x] Strengthened `PolicyAuthorizationServiceTest` authorization short-circuit assertions.
- [x] Added coverage for managed group ID trimming, empty-value filtering, deduplication, and list re-indexing.
- [x] Unit tests added/updated.
- [ ] Capabilities updated (not applicable).
- [ ] Documentation updated (not applicable).
- [ ] API documentation updated (not applicable).

## ✅ Checklist

- [x] I have read and followed the [contribution guide](https://github.com/LibreSign/libresign/blob/main/CONTRIBUTING.md).
- [x] The change is limited to `tests/php/Unit/Service/Policy/PolicyAuthorizationServiceTest.php`.
- [x] Focused PHPUnit tests pass.
- [x] Focused Infection mutation testing passes with 100% Covered Code MSI.
- [x] No production code or mutation-testing configuration was changed.
- [x] The commit includes the required DCO sign-off.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI