### PR TITLE
[stable32] test: kill escaped mutants in certificate FileService

### DIFF
--- a/tests/php/Unit/Service/Certificate/FileServiceTest.php
+++ b/tests/php/Unit/Service/Certificate/FileServiceTest.php
@@ -59,6 +59,69 @@ class FileServiceTest extends TestCase {
 		$this->assertEquals('', $result);
 	}
 
+	#[DataProvider('certificateContentScenarios')]
+	public function testReturnsContentOfExistingCertificateFile(
+		string $methodName,
+		string $expectedContent,
+	): void {
+		$root = vfsStream::setup('libresign', null, [
+			'instance-1' => [
+				'1' => [
+					'ca.pem' => 'root certificate content',
+					'ca-key.pem' => 'private key content',
+				],
+			],
+		]);
+		$mockEngine = $this->createMock(IEngineHandler::class);
+		$configPath = vfsStream::url('libresign/instance-1/1');
+
+		$this->engineFactory
+			->expects($this->once())
+			->method('getEngine')
+			->with(CertificateEngineType::OpenSSL->getEngineName())
+			->willReturn($mockEngine);
+
+		$mockEngine->expects($this->once())
+			->method('getConfigPathByParams')
+			->with('instance-1', 1)
+			->willReturn($configPath);
+
+		$this->logger
+			->expects($this->never())
+			->method('debug');
+
+		$result = $this->service->$methodName('instance-1', 1, CertificateEngineType::OpenSSL);
+		$this->assertSame($expectedContent, $result);
+	}
+
+	public function testReturnsEmptyStringWhenCertificateFileIsNotReadable(): void {
+		$root = vfsStream::setup('libresign', null, [
+			'instance-1' => [
+				'1' => [
+					'ca.pem' => 'root certificate content',
+				],
+			],
+		]);
+		$root->getChild('instance-1/1/ca.pem')->chmod(0o000);
+		$mockEngine = $this->createMock(IEngineHandler::class);
+
+		$this->engineFactory
+			->expects($this->once())
+			->method('getEngine')
+			->willReturn($mockEngine);
+
+		$mockEngine->expects($this->once())
+			->method('getConfigPathByParams')
+			->willReturn(vfsStream::url('libresign/instance-1/1'));
+
+		$this->logger
+			->expects($this->never())
+			->method('debug');
+
+		$result = $this->service->getRootCertificateByGeneration('instance-1', 1, CertificateEngineType::OpenSSL);
+		$this->assertSame('', $result);
+	}
+
 	#[DataProvider('engineExceptionScenarios')]
 	public function testHandlesEngineExceptionGracefully(
 		CertificateEngineType $engineType,
@@ -139,6 +202,19 @@ class FileServiceTest extends TestCase {
 				'generation' => 5,
 				'engineType' => CertificateEngineType::OpenSSL,
 				'methodName' => 'getRootCertificateByGeneration',
+			],
+		];
+	}
+
+	public static function certificateContentScenarios(): array {
+		return [
+			'Root certificate is read from ca.pem' => [
+				'methodName' => 'getRootCertificateByGeneration',
+				'expectedContent' => 'root certificate content',
+			],
+			'Private key is read from ca-key.pem' => [
+				'methodName' => 'getPrivateKeyByGeneration',
+				'expectedContent' => 'private key content',
 			],
 		];
 	}


### PR DESCRIPTION
Backport of PR #8079

The backportbot failed on this branch with an authentication error (the stable33/34/35 backports #8080/#8081/#8082 went through), so this is the manual backport it requested. Clean cherry-pick of c015a47a, no conflicts.