### PR TITLE
test: cover EmailToken and TokenService signature method behaviors

### DIFF
--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
@@ -9,10 +9,14 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Unit\Service\IdentifyMethod\SignatureMethod;
 
 use OCA\Libresign\Db\IdentifyMethod;
+use OCA\Libresign\Db\SignRequest;
+use OCA\Libresign\Db\SignRequestMapper;
+use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\IdentifyMethod\IdentifyService;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\EmailToken;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\TokenService;
 use OCP\L10N\IFactory as IL10NFactory;
+use OCP\Security\IHasher;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -22,10 +26,9 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	#[\Override]
 	public function setUp(): void {
-		$identifyService = $this->createMock(IdentifyService::class);
 		$identifyService = $this->getMockBuilder(IdentifyService::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['getL10n'])
+			->onlyMethods(['getL10n', 'getSignRequestMapper', 'getHasher', 'save'])
 			->getMock();
 		$identifyService->method('getL10n')->willReturn(
 			\OCP\Server::get(IL10NFactory::class)->get(\OCA\Libresign\AppInfo\Application::APP_ID)
@@ -41,8 +44,8 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		);
 	}
 
-	#[DataProvider('providerVaidateEmail')]
-	public function testVaidateEmail(string $email, string $blurred, string $hash): void {
+	#[DataProvider('providerValidateEmail')]
+	public function testValidateEmail(string $email, string $blurred, string $hash): void {
 		$instance = $this->getClass();
 		$identifyMethod = new IdentifyMethod();
 		$entity['identifierKey'] = 'email';
@@ -60,7 +63,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertEquals($hash, $actual['hashOfEmail']);
 	}
 
-	public static function providerVaidateEmail(): array {
+	public static function providerValidateEmail(): array {
 		return [
 			['valid@domain.coop', 'val***@***.coop', md5('valid@domain.coop')],
 			['valiD@Domain.coop', 'val***@***.coop', md5('valid@domain.coop')],
@@ -153,5 +156,118 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			'case_47' => [['code' => '123456', 'identifiedAtDate' => '2025-08-11'], '0',   ['needCode' => true,  'hasConfirmCode' => true]],
 			'case_48' => [['code' => '123456', 'identifiedAtDate' => '2025-08-11'], 'abc', ['needCode' => false, 'hasConfirmCode' => true]],
 		];
+	}
+
+	public function testRequestCodeSendsCodeAndPersistsHash(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setDisplayName('John Doe');
+		$signRequestMapper = $this->createMock(SignRequestMapper::class);
+		$signRequestMapper->method('getById')
+			->with(171)
+			->willReturn($signRequest);
+		$this->identifyService->method('getSignRequestMapper')->willReturn($signRequestMapper);
+		$this->tokenService->expects($this->once())
+			->method('sendCodeByEmail')
+			->with('valid@domain.coop', 'John Doe')
+			->willReturn('hashed-code');
+
+		$instance = $this->getClass();
+		$identifyMethod = (new IdentifyMethod())->fromParams([
+			'identifierKey' => 'email',
+			'identifierValue' => 'valid@domain.coop',
+			'signRequestId' => 171,
+		]);
+		$instance->setEntity($identifyMethod);
+		$this->identifyService->expects($this->once())
+			->method('save')
+			->with($identifyMethod);
+
+		$instance->requestCode('valid@domain.coop', 'email');
+
+		$this->assertSame('hashed-code', $identifyMethod->getCode());
+	}
+
+	public function testRequestCodeOmitsDisplayNameWhenEqualToIdentifier(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setDisplayName('valid@domain.coop');
+		$signRequestMapper = $this->createMock(SignRequestMapper::class);
+		$signRequestMapper->method('getById')
+			->with(171)
+			->willReturn($signRequest);
+		$this->identifyService->method('getSignRequestMapper')->willReturn($signRequestMapper);
+		$this->tokenService->expects($this->once())
+			->method('sendCodeByEmail')
+			->with('valid@domain.coop', '')
+			->willReturn('hashed-code');
+
+		$instance = $this->getClass();
+		$identifyMethod = (new IdentifyMethod())->fromParams([
+			'identifierKey' => 'email',
+			'identifierValue' => 'valid@domain.coop',
+			'signRequestId' => 171,
+		]);
+		$instance->setEntity($identifyMethod);
+
+		$instance->requestCode('valid@domain.coop', 'email');
+
+		$this->assertSame('hashed-code', $identifyMethod->getCode());
+	}
+
+	public function testValidateToSignWithValidCodeDoesNotThrow(): void {
+		$hasher = $this->createMock(IHasher::class);
+		$hasher->method('verify')
+			->with('123456', 'hashed-code')
+			->willReturn(true);
+		$this->identifyService->method('getHasher')->willReturn($hasher);
+
+		$instance = $this->getClass();
+		$identifyMethod = (new IdentifyMethod())->fromParams([
+			'identifierKey' => 'email',
+			'identifierValue' => 'valid@domain.coop',
+			'code' => 'hashed-code',
+		]);
+		$instance->setEntity($identifyMethod);
+		$instance->setCodeSentByUser('123456');
+
+		$instance->validateToSign();
+
+		$this->addToAssertionCount(1);
+	}
+
+	public function testValidateToSignWithWrongCodeThrows(): void {
+		$hasher = $this->createMock(IHasher::class);
+		$hasher->method('verify')
+			->with('654321', 'hashed-code')
+			->willReturn(false);
+		$this->identifyService->method('getHasher')->willReturn($hasher);
+
+		$instance = $this->getClass();
+		$identifyMethod = (new IdentifyMethod())->fromParams([
+			'identifierKey' => 'email',
+			'identifierValue' => 'valid@domain.coop',
+			'code' => 'hashed-code',
+		]);
+		$instance->setEntity($identifyMethod);
+		$instance->setCodeSentByUser('654321');
+
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage('Invalid code.');
+
+		$instance->validateToSign();
+	}
+
+	public function testValidateToSignThrowsWhenCodeWasSentWithoutBeingRequested(): void {
+		$instance = $this->getClass();
+		$identifyMethod = (new IdentifyMethod())->fromParams([
+			'identifierKey' => 'email',
+			'identifierValue' => 'valid@domain.coop',
+		]);
+		$instance->setEntity($identifyMethod);
+		$instance->setCodeSentByUser('123456');
+
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage('Invalid code.');
+
+		$instance->validateToSign();
 	}
 }

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Unit\Service\IdentifyMethod\SignatureMethod;
 
+use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\TokenService;
 use OCA\Libresign\Service\MailService;
 use OCA\Libresign\Service\TwofactorGatewayService;
@@ -41,6 +42,19 @@ final class TokenServiceTest extends TestCase {
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+	}
+
+	public function testSendCodeByGatewayThrowsWhenGatewayAppIsNotEnabled(): void {
+		$this->appManager->method('isEnabledForAnyone')->with('twofactor_gateway')->willReturn(false);
+		$this->container->expects($this->never())
+			->method('get');
+		$this->secureRandom->expects($this->never())
+			->method('generate');
+
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage('App Two-Factor Gateway is not enabled.');
+
+		$this->createService()->sendCodeByGateway('+5511999999999', 'sms');
 	}
 
 	public function testSendCodeByGatewayThrowsWhenGatewayIsIncomplete(): void {
@@ -84,6 +98,22 @@ final class TokenServiceTest extends TestCase {
 		self::assertSame([
 			['gateway' => 'sms', 'identifier' => '+5511999999999', 'message' => '123456 is your LibreSign verification code.'],
 		], $integrationService->sentMessages);
+	}
+
+	public function testSendCodeByEmailSendsCodeAndReturnsHashedCode(): void {
+		$this->secureRandom->expects($this->once())
+			->method('generate')
+			->with(TokenService::TOKEN_LENGTH, ISecureRandom::CHAR_DIGITS)
+			->willReturn('123456');
+		$this->mailService->expects($this->once())
+			->method('sendCodeToSign')
+			->with('signer@domain.coop', 'John Doe', '123456');
+		$this->hasher->expects($this->once())
+			->method('hash')
+			->with('123456')
+			->willReturn('hashed-code');
+
+		self::assertSame('hashed-code', $this->createService()->sendCodeByEmail('signer@domain.coop', 'John Doe'));
 	}
 
 	private function createService(): TokenService {


### PR DESCRIPTION
Ref: #8053 <!-- partial contribution to the mutation-testing issue; intentionally not using a closing keyword -->

## 📝 Summary

Two closely related source/test pairs from #8053 (as claimed on the issue):

- `lib/Service/IdentifyMethod/SignatureMethod/TokenService.php`
- `lib/Service/IdentifyMethod/SignatureMethod/EmailToken.php`

Infection baseline for the two files: 23 mutants generated, 1 escaped, Covered Code MSI 95%. The escaped mutant is the `MethodCallRemoval` of `$this->twofactorGatewayService->ensureAvailable($gatewayName)` in `sendCodeByGateway()` — no scenario exercised an unavailable gateway. One correction to my claim comment: `sendCodeByEmail()`, `requestCode()` and `validateToSign()` did have *indirect* coverage from elsewhere in the unit suite; what was missing were direct tests pinning their observable behavior, plus the escaped kill.

This PR only adds tests — no production code changes:

- `testSendCodeByGatewayThrowsWhenGatewayAppIsNotEnabled`: kills the escaped mutant. With the call in place, `ensureAvailable()` throws `LibresignException("App Two-Factor Gateway is not enabled.")`; with the call removed, execution reaches `isGatewayComplete()` and throws `OCSForbiddenException` instead, so the expected exception class/message pins the guard.
- `testSendCodeByEmailSendsCodeAndReturnsHashedCode`: direct test asserting code generation (`TOKEN_LENGTH`, digits), delivery via `MailService::sendCodeToSign()` and the hashed return value.
- `EmailToken::requestCode()`: both display-name branches (distinct name is forwarded; name equal to the identifier is sent as an empty string), asserting the hashed code is persisted via `IdentifyService::save()`.
- `EmailToken::validateToSign()`: valid code passes; wrong code throws `Invalid code.`; a code sent without ever being requested also throws.
- Typo fix: `testVaidateEmail` → `testValidateEmail` (and its data provider); removed a dead mock assignment in `setUp()`.

After the change, Infection reports **29 mutants generated, 0 escaped, 0 uncovered — Covered Code MSI 100%** for this scope (17 killed by tests, 12 detected via fatal errors).

## 🧪 How to test

```sh
composer test:unit -- --filter "TokenServiceTest|EmailTokenTest"

XDEBUG_MODE=coverage vendor/bin/infection --configuration=infection.json5 \
  --test-framework-options="--testsuite=unit" --show-mutations \
  lib/Service/IdentifyMethod/SignatureMethod/TokenService.php \
  lib/Service/IdentifyMethod/SignatureMethod/EmailToken.php
```

Expected: tests green; 29 mutants generated, 0 escaped, Covered Code MSI 100%.

## ⚙️ API / Back‑end changes

- [x] Unit and/or integration tests added – *required for backend changes*

Test-only change; no production code, capabilities, or API documentation affected.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Full unit suite, focused Infection and `php-cs-fixer` pass for the changed files.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI