### PR TITLE
refactor(exception): add error codes to the invalid token and gateway exceptions

### DIFF
--- a/lib/Exception/LibresignException.php
+++ b/lib/Exception/LibresignException.php
@@ -14,6 +14,13 @@ use JsonSerializable;
  * @codeCoverageIgnore
  */
 class LibresignException extends \Exception implements JsonSerializable {
+	/**
+	 * Error codes follow the closest HTTP status with one extra digit
+	 * (401 -> 4010), so they are not mistaken for HTTP status codes.
+	 */
+	public const int CODE_INVALID_TOKEN = 4010;
+	public const int CODE_TWOFACTOR_GATEWAY_NOT_ENABLED = 5030;
+
 	#[\Override]
 	public function jsonSerialize(): mixed {
 		return ['message' => $this->getMessage()];

--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -257,13 +257,13 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		if ($code === null || $code === '') {
 			if ($this->codeSentByUser !== null) {
 				// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
-				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'));
+				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
 			}
 			return;
 		}
 		if (empty($this->codeSentByUser) || !$this->identifyService->getHasher()->verify($this->codeSentByUser, $code)) {
 			// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
-			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'));
+			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
 		}
 	}
 

--- a/lib/Service/TwofactorGatewayService.php
+++ b/lib/Service/TwofactorGatewayService.php
@@ -89,7 +89,7 @@ final class TwofactorGatewayService {
 	 */
 	private function resolveIntegrationService(): object {
 		if (!$this->isEnabled()) {
-			throw new LibresignException('App Two-Factor Gateway is not enabled.');
+			throw new LibresignException('App Two-Factor Gateway is not enabled.', LibresignException::CODE_TWOFACTOR_GATEWAY_NOT_ENABLED);
 		}
 
 		try {

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
@@ -251,7 +251,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('654321');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionMessage('Invalid code.');
+		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}
@@ -266,7 +266,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('123456');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionMessage('Invalid code.');
+		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
@@ -15,6 +15,8 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\IdentifyMethod\IdentifyService;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\EmailToken;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\TokenService;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 use OCP\Security\IHasher;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -28,7 +30,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	public function setUp(): void {
 		$identifyService = $this->getMockBuilder(IdentifyService::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['getL10n', 'getSignRequestMapper', 'getHasher', 'save'])
+			->onlyMethods(['getL10n', 'getSignRequestMapper', 'getHasher', 'getUserManager', 'save'])
 			->getMock();
 		$identifyService->method('getL10n')->willReturn(
 			\OCP\Server::get(IL10NFactory::class)->get(\OCA\Libresign\AppInfo\Application::APP_ID)
@@ -68,6 +70,44 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			['valid@domain.coop', 'val***@***.coop', md5('valid@domain.coop')],
 			['valiD@Domain.coop', 'val***@***.coop', md5('valid@domain.coop')],
 			['VALID@DOMAIN.COOP', 'val***@***.coop', md5('valid@domain.coop')],
+		];
+	}
+
+	#[DataProvider('dataToArrayResolvesEmailByIdentifierKey')]
+	public function testToArrayResolvesEmailByIdentifierKey(string $identifierKey, string $identifierValue, ?string $accountEmail, string $expectedIdentifyMethod, string $expectedEmail): void {
+		$user = null;
+		if ($accountEmail !== null) {
+			$user = $this->createMock(IUser::class);
+			$user->method('getEMailAddress')->willReturn($accountEmail);
+		}
+		$userManager = $this->createMock(IUserManager::class);
+		$userManager->method('get')->with($identifierValue)->willReturn($user);
+		$this->identifyService->method('getUserManager')->willReturn($userManager);
+
+		$instance = $this->getClass();
+		$instance->setEntity((new IdentifyMethod())->fromParams([
+			'identifierKey' => $identifierKey,
+			'identifierValue' => $identifierValue,
+		]));
+
+		$actual = $instance->toArray();
+
+		$this->assertSame($expectedIdentifyMethod, $actual['identifyMethod']);
+		if ($expectedEmail === '') {
+			$this->assertSame('', $actual['hashOfEmail']);
+			$this->assertSame('', $actual['blurredEmail']);
+			return;
+		}
+		$this->assertSame(md5($expectedEmail), $actual['hashOfEmail']);
+		$this->assertNotSame('', $actual['blurredEmail']);
+	}
+
+	public static function dataToArrayResolvesEmailByIdentifierKey(): array {
+		return [
+			'emailToken uses the identifier value' => ['emailToken', 'Valid@Domain.coop', null, 'email', 'valid@domain.coop'],
+			'account uses the email of the user' => ['account', 'joao', 'Joao@Domain.coop', 'account', 'joao@domain.coop'],
+			'account without a user has no email' => ['account', 'ghost', null, 'account', ''],
+			'unknown key has no email' => ['phone', '+5511999999999', null, 'phone', ''],
 		];
 	}
 

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
@@ -52,7 +52,7 @@ final class TokenServiceTest extends TestCase {
 			->method('generate');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionMessage('App Two-Factor Gateway is not enabled.');
+		$this->expectExceptionCode(LibresignException::CODE_TWOFACTOR_GATEWAY_NOT_ENABLED);
 
 		$this->createService()->sendCodeByGateway('+5511999999999', 'sms');
 	}


### PR DESCRIPTION
### Pull Request Description

Follow-up to #8092, addressing the review comments there and in this PR: the tests added in #8092 asserted on exception messages (`'Invalid code.'` and `'App Two-Factor Gateway is not enabled.'`), which couples them to translatable/easily mutable text, and the suggestion was to identify these errors by an exception code instead.

**`refactor(exception)`** — adds two constants to `LibresignException` and uses them at the throw sites:

| Constant | Value | Thrown by |
| --- | --- | --- |
| `CODE_INVALID_TOKEN` | `4010` | `AbstractIdentifyMethod::throwIfInvalidToken()` — wrong or unsolicited verification code |
| `CODE_TWOFACTOR_GATEWAY_NOT_ENABLED` | `5030` | `TwofactorGatewayService` — the Two-Factor Gateway app is disabled |

The values follow the closest HTTP status with one extra digit, as discussed in #8092, so they are not mistaken for HTTP statuses.

Where the codes end up (checked before choosing the values):

- Both throw sites are only reached through `SignFileController::sign()` and `requestCode*()`, which catch the exception and always answer **422** — the HTTP status does not change.
- `SigningErrorHandler` exposes the code in the payload (`errors[].code`, `0` until now) and picks the action by `code === 400`, so the action does not change either; the frontend only compares the code with `422` (`NON_RETRIABLE_SIGN_ERROR_CODE`).
- `InjectionMiddleware::getStatusCodeFromException()` still uses any non-zero code as the HTTP status. These two exceptions never reach it, but it means codes like these (and the existing `1`) must not leak there — a guard (code outside 100–599 → 422) is worth discussing in #8117.

**`test`** (two commits) — replaces the three `expectExceptionMessage()` calls with `expectExceptionCode()` on the new constants; and covers `EmailToken::toArray()` for the `emailToken`, `account` and unknown identifier keys, which the existing tests never exercised (re-measuring Infection with a single thread showed 4 escaped `MatchArmRemoval` mutants there — the earlier "0 escaped" in this description came from a multi-threaded run, which reports false kills for classes extending the LibreSign `TestCase`).

The pre-existing assertion on `'Gateway sms not configured on Two-Factor Gateway.'` was kept: it checks that the gateway name is interpolated into the message, which is behavior rather than wording.

Validation: PHPUnit `tests/php/Unit/Service/IdentifyMethod` (163 tests) + `TwofactorGatewayServiceTest` (6) green; php-cs-fixer clean; Infection on `EmailToken.php` and `TokenService.php` (single thread, whole unit suite): 31 mutants, 0 escaped, Covered Code MSI 100%.

Backport notes: applies cleanly to stable35 (both commits). Not applicable to stable32–34 — `TwofactorGatewayService.php` and `TokenServiceTest.php` do not exist there.

### Related Issue

Ref #8053, #8117

### Pull Request Type

- Refactor
- Test

### Pull request checklist

- [x] Tests pass locally (PHPUnit + Infection)
- [x] AI-assisted: yes (see commit trailers)
