### PR TITLE
fix(lint): review and enable rules from @nextcloud/eslint-config v9 migration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,7 +86,6 @@ export default [
 			'@stylistic/implicit-arrow-linebreak',
 			'@typescript-eslint/no-use-before-define',
 			'@stylistic/exp-list-style',
-			'no-console',
 			'vue/attributes-order',
 			'@stylistic/quote-props',
 			'vue/padding-line-between-blocks',
@@ -154,5 +153,19 @@ export default [
 			'@stylistic/function-call-spacing',
 			'vue/no-dupe-keys',
 		].map(rule => [rule, 'off'])),
+	},
+		{
+		name: 'libresign/tests-console-override',
+		files: [
+			'src/tests/setup.js',
+			'src/tests/store/filters.spec.ts',
+		],
+		rules: {
+			// These files intentionally intercept console.error/console.warn
+			// to fail tests on unexpected console output, or to silence
+			// expected console output during a specific assertion. This is
+			// test tooling, not application logging.
+			'no-console': 'off',
+		},
 	},
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,64 +23,25 @@ export default [
 		],
 	},
 
-	{
+		{
 		name: 'libresign/config',
 		rules: {
 			// production only
 			'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+			// `eslint-plugin-import` (e quindi `import/order` e `import/no-unresolved`)
+			// non fa più parte di @nextcloud/eslint-config a partire dalla v9.
+			// L'ordinamento degli import è ora gestito da `perfectionist/sort-imports`
+			// (fornito dalla config condivisa), che verrà valutata come regola
+			// separata durante la migrazione.
+		},
+	},
+
+	{
+		name: 'libresign/config-vue',
+		files: ['**/*.vue'],
+		rules: {
+			// production only
 			'vue/no-unused-components': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
-			'import/order': [
-				'error',
-				{
-					groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index'], 'unknown'],
-					pathGroups: [
-						{
-							// group all style imports at the end
-							pattern: '{*.css,*.scss}',
-							patternOptions: { matchBase: true },
-							group: 'unknown',
-							position: 'after',
-						},
-						{
-							// group material design icons
-							pattern: 'vue-material-design-icons/**',
-							group: 'external',
-							position: 'after',
-						},
-						{
-							// group @nextcloud imports
-							pattern: '@nextcloud/{!(vue),!(vue)/**}',
-							group: 'external',
-							position: 'after',
-						},
-						{
-							// group @nextcloud/vue imports
-							pattern: '{@nextcloud/vue,@nextcloud/vue/**}',
-							group: 'external',
-							position: 'after',
-						},
-						{
-							// group project components
-							pattern: '*.vue',
-							patternOptions: { matchBase: true },
-							group: 'parent',
-							position: 'before',
-						},
-					],
-					pathGroupsExcludedImportTypes: ['@nextcloud', 'vue-material-design-icons'],
-					'newlines-between': 'always',
-					alphabetize: {
-						order: 'asc',
-						caseInsensitive: true,
-					},
-					warnOnUnassignedImports: true,
-				},
-			],
-			'import/no-unresolved': ['error', {
-				// Ignore Webpack query parameters, not supported by eslint-plugin-import
-				// https://github.com/import-js/eslint-plugin-import/issues/2562
-				ignore: ['\\?raw$'],
-			}],
 		},
 	},
 
@@ -93,5 +54,105 @@ export default [
 			'no-multiple-empty-lines': 'off',
 			'no-use-before-define': 'off',
 		},
+	},
+		{
+		name: 'libresign/disabled-during-migration',
+		rules: Object.fromEntries([
+			'perfectionist/sort-imports',
+			'jsdoc/require-jsdoc',
+			'@stylistic/indent',
+			'import-extensions/extensions',
+			'vue/first-attribute-linebreak',
+			'vue/attribute-hyphenation',
+			'perfectionist/sort-named-imports',
+			'@stylistic/no-tabs',
+			'@stylistic/member-delimiter-style',
+			'@stylistic/function-paren-newline',
+			'@stylistic/arrow-parens',
+			'vue/html-indent',
+			'antfu/top-level-function',
+			'jsdoc/require-param',
+			'curly',
+			'@typescript-eslint/no-unused-vars',
+			'vue/singleline-html-element-content-newline',
+			'vue/v-on-event-hyphenation',
+			'import-extensions/ban-inline-type-imports',
+			'vue/max-attributes-per-line',
+			'@typescript-eslint/consistent-type-imports',
+			'vue/custom-event-name-casing',
+			'vue/define-macros-order',
+			'@stylistic/comma-dangle',
+			'@stylistic/no-multiple-empty-lines',
+			'@stylistic/implicit-arrow-linebreak',
+			'@typescript-eslint/no-use-before-define',
+			'@stylistic/exp-list-style',
+			'no-console',
+			'vue/attributes-order',
+			'@stylistic/quote-props',
+			'vue/padding-line-between-blocks',
+			'@stylistic/no-extra-semi',
+			'vue/multi-word-component-names',
+			'jsdoc/require-param-description',
+			'@typescript-eslint/no-explicit-any',
+			'@stylistic/semi',
+			'vue/html-self-closing',
+			'vue/no-unused-refs',
+			'@stylistic/eol-last',
+			'prefer-object-has-own',
+			'no-empty',
+			'vue/no-unused-properties',
+			'@nextcloud/no-deprecated-library-props',
+			'jsdoc/no-types',
+			'camelcase',
+			'jsdoc/tag-lines',
+			'no-use-before-define',
+			'vue/new-line-between-multi-line-property',
+			'vue/no-v-html',
+			'vue/no-boolean-default',
+			'vue/prefer-separate-static-class',
+			'@nextcloud/l10n-non-breaking-space',
+			'@nextcloud/l10n-enforce-ellipsis',
+			'@stylistic/operator-linebreak',
+			'@stylistic/max-statements-per-line',
+			'no-empty-pattern',
+			'vue/html-closing-bracket-newline',
+			'jsdoc/check-tag-names',
+			'@stylistic/indent-binary-ops',
+			'@stylistic/padded-blocks',
+			'no-useless-escape',
+			'@stylistic/function-call-argument-newline',
+			'no-useless-assignment',
+			'vue/slot-name-casing',
+			'no-extra-boolean-cast',
+			'@typescript-eslint/no-empty-object-type',
+			'no-unused-vars',
+			'jsdoc/valid-types',
+			'vue/no-template-shadow',
+			'prefer-const',
+			'@stylistic/space-in-parens',
+			'@stylistic/space-before-function-paren',
+			'object-shorthand',
+			'vue/multiline-html-element-content-newline',
+			'vue/no-useless-mustaches',
+			'vue/require-default-prop',
+			'vue/prefer-prop-type-boolean-first',
+			'package-json/sort-package-json',
+			'jsdoc/escape-inline-tags',
+			'vue/key-spacing',
+			'vue/no-useless-v-bind',
+			'vue/no-undef-components',
+			'vue/no-use-v-if-with-v-for',
+			'@nextcloud/no-deprecated-globals',
+			'no-undef',
+			'@stylistic/no-trailing-spaces',
+			'jsdoc/reject-any-type',
+			'@typescript-eslint/no-unused-expressions',
+			'@stylistic/no-multi-spaces',
+			'@stylistic/lines-between-class-members',
+			'no-unassigned-vars',
+			'jsdoc/no-defaults',
+			'@stylistic/function-call-spacing',
+			'vue/no-dupe-keys',
+		].map(rule => [rule, 'off'])),
 	},
 ]

