### PR TITLE
test: kill escaped mutants in certificate FileService

### DIFF
--- a/tests/php/Unit/Service/Certificate/FileServiceTest.php
+++ b/tests/php/Unit/Service/Certificate/FileServiceTest.php
@@ -59,6 +59,69 @@ class FileServiceTest extends TestCase {
 		$this->assertEquals('', $result);
 	}
 
+	#[DataProvider('certificateContentScenarios')]
+	public function testReturnsContentOfExistingCertificateFile(
+		string $methodName,
+		string $expectedContent,
+	): void {
+		$root = vfsStream::setup('libresign', null, [
+			'instance-1' => [
+				'1' => [
+					'ca.pem' => 'root certificate content',
+					'ca-key.pem' => 'private key content',
+				],
+			],
+		]);
+		$mockEngine = $this->createMock(IEngineHandler::class);
+		$configPath = vfsStream::url('libresign/instance-1/1');
+
+		$this->engineFactory
+			->expects($this->once())
+			->method('getEngine')
+			->with(CertificateEngineType::OpenSSL->getEngineName())
+			->willReturn($mockEngine);
+
+		$mockEngine->expects($this->once())
+			->method('getConfigPathByParams')
+			->with('instance-1', 1)
+			->willReturn($configPath);
+
+		$this->logger
+			->expects($this->never())
+			->method('debug');
+
+		$result = $this->service->$methodName('instance-1', 1, CertificateEngineType::OpenSSL);
+		$this->assertSame($expectedContent, $result);
+	}
+
+	public function testReturnsEmptyStringWhenCertificateFileIsNotReadable(): void {
+		$root = vfsStream::setup('libresign', null, [
+			'instance-1' => [
+				'1' => [
+					'ca.pem' => 'root certificate content',
+				],
+			],
+		]);
+		$root->getChild('instance-1/1/ca.pem')->chmod(0o000);
+		$mockEngine = $this->createMock(IEngineHandler::class);
+
+		$this->engineFactory
+			->expects($this->once())
+			->method('getEngine')
+			->willReturn($mockEngine);
+
+		$mockEngine->expects($this->once())
+			->method('getConfigPathByParams')
+			->willReturn(vfsStream::url('libresign/instance-1/1'));
+
+		$this->logger
+			->expects($this->never())
+			->method('debug');
+
+		$result = $this->service->getRootCertificateByGeneration('instance-1', 1, CertificateEngineType::OpenSSL);
+		$this->assertSame('', $result);
+	}
+
 	#[DataProvider('engineExceptionScenarios')]
 	public function testHandlesEngineExceptionGracefully(
 		CertificateEngineType $engineType,
@@ -137,6 +200,19 @@ class FileServiceTest extends TestCase {
 				'generation' => 5,
 				'engineType' => CertificateEngineType::OpenSSL,
 				'methodName' => 'getRootCertificateByGeneration',
+			],
+		];
+	}
+
+	public static function certificateContentScenarios(): array {
+		return [
+			'Root certificate is read from ca.pem' => [
+				'methodName' => 'getRootCertificateByGeneration',
+				'expectedContent' => 'root certificate content',
+			],
+			'Private key is read from ca-key.pem' => [
+				'methodName' => 'getPrivateKeyByGeneration',
+				'expectedContent' => 'private key content',
 			],
 		];
 	}


### PR DESCRIPTION
Ref: #8053 <!-- partial contribution to the mutation-testing issue; intentionally not using a closing keyword -->

## 📝 Summary

One focused source/test pair from #8053:

- `lib/Service/Certificate/FileService.php`
- `tests/php/Unit/Service/Certificate/FileServiceTest.php`

Infection reported 8 escaped mutants for this file (Covered Code MSI 57.89%): the path concatenation in `loadCertificateFileByGeneration()` (5 Concat/ConcatOperandRemoval mutants) and the guards in `readCertificateFile()` (3 LogicalNot/LogicalOr mutants). All existing scenarios asserted only the empty-string fallback and never read an existing certificate file, so mutants that broke the path building or the guards kept every test green.

This PR only adds tests — no production code changes:

- `testReturnsContentOfExistingCertificateFile` (data provider): creates real `ca.pem`/`ca-key.pem` files in the vfsStream virtual filesystem, with different contents, and asserts each public method returns the content of its own file. Kills the 5 path-concatenation mutants and 2 of the guard mutants.
- `testReturnsEmptyStringWhenCertificateFileIsNotReadable`: existing file with `chmod 0o000` in the virtual filesystem; asserts the guard rejects it silently (empty string, no debug log). Kills the remaining `||` → `&&` guard mutant.

After the change, Infection reports **20/20 mutants killed — Covered Code MSI 100%** for this scope, with no errors and no timeouts.

Note on the `||` → `&&` guard mutant: original and mutated code both return `''` for an existing-but-unreadable file. What kills the mutant is that the mutated code reaches `file_get_contents()` and triggers a PHP warning, which fails the run because the project sets `failOnWarning="true"` in `tests/php/phpunit.xml`. The observable behavior protected here is "an unreadable file is rejected by the guard without attempting to read it".

## 🧪 How to test

```sh
composer test:unit -- --filter FileServiceTest

XDEBUG_MODE=coverage vendor/bin/infection --configuration=infection.json5 \
  --test-framework-options="--testsuite=unit" --show-mutations \
  lib/Service/Certificate/FileService.php
```

Expected: 12 tests green; 20 mutants generated, 20 killed, Covered Code MSI 100%.

## ⚙️ API / Back‑end changes

- [x] Unit and/or integration tests added – *required for backend changes*

Test-only change; no production code, capabilities, or API documentation affected.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Focused PHPUnit, focused Infection and `php-cs-fixer` pass for the changed file.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