--- a/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
+++ b/playwright/e2e/sign-envelope-unauthenticated-visible-signature.spec.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-/* eslint-disable jsdoc/require-jsdoc */
 
 import { expect, test } from '@playwright/test'
 import type { APIRequestContext, Locator, Page } from '@playwright/test'

--- a/src/actions/openInLibreSignAction.js
+++ b/src/actions/openInLibreSignAction.js
@@ -9,7 +9,7 @@ import { t } from '@nextcloud/l10n'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import EditNameDialog from '../components/Common/EditNameDialog.vue'
 
-// eslint-disable-next-line import/no-unresolved
+
 import SvgIcon from '../../img/app-dark.svg?raw'
 
 /**

--- a/src/components/Draw/FileUpload.vue
+++ b/src/components/Draw/FileUpload.vue
@@ -121,6 +121,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 
 import 'vue-advanced-cropper/dist/style.css'
 import type { LibresignCapabilities } from '../../types/index'
+import logger from '../../logger.js'
 
 type CropperResult = {
 	canvas?: {
@@ -328,7 +329,7 @@ function fileSelect(event: Event) {
 	})
 
 	fileReader.addEventListener('error', error => {
-		console.error(error)
+		logger.error('Failed to read file', { error })
 	})
 
 	fileReader.readAsDataURL(selectedFile)

--- a/src/components/FileStatusList.vue
+++ b/src/components/FileStatusList.vue
@@ -56,6 +56,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 
 import { FILE_STATUS } from '../constants.js'
 import { getStatusLabel, getStatusIcon } from '../utils/fileStatus.js'
+import logger from '../logger.js'
 
 defineOptions({
 	name: 'FileStatusList',
@@ -121,7 +122,7 @@ async function loadFiles() {
 			.filter(file => file.status === FILE_STATUS.SIGNED)
 			.map(file => file.id)
 	} catch (error) {
-		console.error('[libresign][FileStatusList] Error loading files:', error)
+		logger.error('[libresign][FileStatusList] Error loading files', { error })
 	} finally {
 		isLoading.value = false
 	}

--- a/src/components/FooterTemplateEditor.vue
+++ b/src/components/FooterTemplateEditor.vue
@@ -157,6 +157,7 @@ import '@libresign/pdf-elements/dist/index.css'
 
 import CodeEditor from './CodeEditor.vue'
 import { ensurePdfWorker } from '../helpers/pdfWorker'
+import logger from '../logger.js'
 
 import {
 	mdiCheck,
@@ -303,7 +304,7 @@ function resetTemplateToDefault() {
 		emit('template-reset')
 		setPdfPreview(response.data)
 	}).catch(error => {
-		console.error('Error resetting footer template:', error)
+		logger.error('Error resetting footer template', { error })
 	})
 }
 
@@ -334,7 +335,7 @@ function saveFooterTemplate() {
 	).then(response => {
 		setPdfPreview(response.data)
 	}).catch(error => {
-		console.error('Error saving footer template:', error)
+		logger.error('Error saving footer template', { error })
 	})
 }
 
@@ -353,7 +354,7 @@ function setPdfPreview(blob: Blob) {
 		// Timeout to prevent infinite loading if PDFElements doesn't emit end-init
 		const loadingTimeout = setTimeout(() => {
 			if (loadingPreview.value) {
-				console.warn('PDF loading timeout - forcing preview ready state')
+				logger.warn('PDF loading timeout - forcing preview ready state')
 				loadingPreview.value = false
 				containerHeight.value = null
 			}

--- a/src/components/Request/RequestPicker.vue
+++ b/src/components/Request/RequestPicker.vue
@@ -254,7 +254,6 @@ const canUploadFronUrl = computed(() => {
 		return false
 	}
 	try {
-		// eslint-disable-next-line no-new
 		new URL(pdfUrl.value)
 		return true
 	} catch (error) {

--- a/src/components/RightSidebar/RequestSignatureTab.vue
+++ b/src/components/RightSidebar/RequestSignatureTab.vue
@@ -355,6 +355,7 @@ import { useSignStore } from '../../store/sign.js'
 import { useUserConfigStore } from '../../store/userconfig.js'
 import { startLongPolling } from '../../services/longPolling'
 import { useSigningOrder } from '../../composables/useSigningOrder.js'
+import logger from '../../logger.js'
 import {
 	normalizeIdentifyMethodsPolicy,
 	type IdentifyMethodPolicyEntry,
@@ -1423,7 +1424,7 @@ function startSigningProgressPolling() {
 		},
 		() => !filesStore.getFile() || filesStore.getFile().id !== file.id,
 		(error: unknown) => {
-			console.error('Error during signing progress polling:', error)
+			logger.error('Error during signing progress polling', { error })
 			showError(t('libresign', 'Error monitoring signing progress'))
 		},
 	)

--- a/src/components/validation/FileStatusList.vue
+++ b/src/components/validation/FileStatusList.vue
@@ -46,6 +46,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import { FILE_STATUS } from '../../constants.js'
 import type { ValidationFileRecord } from '../../types'
 import { getStatusLabel, getStatusIcon } from '../../utils/fileStatus.js'
+import logger from '../../logger.js'
 
 defineOptions({
 	name: 'FileStatusList',
@@ -75,7 +76,7 @@ async function loadFiles() {
 		files.value = responses.map((response) => response.data.ocs.data)
 		emit('files-updated', files.value)
 	} catch (error) {
-		console.error('[libresign][front] Failed to load files', error)
+		logger.error('[libresign][front] Failed to load files', { error })
 	}
 }
 

--- a/src/services/SignFlowHandler.ts
+++ b/src/services/SignFlowHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import { REQUIREMENT_TO_MODAL } from '../helpers/ActionMapping.ts'
+import logger from '../logger.js'
 
 interface SignMethodsStore {
 	showModal(modalCode: string): void
@@ -32,7 +33,7 @@ export class SignFlowHandler {
 
 		const handler = actionMap[action]
 		if (!handler) {
-			console.warn(`Unknown action: ${action}`)
+			logger.warn('Unknown action', { action })
 			return null
 		}
 

--- a/src/services/longPolling.ts
+++ b/src/services/longPolling.ts
@@ -6,6 +6,8 @@
 import axios, { type AxiosResponse } from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
+import logger from '../logger.js'
+
 interface FileStatusData {
 	status: number
 	[key: string]: unknown
@@ -76,7 +78,7 @@ export const createLongPolling = (options: LongPollingOptions = {}) => {
 					}
 
 					if (errorCount >= MAX_ERRORS) {
-						console.error('Long polling stopped after', MAX_ERRORS, 'consecutive errors')
+						logger.error('Long polling stopped after consecutive errors', { maxErrors: MAX_ERRORS })
 						break
 					}
 

--- a/src/store/configureCheck.js
+++ b/src/store/configureCheck.js
@@ -8,6 +8,7 @@ import { computed, ref } from 'vue'
 
 import axios from '@nextcloud/axios'
 import { subscribe } from '@nextcloud/event-bus'
+import logger from '../logger.js'
 import { loadState } from '@nextcloud/initial-state'
 import { generateOcsUrl } from '@nextcloud/router'
 
@@ -72,7 +73,7 @@ const _configureCheckStore = defineStore('configureCheck', () => {
 				updateItems(data.ocs?.data || [])
 			})
 			.catch((error) => {
-				console.error('Failed to check setup:', error)
+				logger.error('Failed to check setup', { error })
 				state.value = 'error'
 				downloadInProgress.value = false
 			})
@@ -91,7 +92,7 @@ const _configureCheckStore = defineStore('configureCheck', () => {
 				return checkSetup().then(() => ({ success: true, engine }))
 			})
 			.catch((error) => {
-				console.error('Failed to save certificate engine:', error)
+				logger.error('Failed to save certificate engine', { error })
 				return { success: false, error }
 			})
 	}

--- a/src/store/files.js
+++ b/src/store/files.js
@@ -8,6 +8,7 @@ import { ref } from 'vue'
 
 import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
+import logger from '../logger.js'
 import { emit, subscribe } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
@@ -1059,7 +1060,7 @@ const _filesStore = defineStore('files', () => {
 				return false
 			})
 			.catch((error) => {
-				console.error('Failed to rename file:', error)
+				logger.error('Failed to rename file', { error })
 				return false
 			})
 	}

--- a/src/store/filesSorting.js
+++ b/src/store/filesSorting.js
@@ -5,6 +5,7 @@
 
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import logger from '../logger.js'
 
 import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
@@ -27,7 +28,7 @@ export const useFilesSortingStore = defineStore('filesSorting', () => {
 				value: sortingDirection.value,
 			})
 		} catch (error) {
-			console.error('Failed to save sorting:', error)
+			logger.error('Failed to save sorting', { error })
 		}
 	}
 

--- a/src/store/policies.ts
+++ b/src/store/policies.ts
@@ -9,6 +9,7 @@ import { computed, ref } from 'vue'
 import axios from '@nextcloud/axios'
 import { loadState } from '@nextcloud/initial-state'
 import { generateOcsUrl } from '@nextcloud/router'
+import logger from '../logger.js'
 
 import type {
 	EffectivePolicyState,
@@ -132,7 +133,7 @@ const _policiesStore = defineStore('policies', () => {
 			const response = await axios.get<{ ocs?: { data?: EffectivePoliciesResponse } }>(generateOcsUrl('/apps/libresign/api/v1/policies/effective'))
 			setPolicies(response.data?.ocs?.data?.policies ?? {})
 		} catch (error: unknown) {
-			console.error('Failed to load effective policies', error)
+			logger.error('Failed to load effective policies', { error })
 		}
 	}
 

--- a/src/views/CrlManagement/CrlManagement.vue
+++ b/src/views/CrlManagement/CrlManagement.vue
@@ -313,6 +313,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 
 import { useUserConfigStore } from '../../store/userconfig.js'
+import logger from '../../logger.js'
 
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
@@ -481,8 +482,7 @@ async function loadEntries(append = false) {
 		total.value = data.total
 		hasMore.value = entries.value.length < total.value
 	} catch (error: any) {
-		console.error('Failed to load CRL entries:', error)
-		console.error('Error response:', error.response)
+		logger.error('Failed to load CRL entries', { error, response: error.response })
 		// TRANSLATORS Error shown when CRL records cannot be fetched from server.
 		showError(t('libresign', 'Failed to load CRL entries'))
 	} finally {
@@ -507,7 +507,7 @@ async function saveFilters() {
 			owner: filters.owner,
 		})
 	} catch (error) {
-		console.error('Failed to save filters:', error)
+		logger.error('Failed to save filters', { error })
 	}
 }
 
@@ -518,7 +518,7 @@ async function saveSort() {
 			sortOrder: sortOrder.value,
 		})
 	} catch (error) {
-		console.error('Failed to save sort:', error)
+		logger.error('Failed to save sort', { error })
 	}
 }
 
@@ -653,7 +653,7 @@ async function confirmRevoke() {
 			showError(response.data.ocs.data.message || t('libresign', 'Failed to revoke certificate'))
 		}
 	} catch (error: any) {
-		console.error('Failed to revoke certificate:', error)
+		logger.error('Failed to revoke certificate', { error })
 		// TRANSLATORS Error fallback shown when revocation request fails unexpectedly.
 		const message = error.response?.data?.ocs?.data?.message || t('libresign', 'An error occurred while revoking the certificate')
 		showError(message)

--- a/src/views/Documents/IdDocsValidation.vue
+++ b/src/views/Documents/IdDocsValidation.vue
@@ -194,6 +194,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { FILE_STATUS } from '../../constants.js'
 import { openDocument } from '../../utils/viewer.js'
 import { useUserConfigStore } from '../../store/userconfig.js'
+import logger from '../../logger.js'
 import type { operations, components } from '../../types/openapi/openapi'
 
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -452,7 +453,7 @@ async function saveFilters() {
 			status: filters.status?.value ?? null,
 		})
 	} catch (error) {
-		console.error('Failed to save filters:', error)
+		logger.error('Failed to save filters', { error })
 	}
 }
 
@@ -494,7 +495,7 @@ async function saveSort() {
 			sortOrder: sortOrder.value,
 		})
 	} catch (error) {
-		console.error('Failed to save sort:', error)
+		logger.error('Failed to save sort', { error })
 	}
 }
 

--- a/src/views/Preferences/Preferences.vue
+++ b/src/views/Preferences/Preferences.vue
@@ -86,6 +86,7 @@ import type { EffectivePolicyValue, SignatureFlowMode } from '../../types/index'
 import { realDefinitions } from '../Settings/PolicyWorkbench/settings/realDefinitions'
 import type { RealPolicyPersonalPreferenceContext } from '../Settings/PolicyWorkbench/settings/realTypes'
 import { canRenderPersonalPreferencePolicy } from './personalPreferenceVisibility'
+import logger from '../../logger.js'
 
 defineOptions({
 	name: 'Preferences',
@@ -339,7 +340,7 @@ async function savePreferenceValue(policyKey: string, value: EffectivePolicyValu
 		await persistPreferenceValue(policyKey, value)
 		return true
 	} catch (error) {
-		console.error(`Failed to save ${policyKey} preference`, error)
+		logger.error(`Failed to save ${policyKey} preference`, { error })
 		errorMessage.value = errorText
 		return false
 	} finally {
@@ -363,7 +364,7 @@ async function clearPreferenceValue(policyKey: string, errorText: string): Promi
 	try {
 		await clearPersistedPreferenceValue(policyKey)
 	} catch (error) {
-		console.error(`Failed to clear ${policyKey} preference`, error)
+		logger.error(`Failed to clear ${policyKey} preference`, { error })
 		errorMessage.value = errorText
 	} finally {
 		saving.value = false

--- a/src/views/Settings/ActiveSignings.vue
+++ b/src/views/Settings/ActiveSignings.vue
@@ -81,6 +81,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 import type { operations } from '../../types/openapi/openapi-administration'
+import logger from '../../logger.js'
 
 type ActiveSigningsResponse = operations['admin-get-active-signings']['responses'][200]['content']['application/json']
 type SigningItem = ActiveSigningsResponse['ocs']['data']['data'][number]
@@ -106,7 +107,7 @@ async function refresh() {
 		signings.value = response.data.ocs.data.data
 		updateLastRefreshTime()
 	} catch (error: unknown) {
-		console.error('Failed to fetch active signings:', error)
+		logger.error('Failed to fetch active signings', { error })
 		signings.value = []
 	} finally {
 		loading.value = false

--- a/src/views/Validation.vue
+++ b/src/views/Validation.vue
@@ -129,7 +129,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcListItem from '@nextcloud/vue/components/NcListItem'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
-// eslint-disable-next-line import/no-named-as-default
+
 import NcRichText from '@nextcloud/vue/components/NcRichText'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import EnvelopeValidation from '../components/validation/EnvelopeValidation.vue'


### PR DESCRIPTION
Related to #7876

## 📝 Summary

Follow-up of #7876 (`@nextcloud/eslint-config` v8 → v9 upgrade). This PR
reviews and progressively enables the ESLint rules newly introduced by
v9, tracked in `libresign/disabled-during-migration` in
`eslint.config.mjs`, one rule per commit as requested in the issue.

⚠️ This branch is built on top of #7876, which is not yet merged into
`main`. Once #7876 lands, this diff will shrink to just the
lint-migration work.

## What's done so far

- **Fixed two config scoping bugs surfaced by the v9 upgrade** (both
  needed before `npm run lint` could even run):
  - `vue/no-unused-components` is now scoped to `files: ['**/*.vue']`
    only. In v9 the `vue` plugin is registered only for `.vue` files,
    so applying this rule globally crashed ESLint on non-Vue files.
  - Removed `import/order` and `import/no-unresolved`, which relied on
    `eslint-plugin-import` — no longer a dependency of
    `@nextcloud/eslint-config` v9. Import ordering is now handled by
    `perfectionist/sort-imports` (already provided by the shared
    config), which will be reviewed as its own rule.
- **Removed obsolete `eslint-disable` comments** referencing rules
  that no longer exist, or no longer apply in their file's context
  (`import/no-named-as-default`, `import/no-unresolved`,
  `jsdoc/require-jsdoc`, an unused `no-new` directive).
- **Enabled `no-console`**: replaced application-level
  `console.error` / `console.warn` calls across 13 files with the
  project's existing `src/logger.js` wrapper around
  `@nextcloud/logger`, passing error/context as a structured object
  (e.g. `logger.error('Failed to save filters', { error })`) instead
  of loose positional arguments. Test files that intentionally
  intercept `console.*` for assertions (`src/tests/setup.js`,
  `src/tests/store/filters.spec.ts`) are excluded via a scoped
  `no-console: off` override, since that's test tooling rather than
  application logging.

## Still to do

Remaining rules in `libresign/disabled-during-migration` (~96 rules)
will be enabled incrementally, one commit per rule, following the
process described in the issue.

## 🧪 How to test

1. `npm ci`
2. `npm run lint` → should report 0 problems
3. `npm run test:unit -- --run` → should pass with no new failures

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [ ] Work in progress — not ready for final review/merge yet.