### PR TITLE
feat: add mail_sender_strategy policy to send notifications as the requester

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -409,6 +409,7 @@ namespace OCA\Libresign;
  *     helper?: bool,
  *     parentPolicyKey?: string,
  *     compositeChildren?: list<string>,
+ *     mailProviderAvailable?: bool,
  * }
  * @psalm-type LibresignEffectivePolicyState = array{
  *     policyKey: string,

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -12,10 +12,19 @@ use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Db\SignRequest;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\Policy\PolicyService;
+use OCA\Libresign\Service\Policy\Provider\MailSenderStrategy\MailSenderStrategyPolicy;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
+use OCP\Mail\Provider\Address;
+use OCP\Mail\Provider\IManager as IMailProviderManager;
+use OCP\Mail\Provider\IMessageSend;
+use OCP\Mail\Provider\IService;
 use Psr\Log\LoggerInterface;
 
 class MailService {
@@ -29,6 +38,9 @@ class MailService {
 		private IL10N $l10n,
 		private IURLGenerator $urlGenerator,
 		private IAppConfig $appConfig,
+		private PolicyService $policyService,
+		private IMailProviderManager $mailProviderManager,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -67,15 +79,8 @@ class MailService {
 			$this->l10n->t('Sign "%s"', [$file->getName()]),
 			$link
 		);
-		$message = $this->mailer->createMessage();
-		if ($data->getDisplayName()) {
-			$message->setTo([$email => $data->getDisplayName()]);
-		} else {
-			$message->setTo([$email]);
-		}
-		$message->useTemplate($emailTemplate);
 		try {
-			$this->mailer->send($message);
+			$this->sendSignRequestNotification($emailTemplate, $data, $email);
 		} catch (\Exception $e) {
 			$this->logger->error('Notify changes in unsigned notification mail could not be sent: ' . $e->getMessage());
 			throw new LibresignException('Notify unsigned notification mail could not be sent', 1);
@@ -107,6 +112,36 @@ class MailService {
 			$this->l10n->t('Sign "%s"', [$file->getName()]),
 			$link
 		);
+		try {
+			$this->sendSignRequestNotification($emailTemplate, $data, $email);
+		} catch (\Exception $e) {
+			$this->logger->error('Notify unsigned notification mail could not be sent: ' . $e->getMessage());
+			throw new LibresignException('Notify unsigned notification mail could not be sent', 1);
+		}
+	}
+
+	/**
+	 * Sends a signature request notification using the strategy configured in
+	 * the mail_sender_strategy policy, falling back to the system mailer when
+	 * the requester mail account cannot be used.
+	 */
+	private function sendSignRequestNotification(IEMailTemplate $emailTemplate, SignRequest $data, string $email): void {
+		$requesterId = $this->getFileById($data->getFileId())->getUserId();
+		if ($this->resolveMailSenderStrategy($requesterId) === MailSenderStrategyPolicy::STRATEGY_REQUESTER
+			&& $this->sendAsRequester($emailTemplate, $data, $email, $requesterId)
+		) {
+			return;
+		}
+		$this->sendAsSystem($emailTemplate, $data, $email);
+	}
+
+	private function resolveMailSenderStrategy(string $requesterId): string {
+		return (string)$this->policyService
+			->resolveForUserId(MailSenderStrategyPolicy::KEY, $requesterId !== '' ? $requesterId : null)
+			->getEffectiveValue();
+	}
+
+	private function sendAsSystem(IEMailTemplate $emailTemplate, SignRequest $data, string $email): void {
 		$message = $this->mailer->createMessage();
 		if ($data->getDisplayName()) {
 			$message->setTo([$email => $data->getDisplayName()]);
@@ -114,12 +149,65 @@ class MailService {
 			$message->setTo([$email]);
 		}
 		$message->useTemplate($emailTemplate);
+		$this->mailer->send($message);
+	}
+
+	/**
+	 * @return bool true when the message was sent through the requester mail account
+	 */
+	private function sendAsRequester(IEMailTemplate $emailTemplate, SignRequest $data, string $email, string $requesterId): bool {
 		try {
-			$this->mailer->send($message);
-		} catch (\Exception $e) {
-			$this->logger->error('Notify unsigned notification mail could not be sent: ' . $e->getMessage());
-			throw new LibresignException('Notify unsigned notification mail could not be sent', 1);
+			$service = $this->findRequesterMailService($requesterId);
+			if ($service === null) {
+				return false;
+			}
+			$message = $service->initiateMessage()
+				->setFrom($service->getPrimaryAddress())
+				->setTo(new Address($email, $data->getDisplayName() ?: null))
+				->setSubject($emailTemplate->renderSubject())
+				->setBodyHtml($emailTemplate->renderHtml())
+				->setBodyPlain($emailTemplate->renderText());
+			$service->sendMessage($message);
+			return true;
+		} catch (\Throwable $e) {
+			$this->logger->warning('Unable to send the notification through the requester mail account, falling back to the system mailer.', [
+				'requester' => $requesterId,
+				'exception' => $e,
+			]);
+			return false;
 		}
+	}
+
+	private function findRequesterMailService(string $requesterId): (IService&IMessageSend)|null {
+		if ($requesterId === '' || !$this->mailProviderManager->has()) {
+			$this->logger->info('No mail provider is available to send the notification as the requester, falling back to the system mailer.', [
+				'requester' => $requesterId,
+			]);
+			return null;
+		}
+		$user = $this->userManager->get($requesterId);
+		if (!$user instanceof IUser) {
+			$this->logger->info('Requester account not found, falling back to the system mailer.', [
+				'requester' => $requesterId,
+			]);
+			return null;
+		}
+		$address = (string)$user->getEMailAddress();
+		$service = $address !== '' ? $this->mailProviderManager->findServiceByAddress($requesterId, $address) : null;
+		if ($service instanceof IMessageSend) {
+			return $service;
+		}
+		foreach ($this->mailProviderManager->services($requesterId) as $providerServices) {
+			foreach ($providerServices as $candidate) {
+				if ($candidate instanceof IMessageSend) {
+					return $candidate;
+				}
+			}
+		}
+		$this->logger->info('Requester has no mail account able to send messages, falling back to the system mailer.', [
+			'requester' => $requesterId,
+		]);
+		return null;
 	}
 
 	public function notifySignedUser(SignRequest $signRequest, string $email, File $libreSignFile, string $displayName): void {

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -222,14 +222,7 @@ class MailService {
 		if ($service instanceof IMessageSend) {
 			return $service;
 		}
-		foreach ($this->mailProviderManager->services($requesterId) as $providerServices) {
-			foreach ($providerServices as $candidate) {
-				if ($candidate instanceof IMessageSend) {
-					return $candidate;
-				}
-			}
-		}
-		$this->logger->info('Requester has no mail account able to send messages, falling back to the system mailer.', [
+		$this->logger->info('No mail account matching the requester email address can send messages, falling back to the system mailer.', [
 			'requester' => $requesterId,
 		]);
 		return null;

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -127,12 +127,32 @@ class MailService {
 	 */
 	private function sendSignRequestNotification(IEMailTemplate $emailTemplate, SignRequest $data, string $email): void {
 		$requesterId = $this->getFileById($data->getFileId())->getUserId();
-		if ($this->resolveMailSenderStrategy($requesterId) === MailSenderStrategyPolicy::STRATEGY_REQUESTER
-			&& $this->sendAsRequester($emailTemplate, $data, $email, $requesterId)
-		) {
+		if ($this->resolveMailSenderStrategy($requesterId) !== MailSenderStrategyPolicy::STRATEGY_REQUESTER) {
+			$this->sendAsSystem($emailTemplate, $data, $email);
 			return;
 		}
-		$this->sendAsSystem($emailTemplate, $data, $email);
+
+		$requester = $requesterId !== '' ? $this->userManager->get($requesterId) : null;
+		if ($this->sendAsRequester($emailTemplate, $data, $email, $requesterId, $requester)) {
+			return;
+		}
+		// Keep replies going to the person who requested the signature even
+		// when the message could not leave their own mail account.
+		$this->sendAsSystem($emailTemplate, $data, $email, $this->replyToAddress($requester));
+	}
+
+	/**
+	 * @return array<string, string>|null
+	 */
+	private function replyToAddress(?IUser $requester): ?array {
+		if (!$requester instanceof IUser) {
+			return null;
+		}
+		$address = (string)$requester->getEMailAddress();
+		if ($address === '') {
+			return null;
+		}
+		return [$address => $requester->getDisplayName()];
 	}
 
 	private function resolveMailSenderStrategy(string $requesterId): string {
@@ -141,12 +161,18 @@ class MailService {
 			->getEffectiveValue();
 	}
 
-	private function sendAsSystem(IEMailTemplate $emailTemplate, SignRequest $data, string $email): void {
+	/**
+	 * @param array<string, string>|null $replyTo
+	 */
+	private function sendAsSystem(IEMailTemplate $emailTemplate, SignRequest $data, string $email, ?array $replyTo = null): void {
 		$message = $this->mailer->createMessage();
 		if ($data->getDisplayName()) {
 			$message->setTo([$email => $data->getDisplayName()]);
 		} else {
 			$message->setTo([$email]);
+		}
+		if ($replyTo !== null) {
+			$message->setReplyTo($replyTo);
 		}
 		$message->useTemplate($emailTemplate);
 		$this->mailer->send($message);
@@ -155,9 +181,9 @@ class MailService {
 	/**
 	 * @return bool true when the message was sent through the requester mail account
 	 */
-	private function sendAsRequester(IEMailTemplate $emailTemplate, SignRequest $data, string $email, string $requesterId): bool {
+	private function sendAsRequester(IEMailTemplate $emailTemplate, SignRequest $data, string $email, string $requesterId, ?IUser $requester): bool {
 		try {
-			$service = $this->findRequesterMailService($requesterId);
+			$service = $this->findRequesterMailService($requesterId, $requester);
 			if ($service === null) {
 				return false;
 			}
@@ -178,21 +204,20 @@ class MailService {
 		}
 	}
 
-	private function findRequesterMailService(string $requesterId): (IService&IMessageSend)|null {
+	private function findRequesterMailService(string $requesterId, ?IUser $requester): (IService&IMessageSend)|null {
 		if ($requesterId === '' || !$this->mailProviderManager->has()) {
 			$this->logger->info('No mail provider is available to send the notification as the requester, falling back to the system mailer.', [
 				'requester' => $requesterId,
 			]);
 			return null;
 		}
-		$user = $this->userManager->get($requesterId);
-		if (!$user instanceof IUser) {
+		if (!$requester instanceof IUser) {
 			$this->logger->info('Requester account not found, falling back to the system mailer.', [
 				'requester' => $requesterId,
 			]);
 			return null;
 		}
-		$address = (string)$user->getEMailAddress();
+		$address = (string)$requester->getEMailAddress();
 		$service = $address !== '' ? $this->mailProviderManager->findServiceByAddress($requesterId, $address) : null;
 		if ($service instanceof IMessageSend) {
 			return $service;

--- a/lib/Service/Policy/Contract/IPolicyDefinition.php
+++ b/lib/Service/Policy/Contract/IPolicyDefinition.php
@@ -38,6 +38,18 @@ interface IPolicyDefinition {
 
 	public function validateValue(mixed $value, PolicyContext $context): void;
 
+	/**
+	 * Validate a value that is about to be persisted (system, group or user
+	 * scope). Runs the regular validateValue() checks plus any constraint that
+	 * only makes sense at configuration time, such as requiring an external
+	 * capability to be available. Runtime resolution keeps using
+	 * validateValue() so already stored values are not silently discarded
+	 * when the environment changes later.
+	 *
+	 * @throws \InvalidArgumentException when the value must not be saved
+	 */
+	public function validateValueForPersistence(mixed $value, PolicyContext $context): void;
+
 	/** @return list<mixed> */
 	public function allowedValues(PolicyContext $context): array;
 

--- a/lib/Service/Policy/Model/PolicySpec.php
+++ b/lib/Service/Policy/Model/PolicySpec.php
@@ -26,6 +26,8 @@ final class PolicySpec implements IPolicyDefinition {
 	private ?Closure $normalizer;
 	/** @var Closure(mixed, PolicyContext): void|null */
 	private ?Closure $validator;
+	/** @var Closure(mixed, PolicyContext): void|null */
+	private ?Closure $persistenceValidator;
 	/** @var array<string, mixed>|Closure(PolicyContext): array<string, mixed> */
 	private array|Closure $resolvedStateMetaResolver;
 	/** @var Closure(PolicyContext, ?PolicyLayer): bool|null */
@@ -41,6 +43,7 @@ final class PolicySpec implements IPolicyDefinition {
 	 * @param list<mixed>|Closure(PolicyContext): list<mixed> $allowedValues
 	 * @param Closure(mixed): mixed|null $normalizer
 	 * @param Closure(mixed, PolicyContext): void|null $validator
+	 * @param Closure(mixed, PolicyContext): void|null $persistenceValidator Extra checks applied only when a value is saved
 	 * @param array<string, mixed>|Closure(PolicyContext): array<string, mixed> $resolvedStateMeta
 	 * @param Closure(mixed, mixed, PolicyContext): void|null $delegatedValueValidator
 	 * @param Closure(PolicyContext, ?PolicyLayer): bool|null $visibleGroupCountFilter
@@ -69,10 +72,12 @@ final class PolicySpec implements IPolicyDefinition {
 		private bool $helper = false,
 		private ?string $parentPolicyKey = null,
 		private array $compositeChildren = [],
+		?Closure $persistenceValidator = null,
 	) {
 		$this->allowedValuesResolver = $allowedValues;
 		$this->normalizer = $normalizer;
 		$this->validator = $validator;
+		$this->persistenceValidator = $persistenceValidator;
 		$this->resolvedStateMetaResolver = $resolvedStateMeta;
 		$this->visibleGroupCountFilterResolver = $visibleGroupCountFilter;
 		$this->groupPolicyManagerResolver = $groupPolicyManager;
@@ -155,6 +160,14 @@ final class PolicySpec implements IPolicyDefinition {
 
 		if (!in_array($value, $this->allowedValues($context), true)) {
 			throw new \InvalidArgumentException(sprintf('Invalid value for %s', $this->key()));
+		}
+	}
+
+	#[\Override]
+	public function validateValueForPersistence(mixed $value, PolicyContext $context): void {
+		$this->validateValue($value, $context);
+		if ($this->persistenceValidator !== null) {
+			($this->persistenceValidator)($value, $context);
 		}
 	}
 

--- a/lib/Service/Policy/PolicyService.php
+++ b/lib/Service/Policy/PolicyService.php
@@ -144,7 +144,7 @@ class PolicyService {
 			? $definition->normalizeValue($definition->defaultSystemValue())
 			: $definition->normalizeValue($value);
 
-		$definition->validateValue($normalizedValue, $context);
+		$definition->validateValueForPersistence($normalizedValue, $context);
 		$this->source->saveSystemPolicy($definition->key(), $normalizedValue, $allowChildOverride);
 
 		return $this->resolver->resolve(
@@ -233,7 +233,7 @@ class PolicyService {
 		$this->assertCurrentActorCanManageGroupPolicy($definition->key(), $context);
 		$this->assertCurrentActorCanEditGroupPolicy($definition->key(), $groupId, $context);
 		$normalizedValue = $definition->normalizeValue($value);
-		$definition->validateValue($normalizedValue, $context);
+		$definition->validateValueForPersistence($normalizedValue, $context);
 		$createdBySystemAdmin = $context->getActorRole()->canManageSystemPolicies;
 		$this->source->saveGroupPolicy(
 			$definition->key(),
@@ -419,7 +419,7 @@ class PolicyService {
 		$definition = $this->registry->get($policyKey);
 		$this->assertScopeSupported($definition, PolicySpec::SCOPE_USER);
 		$normalizedValue = $definition->normalizeValue($value);
-		$definition->validateValue($normalizedValue, $context);
+		$definition->validateValueForPersistence($normalizedValue, $context);
 		$resolved = $this->resolver->resolve($definition, $context);
 		if (!$resolved->canSaveAsUserDefault()) {
 			// TRANSLATORS Error shown when saving a user preference for a policy that does not allow personal overrides. {policyKey} is the policy identifier.
@@ -447,7 +447,7 @@ class PolicyService {
 		$definition = $this->registry->get($policyKey);
 		$this->assertScopeSupported($definition, PolicySpec::SCOPE_USER);
 		$normalizedValue = $definition->normalizeValue($value);
-		$definition->validateValue($normalizedValue, $context);
+		$definition->validateValueForPersistence($normalizedValue, $context);
 		$this->source->saveUserPolicy($definition->key(), $context, $normalizedValue, $allowChildOverride);
 
 		return $this->source->loadUserPolicy($definition->key(), $context)

--- a/lib/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicy.php
+++ b/lib/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicy.php
@@ -12,6 +12,7 @@ use OCA\Libresign\Service\Policy\Contract\IPolicyDefinition;
 use OCA\Libresign\Service\Policy\Contract\IPolicyDefinitionProvider;
 use OCA\Libresign\Service\Policy\Model\PolicySpec;
 use OCA\Libresign\Service\Policy\Provider\Helper\PolicyKeyNormalizer;
+use OCP\Mail\Provider\IManager as IMailProviderManager;
 
 /**
  * Controls which mail account LibreSign uses to send signature request
@@ -28,6 +29,11 @@ final class MailSenderStrategyPolicy implements IPolicyDefinitionProvider {
 		self::STRATEGY_SYSTEM,
 		self::STRATEGY_REQUESTER,
 	];
+
+	public function __construct(
+		private IMailProviderManager $mailProviderManager,
+	) {
+	}
 
 	#[\Override]
 	public function keys(): array {
@@ -51,7 +57,19 @@ final class MailSenderStrategyPolicy implements IPolicyDefinitionProvider {
 				},
 				appConfigKey: self::SYSTEM_APP_CONFIG_KEY,
 				supportsUserPreference: false,
+				resolvedStateMeta: fn (): array => [
+					'mailProviderAvailable' => $this->mailProviderManager->has(),
+				],
 				supportedScopes: [PolicySpec::SCOPE_SYSTEM],
+				// The requester strategy can only be configured while a mail provider
+				// is available. Once stored, runtime resolution keeps the value and
+				// MailService falls back to the system mailer when the environment
+				// changes later (provider removed, account deleted, sending failure).
+				persistenceValidator: function (mixed $value): void {
+					if ($value === self::STRATEGY_REQUESTER && !$this->mailProviderManager->has()) {
+						throw new \InvalidArgumentException('The requester strategy requires an available mail provider');
+					}
+				},
 			),
 			default => throw new \InvalidArgumentException('Unknown policy key: ' . PolicyKeyNormalizer::normalize($policyKey)),
 		};

--- a/lib/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicy.php
+++ b/lib/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Service\Policy\Provider\MailSenderStrategy;
+
+use OCA\Libresign\Service\Policy\Contract\IPolicyDefinition;
+use OCA\Libresign\Service\Policy\Contract\IPolicyDefinitionProvider;
+use OCA\Libresign\Service\Policy\Model\PolicySpec;
+use OCA\Libresign\Service\Policy\Provider\Helper\PolicyKeyNormalizer;
+
+/**
+ * Controls which mail account LibreSign uses to send signature request
+ * notifications: the system mailer or the account of the requester.
+ */
+final class MailSenderStrategyPolicy implements IPolicyDefinitionProvider {
+	public const KEY = 'mail_sender_strategy';
+	public const SYSTEM_APP_CONFIG_KEY = self::KEY;
+
+	public const STRATEGY_SYSTEM = 'system';
+	public const STRATEGY_REQUESTER = 'requester';
+
+	private const STRATEGIES = [
+		self::STRATEGY_SYSTEM,
+		self::STRATEGY_REQUESTER,
+	];
+
+	#[\Override]
+	public function keys(): array {
+		return [
+			self::KEY,
+		];
+	}
+
+	#[\Override]
+	public function get(string|\BackedEnum $policyKey): IPolicyDefinition {
+		return match (PolicyKeyNormalizer::normalize($policyKey)) {
+			self::KEY => new PolicySpec(
+				key: self::KEY,
+				defaultSystemValue: self::STRATEGY_SYSTEM,
+				allowedValues: self::STRATEGIES,
+				normalizer: static fn (mixed $rawValue): string => strtolower(trim((string)$rawValue)),
+				validator: static function (mixed $value): void {
+					if (!is_string($value) || !in_array($value, self::STRATEGIES, true)) {
+						throw new \InvalidArgumentException('Invalid value for ' . self::KEY);
+					}
+				},
+				appConfigKey: self::SYSTEM_APP_CONFIG_KEY,
+				supportsUserPreference: false,
+				supportedScopes: [PolicySpec::SCOPE_SYSTEM],
+			),
+			default => throw new \InvalidArgumentException('Unknown policy key: ' . PolicyKeyNormalizer::normalize($policyKey)),
+		};
+	}
+}

--- a/lib/Service/Policy/Provider/PolicyProviders.php
+++ b/lib/Service/Policy/Provider/PolicyProviders.php
@@ -20,6 +20,7 @@ use OCA\Libresign\Service\Policy\Provider\Footer\FooterPolicy;
 use OCA\Libresign\Service\Policy\Provider\IdentificationDocuments\IdentificationDocumentsPolicy;
 use OCA\Libresign\Service\Policy\Provider\IdentifyMethods\IdentifyMethodsPolicy;
 use OCA\Libresign\Service\Policy\Provider\LegalInformation\LegalInformationPolicy;
+use OCA\Libresign\Service\Policy\Provider\MailSenderStrategy\MailSenderStrategyPolicy;
 use OCA\Libresign\Service\Policy\Provider\Reminder\ReminderPolicy;
 use OCA\Libresign\Service\Policy\Provider\RequestSignGroups\RequestSignGroupsPolicy;
 use OCA\Libresign\Service\Policy\Provider\Signature\SignatureFlowPolicy;
@@ -47,6 +48,7 @@ final class PolicyProviders {
 		ReminderPolicy::KEY => ReminderPolicy::class,
 		DefaultUserFolderPolicy::KEY => DefaultUserFolderPolicy::class,
 		LegalInformationPolicy::KEY => LegalInformationPolicy::class,
+		MailSenderStrategyPolicy::KEY => MailSenderStrategyPolicy::class,
 		SignatureHashAlgorithmPolicy::KEY => SignatureHashAlgorithmPolicy::class,
 		ValidationAccessPolicy::KEY => ValidationAccessPolicy::class,
 		SignatureFlowPolicy::KEY => SignatureFlowPolicy::class,

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -447,6 +447,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "mailProviderAvailable": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1044,6 +1044,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "mailProviderAvailable": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -677,6 +677,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "mailProviderAvailable": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.spec.ts
@@ -13,8 +13,8 @@ vi.mock('@nextcloud/l10n', () => createL10nMock())
 
 const NcCheckboxRadioSwitchStub = {
 	name: 'NcCheckboxRadioSwitch',
-	props: ['modelValue', 'type', 'name'],
-	template: '<button class="radio-stub" :data-checked="modelValue" @click="$emit(\'update:modelValue\', true)"><slot /></button>',
+	props: ['modelValue', 'type', 'name', 'disabled'],
+	template: '<button class="radio-stub" :data-checked="modelValue" :data-disabled="disabled" @click="$emit(\'update:modelValue\', true)"><slot /></button>',
 	emits: ['update:modelValue'],
 }
 
@@ -24,10 +24,11 @@ const NcCheckboxRadioSwitchStub = {
  * @param modelValue Effective policy value passed to the editor
  * @param stub Stub used for NcCheckboxRadioSwitch
  */
-function mountEditor(modelValue: unknown, stub = NcCheckboxRadioSwitchStub) {
+function mountEditor(modelValue: unknown, stub = NcCheckboxRadioSwitchStub, extraProps: Record<string, unknown> = {}) {
 	return mount(MailSenderStrategyRuleEditor, {
 		props: {
 			modelValue: modelValue as never,
+			...extraProps,
 		},
 		global: {
 			stubs: {
@@ -49,6 +50,18 @@ describe('MailSenderStrategyRuleEditor.vue', () => {
 		expect(wrapper.text()).toContain('when the account cannot be used, the system mailer is used instead')
 		expect(options[0]?.attributes('data-checked')).toBe('true')
 		expect(options[1]?.attributes('data-checked')).toBe('false')
+		expect(options[0]?.attributes('data-disabled')).toBe('false')
+		expect(options[1]?.attributes('data-disabled')).toBe('false')
+		expect(wrapper.text()).not.toContain('No mail provider is available on this instance')
+	})
+
+	it('disables the requester option with a hint when no mail provider is available', () => {
+		const wrapper = mountEditor('system', NcCheckboxRadioSwitchStub, { mailProviderAvailable: false })
+
+		const options = wrapper.findAll('.radio-stub')
+		expect(options[0]?.attributes('data-disabled')).toBe('false')
+		expect(options[1]?.attributes('data-disabled')).toBe('true')
+		expect(wrapper.text()).toContain('No mail provider is available on this instance, so this option cannot be selected.')
 	})
 
 	it('marks the requester option when the model value is requester, even with different casing', () => {

--- a/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createL10nMock } from '../../../../../testHelpers/l10n.js'
+import MailSenderStrategyRuleEditor from '../../../../../../views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.vue'
+
+vi.mock('@nextcloud/l10n', () => createL10nMock())
+
+const NcCheckboxRadioSwitchStub = {
+	name: 'NcCheckboxRadioSwitch',
+	props: ['modelValue', 'type', 'name'],
+	template: '<button class="radio-stub" :data-checked="modelValue" @click="$emit(\'update:modelValue\', true)"><slot /></button>',
+	emits: ['update:modelValue'],
+}
+
+/**
+ * Mounts the editor with the given model value and radio stub.
+ *
+ * @param modelValue Effective policy value passed to the editor
+ * @param stub Stub used for NcCheckboxRadioSwitch
+ */
+function mountEditor(modelValue: unknown, stub = NcCheckboxRadioSwitchStub) {
+	return mount(MailSenderStrategyRuleEditor, {
+		props: {
+			modelValue: modelValue as never,
+		},
+		global: {
+			stubs: {
+				NcCheckboxRadioSwitch: stub,
+			},
+		},
+	})
+}
+
+describe('MailSenderStrategyRuleEditor.vue', () => {
+	it('renders the system mailer and requester options', () => {
+		const wrapper = mountEditor('system')
+
+		const options = wrapper.findAll('.radio-stub')
+		expect(options).toHaveLength(2)
+		expect(wrapper.text()).toContain('System mailer')
+		expect(wrapper.text()).toContain('Requester mail account')
+		expect(wrapper.text()).toContain('Send notifications from the email address configured for this Nextcloud instance.')
+		expect(wrapper.text()).toContain('when the account cannot be used, the system mailer is used instead')
+		expect(options[0]?.attributes('data-checked')).toBe('true')
+		expect(options[1]?.attributes('data-checked')).toBe('false')
+	})
+
+	it('marks the requester option when the model value is requester, even with different casing', () => {
+		const wrapper = mountEditor(' Requester ')
+
+		const options = wrapper.findAll('.radio-stub')
+		expect(options[0]?.attributes('data-checked')).toBe('false')
+		expect(options[1]?.attributes('data-checked')).toBe('true')
+	})
+
+	it('falls back to the system mailer for unknown model values', () => {
+		const wrapper = mountEditor(null)
+
+		expect(wrapper.findAll('.radio-stub')[0]?.attributes('data-checked')).toBe('true')
+	})
+
+	it('emits the selected strategy', async () => {
+		const wrapper = mountEditor('system')
+
+		await wrapper.findAll('.radio-stub')[1]?.trigger('click')
+		expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toBe('requester')
+
+		await wrapper.findAll('.radio-stub')[0]?.trigger('click')
+		expect(wrapper.emitted('update:modelValue')?.[1]?.[0]).toBe('system')
+	})
+
+	it('ignores deselection events from the radio control', async () => {
+		const wrapper = mountEditor('requester', {
+			...NcCheckboxRadioSwitchStub,
+			template: '<button class="radio-stub" @click="$emit(\'update:modelValue\', false)"><slot /></button>',
+		})
+
+		await wrapper.findAll('.radio-stub')[1]?.trigger('click')
+		expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+	})
+})

--- a/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/model.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/model.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+	DEFAULT_MAIL_SENDER_STRATEGY,
+	MAIL_SENDER_STRATEGIES,
+	isMailSenderStrategy,
+	normalizeMailSenderStrategy,
+} from '../../../../../../views/Settings/PolicyWorkbench/settings/mail-sender-strategy/model'
+
+describe('mail-sender-strategy model', () => {
+	it('exposes the supported strategies and defaults to the system mailer', () => {
+		expect(MAIL_SENDER_STRATEGIES).toEqual(['system', 'requester'])
+		expect(DEFAULT_MAIL_SENDER_STRATEGY).toBe('system')
+	})
+
+	it.each([
+		['system', true],
+		['requester', true],
+		['user_choice', false],
+		['', false],
+		[null, false],
+		[true, false],
+	])('recognizes %s as a strategy: %s', (value, expected) => {
+		expect(isMailSenderStrategy(value)).toBe(expected)
+	})
+
+	it.each([
+		['system', 'system'],
+		['requester', 'requester'],
+		['  REQUESTER ', 'requester'],
+		['System', 'system'],
+		['user_choice', 'system'],
+		['', 'system'],
+		[null, 'system'],
+		[undefined, 'system'],
+		[true, 'system'],
+		[{ strategy: 'requester' }, 'system'],
+	])('normalizes %s to %s', (value, expected) => {
+		expect(normalizeMailSenderStrategy(value as never)).toBe(expected)
+	})
+})

--- a/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@nextcloud/l10n', () => ({
+	t: (_app: string, text: string) => text,
+	getLanguage: () => 'en',
+	isRTL: () => false,
+}))
+
+import { mailSenderStrategyRealDefinition } from '../../../../../../views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition'
+
+describe('mailSenderStrategyRealDefinition', () => {
+	it('registers the policy key and copy', () => {
+		expect(mailSenderStrategyRealDefinition.key).toBe('mail_sender_strategy')
+		expect(mailSenderStrategyRealDefinition.title).toBe('Notification email sender')
+		expect(mailSenderStrategyRealDefinition.description).toContain('system mailer')
+	})
+
+	it('supports only the system scope and hides the workbench card for group admins', () => {
+		expect(mailSenderStrategyRealDefinition.supportedScopes).toEqual(['system'])
+		expect(mailSenderStrategyRealDefinition.groupAdminBehavior?.canRenderPolicy?.({
+			editableByCurrentActor: false,
+			canSaveAsUserDefault: false,
+			meta: { canCreateDescendantRules: false },
+		} as never)).toBe(false)
+	})
+
+	it('starts from the system mailer and always offers a selectable draft value', () => {
+		expect(mailSenderStrategyRealDefinition.createEmptyValue()).toBe('system')
+		expect(mailSenderStrategyRealDefinition.hasSelectableDraftValue('system')).toBe(true)
+		expect(mailSenderStrategyRealDefinition.hasSelectableDraftValue('requester')).toBe(true)
+	})
+
+	it('normalizes draft values to a known strategy', () => {
+		expect(mailSenderStrategyRealDefinition.normalizeDraftValue('requester')).toBe('requester')
+		expect(mailSenderStrategyRealDefinition.normalizeDraftValue(' System ')).toBe('system')
+		expect(mailSenderStrategyRealDefinition.normalizeDraftValue('unknown')).toBe('system')
+		expect(mailSenderStrategyRealDefinition.normalizeDraftValue(null)).toBe('system')
+	})
+
+	it('disables child-override toggles for every scope', () => {
+		expect(mailSenderStrategyRealDefinition.normalizeAllowChildOverride('system', true)).toBe(false)
+		expect(mailSenderStrategyRealDefinition.normalizeAllowChildOverride('system', false)).toBe(false)
+		expect(mailSenderStrategyRealDefinition.normalizeAllowChildOverride('group', true)).toBe(false)
+	})
+
+	it('falls back to the persisted system value only when it comes from the system scope', () => {
+		expect(mailSenderStrategyRealDefinition.getFallbackSystemDefault('requester', 'system')).toBe('requester')
+		expect(mailSenderStrategyRealDefinition.getFallbackSystemDefault('REQUESTER', 'system')).toBe('requester')
+		expect(mailSenderStrategyRealDefinition.getFallbackSystemDefault('requester', 'group')).toBe('system')
+		expect(mailSenderStrategyRealDefinition.getFallbackSystemDefault(null, 'system')).toBe('system')
+		expect(mailSenderStrategyRealDefinition.getFallbackSystemDefault(undefined, null)).toBe('system')
+	})
+
+	it('summarizes each strategy with a human readable label', () => {
+		expect(mailSenderStrategyRealDefinition.summarizeValue('system')).toBe('System mailer')
+		expect(mailSenderStrategyRealDefinition.summarizeValue('requester')).toBe('Requester mail account')
+		expect(mailSenderStrategyRealDefinition.summarizeValue('unknown')).toBe('System mailer')
+	})
+
+	it('explains that lower scopes cannot customize the setting', () => {
+		expect(mailSenderStrategyRealDefinition.formatAllowOverride(true)).toBe('Lower-level customization is disabled for this setting')
+		expect(mailSenderStrategyRealDefinition.formatAllowOverride(false)).toBe('Lower-level customization is disabled for this setting')
+	})
+})

--- a/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.spec.ts
@@ -66,4 +66,12 @@ describe('mailSenderStrategyRealDefinition', () => {
 		expect(mailSenderStrategyRealDefinition.formatAllowOverride(true)).toBe('Lower-level customization is disabled for this setting')
 		expect(mailSenderStrategyRealDefinition.formatAllowOverride(false)).toBe('Lower-level customization is disabled for this setting')
 	})
+
+	it('passes the mail provider availability from the policy meta to the editor', () => {
+		const resolve = mailSenderStrategyRealDefinition.resolveEditorProps!
+		expect(resolve({ meta: { mailProviderAvailable: false } } as never, { foo: 'bar' })).toEqual({ foo: 'bar', mailProviderAvailable: false })
+		expect(resolve({ meta: { mailProviderAvailable: true } } as never, {})).toEqual({ mailProviderAvailable: true })
+		expect(resolve({ meta: {} } as never, {})).toEqual({ mailProviderAvailable: true })
+		expect(resolve(null, {})).toEqual({ mailProviderAvailable: true })
+	})
 })

--- a/src/tests/views/Settings/PolicyWorkbench/settings/realDefinitions.spec.ts
+++ b/src/tests/views/Settings/PolicyWorkbench/settings/realDefinitions.spec.ts
@@ -34,6 +34,7 @@ const expectedTopLevelKeys = [
 	'default_user_folder',
 	'make_validation_url_private',
 	'signing_mode',
+	'mail_sender_strategy',
 ] as const
 
 describe('realDefinitions', () => {
@@ -61,5 +62,6 @@ describe('realDefinitions', () => {
 		expect(realDefinitions.legal_information.category).toBe('what-gets-recorded')
 		expect(realDefinitions.docmdp.category).toBe('trust-and-verification')
 		expect(realDefinitions.signing_mode.category).toBe('system-behavior')
+		expect(realDefinitions.mail_sender_strategy.category).toBe('system-behavior')
 	})
 })

--- a/src/types/openapi/openapi-administration.ts
+++ b/src/types/openapi/openapi-administration.ts
@@ -401,6 +401,7 @@ export type components = {
             helper?: boolean;
             parentPolicyKey?: string;
             compositeChildren?: string[];
+            mailProviderAvailable?: boolean;
         };
         EffectivePolicyResponse: {
             policy: components["schemas"]["EffectivePolicyState"];

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1458,6 +1458,7 @@ export type components = {
             helper?: boolean;
             parentPolicyKey?: string;
             compositeChildren?: string[];
+            mailProviderAvailable?: boolean;
         };
         EffectivePolicyResponse: {
             policy: components["schemas"]["EffectivePolicyState"];

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1086,6 +1086,7 @@ export type components = {
             helper?: boolean;
             parentPolicyKey?: string;
             compositeChildren?: string[];
+            mailProviderAvailable?: boolean;
         };
         EffectivePolicyResponse: {
             policy: components["schemas"]["EffectivePolicyState"];

--- a/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.vue
+++ b/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.vue
@@ -1,0 +1,93 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="mail-sender-strategy-rule-editor">
+		<NcCheckboxRadioSwitch
+			v-for="option in options"
+			:key="option.value"
+			type="radio"
+			:model-value="selected === option.value"
+			name="mail-sender-strategy-rule-editor"
+			class="mail-sender-strategy-rule-editor__option"
+			@update:modelValue="onChange(option.value, $event)">
+			<div class="mail-sender-strategy-rule-editor__copy">
+				<strong>{{ option.label }}</strong>
+				<p>{{ option.description }}</p>
+			</div>
+		</NcCheckboxRadioSwitch>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { t } from '@nextcloud/l10n'
+
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+
+import type { EffectivePolicyValue } from '../../../../../types/index'
+import { normalizeMailSenderStrategy, type MailSenderStrategy } from './model'
+
+defineOptions({
+	name: 'MailSenderStrategyRuleEditor',
+})
+
+const props = defineProps<{
+	modelValue: EffectivePolicyValue
+}>()
+
+const emit = defineEmits<{
+	'update:modelValue': [value: EffectivePolicyValue]
+}>()
+
+const selected = computed(() => normalizeMailSenderStrategy(props.modelValue))
+
+const options: Array<{ value: MailSenderStrategy, label: string, description: string }> = [
+	{
+		value: 'system',
+		// TRANSLATORS Option label meaning notification emails are sent by the Nextcloud system mailer.
+		label: t('libresign', 'System mailer'),
+		// TRANSLATORS Option description for sending notification emails from the address configured for the Nextcloud instance.
+		description: t('libresign', 'Send notifications from the email address configured for this Nextcloud instance.'),
+	},
+	{
+		value: 'requester',
+		// TRANSLATORS Option label meaning notification emails are sent from the mail account of the person who requested the signature.
+		label: t('libresign', 'Requester mail account'),
+		// TRANSLATORS Option description for sending notification emails through the requester mail account, with automatic fallback to the system mailer.
+		description: t('libresign', 'Try to send notifications from the mail account of the person who requested the signature. This requires a mail provider such as the Mail app; when the account cannot be used, the system mailer is used instead.'),
+	},
+]
+
+function onChange(nextValue: MailSenderStrategy, selectedOption?: unknown): void {
+	if (selectedOption === false) {
+		return
+	}
+
+	emit('update:modelValue', nextValue)
+}
+</script>
+
+<style scoped lang="scss">
+.mail-sender-strategy-rule-editor {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+
+	&__copy p {
+		margin: 0.35rem 0 0;
+		color: var(--color-text-maxcontrast);
+	}
+
+	:deep(.mail-sender-strategy-rule-editor__option.checkbox-radio-switch) {
+		width: 100%;
+	}
+
+	:deep(.mail-sender-strategy-rule-editor__option .checkbox-radio-switch__content) {
+		width: 100%;
+		max-width: none;
+	}
+}
+</style>

--- a/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.vue
+++ b/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/MailSenderStrategyRuleEditor.vue
@@ -10,12 +10,16 @@
 			:key="option.value"
 			type="radio"
 			:model-value="selected === option.value"
+			:disabled="option.disabled"
 			name="mail-sender-strategy-rule-editor"
 			class="mail-sender-strategy-rule-editor__option"
 			@update:modelValue="onChange(option.value, $event)">
 			<div class="mail-sender-strategy-rule-editor__copy">
 				<strong>{{ option.label }}</strong>
 				<p>{{ option.description }}</p>
+				<p v-if="option.disabled" class="mail-sender-strategy-rule-editor__hint">
+					{{ unavailableHint }}
+				</p>
 			</div>
 		</NcCheckboxRadioSwitch>
 	</div>
@@ -34,9 +38,12 @@ defineOptions({
 	name: 'MailSenderStrategyRuleEditor',
 })
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
 	modelValue: EffectivePolicyValue
-}>()
+	mailProviderAvailable?: boolean
+}>(), {
+	mailProviderAvailable: true,
+})
 
 const emit = defineEmits<{
 	'update:modelValue': [value: EffectivePolicyValue]
@@ -44,9 +51,13 @@ const emit = defineEmits<{
 
 const selected = computed(() => normalizeMailSenderStrategy(props.modelValue))
 
-const options: Array<{ value: MailSenderStrategy, label: string, description: string }> = [
+// TRANSLATORS Hint shown under the requester option when no mail provider (for example the Mail app) is available on the instance.
+const unavailableHint = t('libresign', 'No mail provider is available on this instance, so this option cannot be selected.')
+
+const options = computed((): Array<{ value: MailSenderStrategy, label: string, description: string, disabled: boolean }> => [
 	{
 		value: 'system',
+		disabled: false,
 		// TRANSLATORS Option label meaning notification emails are sent by the Nextcloud system mailer.
 		label: t('libresign', 'System mailer'),
 		// TRANSLATORS Option description for sending notification emails from the address configured for the Nextcloud instance.
@@ -54,12 +65,13 @@ const options: Array<{ value: MailSenderStrategy, label: string, description: st
 	},
 	{
 		value: 'requester',
+		disabled: !props.mailProviderAvailable,
 		// TRANSLATORS Option label meaning notification emails are sent from the mail account of the person who requested the signature.
 		label: t('libresign', 'Requester mail account'),
 		// TRANSLATORS Option description for sending notification emails through the requester mail account, with automatic fallback to the system mailer.
 		description: t('libresign', 'Try to send notifications from the mail account of the person who requested the signature. This requires a mail provider such as the Mail app; when the account cannot be used, the system mailer is used instead.'),
 	},
-]
+])
 
 function onChange(nextValue: MailSenderStrategy, selectedOption?: unknown): void {
 	if (selectedOption === false) {
@@ -79,6 +91,10 @@ function onChange(nextValue: MailSenderStrategy, selectedOption?: unknown): void
 	&__copy p {
 		margin: 0.35rem 0 0;
 		color: var(--color-text-maxcontrast);
+	}
+
+	&__hint {
+		font-weight: bold;
 	}
 
 	:deep(.mail-sender-strategy-rule-editor__option.checkbox-radio-switch) {

--- a/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/model.ts
+++ b/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/model.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and LibreCode contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { EffectivePolicyValue } from '../../../../../types/index'
+
+export const MAIL_SENDER_STRATEGIES = ['system', 'requester'] as const
+export type MailSenderStrategy = typeof MAIL_SENDER_STRATEGIES[number]
+
+export const DEFAULT_MAIL_SENDER_STRATEGY: MailSenderStrategy = 'system'
+
+/**
+ * Type guard for the values accepted by the mail_sender_strategy policy.
+ *
+ * @param value Candidate value
+ */
+export function isMailSenderStrategy(value: unknown): value is MailSenderStrategy {
+	return MAIL_SENDER_STRATEGIES.includes(value as MailSenderStrategy)
+}
+
+/**
+ * Normalizes any effective policy value to a known strategy, defaulting to the system mailer.
+ *
+ * @param value Effective policy value coming from the backend or the editor
+ */
+export function normalizeMailSenderStrategy(value: EffectivePolicyValue): MailSenderStrategy {
+	if (typeof value === 'string') {
+		const normalized = value.trim().toLowerCase()
+		if (isMailSenderStrategy(normalized)) {
+			return normalized
+		}
+	}
+
+	return DEFAULT_MAIL_SENDER_STRATEGY
+}

--- a/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.ts
+++ b/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and LibreCode contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+
+import MailSenderStrategyRuleEditor from './MailSenderStrategyRuleEditor.vue'
+
+import type { EffectivePolicyValue } from '../../../../../types/index'
+import type { RealPolicySettingDefinition } from '../realTypes'
+import { DEFAULT_MAIL_SENDER_STRATEGY, normalizeMailSenderStrategy } from './model'
+
+export const mailSenderStrategyRealDefinition: RealPolicySettingDefinition = {
+	key: 'mail_sender_strategy',
+	// TRANSLATORS Policy title controlling which mail account sends signature request notification emails.
+	title: t('libresign', 'Notification email sender'),
+	// TRANSLATORS Policy description for choosing between the system mailer and the mail account of the person who requested the signature.
+	description: t('libresign', 'Choose whether signature request emails are sent by the system mailer or by the mail account of the person who requested the signature.'),
+	supportedScopes: ['system'],
+	groupAdminBehavior: {
+		canRenderPolicy: () => false,
+	},
+	editor: MailSenderStrategyRuleEditor,
+	createEmptyValue: () => DEFAULT_MAIL_SENDER_STRATEGY,
+	normalizeDraftValue: (value: EffectivePolicyValue) => normalizeMailSenderStrategy(value),
+	hasSelectableDraftValue: () => true,
+	normalizeAllowChildOverride: () => false,
+	getFallbackSystemDefault: (policyValue: EffectivePolicyValue | null | undefined, sourceScope?: string | null) => {
+		if (sourceScope === 'system' && policyValue !== null && policyValue !== undefined) {
+			return normalizeMailSenderStrategy(policyValue)
+		}
+
+		return DEFAULT_MAIL_SENDER_STRATEGY
+	},
+	summarizeValue: (value: EffectivePolicyValue) => {
+		if (normalizeMailSenderStrategy(value) === 'requester') {
+			// TRANSLATORS Policy summary meaning notification emails are sent from the mail account of the person who requested the signature.
+			return t('libresign', 'Requester mail account')
+		}
+
+		// TRANSLATORS Policy summary meaning notification emails are sent by the Nextcloud system mailer.
+		return t('libresign', 'System mailer')
+	},
+	formatAllowOverride: () =>
+		// TRANSLATORS Policy inheritance message indicating group and user scopes cannot override this setting.
+		t('libresign', 'Lower-level customization is disabled for this setting'),
+}

--- a/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.ts
+++ b/src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/realDefinition.ts
@@ -8,7 +8,7 @@ import { t } from '@nextcloud/l10n'
 import MailSenderStrategyRuleEditor from './MailSenderStrategyRuleEditor.vue'
 
 import type { EffectivePolicyValue } from '../../../../../types/index'
-import type { RealPolicySettingDefinition } from '../realTypes'
+import type { EffectivePolicyState, RealPolicySettingDefinition } from '../realTypes'
 import { DEFAULT_MAIL_SENDER_STRATEGY, normalizeMailSenderStrategy } from './model'
 
 export const mailSenderStrategyRealDefinition: RealPolicySettingDefinition = {
@@ -22,6 +22,10 @@ export const mailSenderStrategyRealDefinition: RealPolicySettingDefinition = {
 		canRenderPolicy: () => false,
 	},
 	editor: MailSenderStrategyRuleEditor,
+	resolveEditorProps: (policy: EffectivePolicyState | null, baseEditorProps: Record<string, unknown>) => ({
+		...baseEditorProps,
+		mailProviderAvailable: policy?.meta?.mailProviderAvailable !== false,
+	}),
 	createEmptyValue: () => DEFAULT_MAIL_SENDER_STRATEGY,
 	normalizeDraftValue: (value: EffectivePolicyValue) => normalizeMailSenderStrategy(value),
 	hasSelectableDraftValue: () => true,

--- a/src/views/Settings/PolicyWorkbench/settings/realDefinitions.ts
+++ b/src/views/Settings/PolicyWorkbench/settings/realDefinitions.ts
@@ -16,6 +16,7 @@ import {
 import { identificationDocumentsRealDefinition } from './identification-documents/realDefinition'
 import { identifyMethodsRealDefinition } from './identify-methods/realDefinition'
 import { legalInformationRealDefinition } from './legal-information/realDefinition'
+import { mailSenderStrategyRealDefinition } from './mail-sender-strategy/realDefinition'
 import type { RealPolicySettingDefinition } from './realTypes'
 import { reminderRealDefinition } from './reminder/realDefinition'
 import { requestSignGroupsRealDefinition } from './request-sign-groups/realDefinition'
@@ -63,4 +64,5 @@ export const realDefinitions = {
 	default_user_folder: { ...defaultUserFolderRealDefinition, category: 'system-behavior' },
 	make_validation_url_private: { ...validationAccessRealDefinition, category: 'system-behavior' },
 	signing_mode: { ...signingModeRealDefinition, category: 'system-behavior' },
+	mail_sender_strategy: { ...mailSenderStrategyRealDefinition, category: 'system-behavior' },
 } satisfies Record<string, RealPolicySettingDefinition>

--- a/tests/php/Unit/Service/MailServiceTest.php
+++ b/tests/php/Unit/Service/MailServiceTest.php
@@ -23,6 +23,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
+use OCP\Mail\IMessage as ISystemMessage;
 use OCP\Mail\Provider\Address;
 use OCP\Mail\Provider\IManager as IMailProviderManager;
 use OCP\Mail\Provider\IMessage;
@@ -276,6 +277,55 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->willThrowException(new \RuntimeException('SMTP unavailable'));
 		$this->logger->expects($this->once())
 			->method('warning');
+		$systemMessage = $this->mockSystemMessage();
+		$systemMessage->expects($this->once())
+			->method('setReplyTo')
+			->with(['requester@domain.coop' => 'Requester Name']);
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($systemMessage);
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallbackSetsReplyToRequesterWhenNoProviderIsAvailable(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockRequesterAccount('requester@domain.coop', 'Requester Name');
+		$this->mailProviderManager->method('has')->willReturn(false);
+		$systemMessage = $this->mockSystemMessage();
+		$systemMessage->expects($this->once())
+			->method('setReplyTo')
+			->with(['requester@domain.coop' => 'Requester Name']);
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($systemMessage);
+
+		$this->service->notifySignDataUpdated($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallbackWithoutRequesterEmailDoesNotSetReplyTo(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockRequesterAccount('');
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->method('services')->willReturn([]);
+		$systemMessage = $this->mockSystemMessage();
+		$systemMessage->expects($this->never())
+			->method('setReplyTo');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testSystemStrategyDoesNotSetReplyTo(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_SYSTEM);
+		$this->mockRequesterAccount('requester@domain.coop');
+		$systemMessage = $this->mockSystemMessage();
+		$systemMessage->expects($this->never())
+			->method('setReplyTo');
 		$this->mailer->expects($this->once())
 			->method('send');
 
@@ -340,10 +390,17 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->mailer->method('createEMailTemplate')->willReturn($template);
 	}
 
-	private function mockRequesterAccount(string $email): void {
+	private function mockRequesterAccount(string $email, string $displayName = 'Requester Name'): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getEMailAddress')->willReturn($email);
+		$user->method('getDisplayName')->willReturn($displayName);
 		$this->userManager->method('get')->with('requester')->willReturn($user);
+	}
+
+	private function mockSystemMessage(): ISystemMessage&MockObject {
+		$message = $this->createMock(ISystemMessage::class);
+		$this->mailer->method('createMessage')->willReturn($message);
+		return $message;
 	}
 
 	/**

--- a/tests/php/Unit/Service/MailServiceTest.php
+++ b/tests/php/Unit/Service/MailServiceTest.php
@@ -11,11 +11,24 @@ namespace OCA\Libresign\Tests\Unit\Service;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Db\SignRequest;
+use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\MailService;
+use OCA\Libresign\Service\Policy\Model\ResolvedPolicy;
+use OCA\Libresign\Service\Policy\PolicyService;
+use OCA\Libresign\Service\Policy\Provider\MailSenderStrategy\MailSenderStrategyPolicy;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
+use OCP\Mail\Provider\Address;
+use OCP\Mail\Provider\IManager as IMailProviderManager;
+use OCP\Mail\Provider\IMessage;
+use OCP\Mail\Provider\IMessageSend;
+use OCP\Mail\Provider\IService;
+use OCP\Mail\Provider\Message;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -29,6 +42,9 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IL10N&MockObject $l10n;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IAppConfig&MockObject $appConfig;
+	private PolicyService&MockObject $policyService;
+	private IMailProviderManager&MockObject $mailProviderManager;
+	private IUserManager&MockObject $userManager;
 	private MailService $service;
 
 	public function setUp(): void {
@@ -42,75 +58,301 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->willReturnArgument(0);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->policyService = $this->createMock(PolicyService::class);
+		$this->mailProviderManager = $this->createMock(IMailProviderManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->service = new MailService(
 			$this->logger,
 			$this->mailer,
 			$this->fileMapper,
 			$this->l10n,
 			$this->urlGenerator,
-			$this->appConfig
+			$this->appConfig,
+			$this->policyService,
+			$this->mailProviderManager,
+			$this->userManager,
 		);
 	}
 
 	public function testSuccessNotifyUnsignedUser():void {
-		$signRequest = $this->createMock(SignRequest::class);
-		$signRequest
-			->method('__call')
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_SYSTEM);
+		$this->mailer->expects($this->once())
+			->method('send');
+		$this->mailProviderManager->expects($this->never())
+			->method('has');
 
-			->willReturnCallback(fn (string $method)
-				=> match ($method) {
-					'getUuid' => 'asdfg',
-					'getFileId' => 1,
-					'getDisplayName' => 'John Doe'
-				}
-			);
-
-		$file = $this->createMock(File::class);
-		$file
-			->method('__call')
-			->with($this->equalTo('getName'), $this->anything())
-			->willReturn('Filename');
-		$this->fileMapper
-			->method('getById')
-			->willReturn($file);
-		$this->appConfig
-			->method('getValueBool')
-			->willReturn(true);
-		$actual = $this->service->notifyUnsignedUser($signRequest, 'a@b.coop');
+		$actual = $this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
 		$this->assertNull($actual);
 	}
 
 	public function testFailToSendMailToUnsignedUser():void {
+		$this->expectException(LibresignException::class);
 		$this->expectExceptionMessage('Notify unsigned notification mail could not be sent');
 
-		$signRequest = $this->createMock(SignRequest::class);
-		$signRequest
-			->method('__call')
-			->willReturnCallback(fn (string $method)
-				=> match ($method) {
-					'getUuid' => 'asdfg',
-					'getFileId' => 1,
-					'getDisplayName' => 'John doe',
-				}
-			);
-
-		$file = $this->createMock(File::class);
-		$file
-			->method('__call')
-			->with($this->equalTo('getName'), $this->anything())
-			->willReturn('Filename');
-		$this->fileMapper
-			->method('getById')
-			->willReturn($file);
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_SYSTEM);
 		$this->mailer
 			->method('send')
 			->willReturnCallback(function ():void {
 				throw new \Exception('Error Processing Request', 1);
 			});
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testNotifySignDataUpdatedUsesSystemMailerByDefault(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_SYSTEM);
+		$this->mailer->expects($this->once())
+			->method('send');
+		$this->mailProviderManager->expects($this->never())
+			->method('has');
+
+		$this->service->notifySignDataUpdated($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testNotifyUnsignedUserSendsThroughRequesterAccount(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockEmailTemplate();
+		$this->mockRequesterAccount('requester@domain.coop');
+		$service = $this->mockSendableService(new Address('requester@domain.coop', 'Requester'));
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->expects($this->once())
+			->method('findServiceByAddress')
+			->with('requester', 'requester@domain.coop')
+			->willReturn($service);
+		$sent = null;
+		$service->expects($this->once())
+			->method('sendMessage')
+			->willReturnCallback(function (IMessage $message) use (&$sent): void {
+				$sent = $message;
+			});
+		$this->mailer->expects($this->never())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest('John Doe'), 'a@b.coop');
+
+		$this->assertInstanceOf(IMessage::class, $sent);
+		$this->assertSame('requester@domain.coop', $sent->getFrom()?->getAddress());
+		$this->assertSame('Requester', $sent->getFrom()?->getLabel());
+		$this->assertCount(1, $sent->getTo());
+		$this->assertSame('a@b.coop', $sent->getTo()[0]->getAddress());
+		$this->assertSame('John Doe', $sent->getTo()[0]->getLabel());
+		$this->assertSame('Rendered subject', $sent->getSubject());
+		$this->assertSame('<p>Rendered html</p>', $sent->getBodyHtml());
+		$this->assertSame('Rendered text', $sent->getBodyPlain());
+	}
+
+	public function testNotifySignDataUpdatedSendsThroughRequesterAccount(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockEmailTemplate();
+		$this->mockRequesterAccount('requester@domain.coop');
+		$service = $this->mockSendableService(new Address('requester@domain.coop'));
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->method('findServiceByAddress')->willReturn($service);
+		$service->expects($this->once())
+			->method('sendMessage');
+		$this->mailer->expects($this->never())
+			->method('send');
+
+		$this->service->notifySignDataUpdated($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyOmitsRecipientLabelWithoutDisplayName(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockEmailTemplate();
+		$this->mockRequesterAccount('requester@domain.coop');
+		$service = $this->mockSendableService(new Address('requester@domain.coop'));
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->method('findServiceByAddress')->willReturn($service);
+		$sent = null;
+		$service->expects($this->once())
+			->method('sendMessage')
+			->willReturnCallback(function (IMessage $message) use (&$sent): void {
+				$sent = $message;
+			});
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(''), 'a@b.coop');
+
+		$this->assertInstanceOf(IMessage::class, $sent);
+		$this->assertSame('a@b.coop', $sent->getTo()[0]->getAddress());
+		$this->assertNull($sent->getTo()[0]->getLabel());
+	}
+
+	public function testRequesterStrategyFallsBackWhenNoProviderIsAvailable(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mailProviderManager->method('has')->willReturn(false);
+		$this->mailProviderManager->expects($this->never())
+			->method('findServiceByAddress');
+		$this->logger->expects($this->once())
+			->method('info');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallsBackWhenRequesterIsUnknown(): void {
+		$this->mockRequest(requesterId: '');
+		$this->policyService->expects($this->once())
+			->method('resolveForUserId')
+			->with(MailSenderStrategyPolicy::KEY, null)
+			->willReturn((new ResolvedPolicy())->setEffectiveValue(MailSenderStrategyPolicy::STRATEGY_REQUESTER));
+		$this->mailProviderManager->expects($this->never())
+			->method('has');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallsBackWhenRequesterAccountIsMissing(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->userManager->method('get')->with('requester')->willReturn(null);
+		$this->mailProviderManager->expects($this->never())
+			->method('findServiceByAddress');
+		$this->logger->expects($this->once())
+			->method('info');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyUsesFirstSendableServiceWhenAddressDoesNotMatch(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockEmailTemplate();
+		$this->mockRequesterAccount('requester@domain.coop');
+		$readOnly = $this->createMock(IService::class);
+		$sendable = $this->mockSendableService(new Address('other@domain.coop'));
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->method('findServiceByAddress')->willReturn(null);
+		$this->mailProviderManager->expects($this->once())
+			->method('services')
+			->with('requester')
+			->willReturn(['mail' => ['read-only' => $readOnly, 'sendable' => $sendable]]);
+		$sendable->expects($this->once())
+			->method('sendMessage');
+		$this->mailer->expects($this->never())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallsBackWhenNoServiceCanSend(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockRequesterAccount('');
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->expects($this->never())
+			->method('findServiceByAddress');
+		$this->mailProviderManager->method('services')
+			->willReturn(['mail' => ['read-only' => $this->createMock(IService::class)]]);
+		$this->logger->expects($this->once())
+			->method('info');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallsBackWhenProviderSendingFails(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockEmailTemplate();
+		$this->mockRequesterAccount('requester@domain.coop');
+		$service = $this->mockSendableService(new Address('requester@domain.coop'));
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->method('findServiceByAddress')->willReturn($service);
+		$service->method('sendMessage')
+			->willThrowException(new \RuntimeException('SMTP unavailable'));
+		$this->logger->expects($this->once())
+			->method('warning');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyThrowsWhenFallbackAlsoFails(): void {
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage('Notify unsigned notification mail could not be sent');
+
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mailProviderManager->method('has')->willReturn(false);
+		$this->mailer->method('send')
+			->willThrowException(new \Exception('Error Processing Request', 1));
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	private function mockSignRequest(string $displayName = 'John Doe'): SignRequest&MockObject {
+		$signRequest = $this->createMock(SignRequest::class);
+		$signRequest
+			->method('__call')
+			->willReturnCallback(fn (string $method)
+				=> match ($method) {
+					'getUuid' => 'asdfg',
+					'getFileId' => 1,
+					'getDisplayName' => $displayName,
+				}
+			);
+		return $signRequest;
+	}
+
+	private function mockRequest(string $requesterId = 'requester'): void {
+		$file = $this->createMock(File::class);
+		$file
+			->method('__call')
+			->with($this->equalTo('getName'), $this->anything())
+			->willReturn('Filename');
+		$file->method('getUserId')->willReturn($requesterId);
+		$this->fileMapper
+			->method('getById')
+			->with(1)
+			->willReturn($file);
 		$this->appConfig
 			->method('getValueBool')
 			->willReturn(true);
-		$actual = $this->service->notifyUnsignedUser($signRequest, 'a@b.coop');
-		$this->assertNull($actual);
+	}
+
+	private function mockStrategy(string $strategy): void {
+		$this->policyService
+			->method('resolveForUserId')
+			->with(MailSenderStrategyPolicy::KEY, 'requester')
+			->willReturn((new ResolvedPolicy())->setEffectiveValue($strategy));
+	}
+
+	private function mockEmailTemplate(): void {
+		$template = $this->createMock(IEMailTemplate::class);
+		$template->method('renderSubject')->willReturn('Rendered subject');
+		$template->method('renderHtml')->willReturn('<p>Rendered html</p>');
+		$template->method('renderText')->willReturn('Rendered text');
+		$this->mailer->method('createEMailTemplate')->willReturn($template);
+	}
+
+	private function mockRequesterAccount(string $email): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn($email);
+		$this->userManager->method('get')->with('requester')->willReturn($user);
+	}
+
+	/**
+	 * @return IService&IMessageSend&MockObject
+	 */
+	private function mockSendableService(Address $primaryAddress): MockObject {
+		$service = $this->createMockForIntersectionOfInterfaces([IService::class, IMessageSend::class]);
+		$service->method('initiateMessage')->willReturnCallback(static fn (): Message => new Message());
+		$service->method('getPrimaryAddress')->willReturn($primaryAddress);
+		return $service;
 	}
 }

--- a/tests/php/Unit/Service/MailServiceTest.php
+++ b/tests/php/Unit/Service/MailServiceTest.php
@@ -227,36 +227,53 @@ final class MailServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
 	}
 
-	public function testRequesterStrategyUsesFirstSendableServiceWhenAddressDoesNotMatch(): void {
+	public function testRequesterStrategyFallsBackWhenNoAccountMatchesTheRequesterAddress(): void {
 		$this->mockRequest();
 		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
-		$this->mockEmailTemplate();
 		$this->mockRequesterAccount('requester@domain.coop');
-		$readOnly = $this->createMock(IService::class);
-		$sendable = $this->mockSendableService(new Address('other@domain.coop'));
 		$this->mailProviderManager->method('has')->willReturn(true);
-		$this->mailProviderManager->method('findServiceByAddress')->willReturn(null);
 		$this->mailProviderManager->expects($this->once())
-			->method('services')
-			->with('requester')
-			->willReturn(['mail' => ['read-only' => $readOnly, 'sendable' => $sendable]]);
-		$sendable->expects($this->once())
-			->method('sendMessage');
-		$this->mailer->expects($this->never())
+			->method('findServiceByAddress')
+			->with('requester', 'requester@domain.coop')
+			->willReturn(null);
+		$this->mailProviderManager->expects($this->never())
+			->method('services');
+		$this->logger->expects($this->once())
+			->method('info');
+		$this->mailer->expects($this->once())
 			->method('send');
 
 		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
 	}
 
-	public function testRequesterStrategyFallsBackWhenNoServiceCanSend(): void {
+	public function testRequesterStrategyFallsBackWhenTheMatchingAccountCannotSend(): void {
+		$this->mockRequest();
+		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
+		$this->mockRequesterAccount('requester@domain.coop');
+		$this->mailProviderManager->method('has')->willReturn(true);
+		$this->mailProviderManager->expects($this->once())
+			->method('findServiceByAddress')
+			->with('requester', 'requester@domain.coop')
+			->willReturn($this->createMock(IService::class));
+		$this->mailProviderManager->expects($this->never())
+			->method('services');
+		$this->logger->expects($this->once())
+			->method('info');
+		$this->mailer->expects($this->once())
+			->method('send');
+
+		$this->service->notifyUnsignedUser($this->mockSignRequest(), 'a@b.coop');
+	}
+
+	public function testRequesterStrategyFallsBackWhenTheRequesterHasNoEmailAddress(): void {
 		$this->mockRequest();
 		$this->mockStrategy(MailSenderStrategyPolicy::STRATEGY_REQUESTER);
 		$this->mockRequesterAccount('');
 		$this->mailProviderManager->method('has')->willReturn(true);
 		$this->mailProviderManager->expects($this->never())
 			->method('findServiceByAddress');
-		$this->mailProviderManager->method('services')
-			->willReturn(['mail' => ['read-only' => $this->createMock(IService::class)]]);
+		$this->mailProviderManager->expects($this->never())
+			->method('services');
 		$this->logger->expects($this->once())
 			->method('info');
 		$this->mailer->expects($this->once())

--- a/tests/php/Unit/Service/Policy/Model/PolicySpecTest.php
+++ b/tests/php/Unit/Service/Policy/Model/PolicySpecTest.php
@@ -384,4 +384,58 @@ final class PolicySpecTest extends TestCase {
 			'disallowed value' => ['unsupported_mode', true],
 		];
 	}
+
+	public function testValidateValueForPersistenceRunsRegularValidationByDefault(): void {
+		$spec = new PolicySpec(
+			key: 'signature_flow',
+			defaultSystemValue: 'none',
+			allowedValues: ['none', 'parallel'],
+		);
+
+		$spec->validateValueForPersistence('parallel', new PolicyContext());
+		$this->addToAssertionCount(1);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid value for signature_flow');
+		$spec->validateValueForPersistence('invalid', new PolicyContext());
+	}
+
+	public function testPersistenceValidatorRunsOnlyWhenSavingAValue(): void {
+		$persistenceChecks = [];
+		$spec = new PolicySpec(
+			key: 'mail_sender_strategy',
+			defaultSystemValue: 'system',
+			allowedValues: ['system', 'requester'],
+			persistenceValidator: static function (mixed $value, PolicyContext $context) use (&$persistenceChecks): void {
+				$persistenceChecks[] = [$value, $context->getUserId()];
+				if ($value === 'requester') {
+					throw new \InvalidArgumentException('No mail provider available');
+				}
+			},
+		);
+
+		// Runtime validation ignores persistence-only constraints.
+		$spec->validateValue('requester', new PolicyContext());
+		$this->assertSame([], $persistenceChecks);
+
+		$spec->validateValueForPersistence('system', PolicyContext::fromUserId('john'));
+		$this->assertSame([['system', 'john']], $persistenceChecks);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('No mail provider available');
+		$spec->validateValueForPersistence('requester', new PolicyContext());
+	}
+
+	public function testPersistenceValidatorDoesNotBypassRegularValidation(): void {
+		$spec = new PolicySpec(
+			key: 'mail_sender_strategy',
+			defaultSystemValue: 'system',
+			allowedValues: ['system', 'requester'],
+			persistenceValidator: static fn (mixed $value, PolicyContext $context): null => null,
+		);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid value for mail_sender_strategy');
+		$spec->validateValueForPersistence('invalid', new PolicyContext());
+	}
 }

--- a/tests/php/Unit/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicyTest.php
+++ b/tests/php/Unit/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicyTest.php
@@ -10,12 +10,19 @@ namespace OCA\Libresign\Tests\Unit\Service\Policy\Provider\MailSenderStrategy;
 
 use OCA\Libresign\Service\Policy\Model\PolicyContext;
 use OCA\Libresign\Service\Policy\Provider\MailSenderStrategy\MailSenderStrategyPolicy;
+use OCP\Mail\Provider\IManager as IMailProviderManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MailSenderStrategyPolicyTest extends TestCase {
+	private function createProvider(bool $mailProviderAvailable = true): MailSenderStrategyPolicy {
+		$mailProviderManager = $this->createMock(IMailProviderManager::class);
+		$mailProviderManager->method('has')->willReturn($mailProviderAvailable);
+		return new MailSenderStrategyPolicy($mailProviderManager);
+	}
+
 	public function testProviderBuildsDefinition(): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 		$this->assertSame([MailSenderStrategyPolicy::KEY], $provider->keys());
 
 		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
@@ -26,7 +33,7 @@ final class MailSenderStrategyPolicyTest extends TestCase {
 	}
 
 	public function testProviderIsRestrictedToSystemScope(): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
 
 		$this->assertSame(['system'], $definition->supportedScopes());
@@ -39,7 +46,7 @@ final class MailSenderStrategyPolicyTest extends TestCase {
 
 	#[DataProvider('provideRawValues')]
 	public function testNormalizeValueTrimsAndLowercases(mixed $rawValue, string $expected): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
 
 		$this->assertSame($expected, $definition->normalizeValue($rawValue));
@@ -58,7 +65,7 @@ final class MailSenderStrategyPolicyTest extends TestCase {
 
 	#[DataProvider('provideValidStrategies')]
 	public function testValidateValueAcceptsKnownStrategies(string $strategy): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
 
 		$definition->validateValue($definition->normalizeValue($strategy), new PolicyContext());
@@ -76,7 +83,7 @@ final class MailSenderStrategyPolicyTest extends TestCase {
 
 	#[DataProvider('provideInvalidValues')]
 	public function testValidateValueRejectsUnknownStrategies(mixed $value): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
 
 		$this->expectException(\InvalidArgumentException::class);
@@ -96,11 +103,49 @@ final class MailSenderStrategyPolicyTest extends TestCase {
 	}
 
 	public function testThrowsOnUnknownPolicyKey(): void {
-		$provider = new MailSenderStrategyPolicy();
+		$provider = $this->createProvider();
 
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Unknown policy key: unknown_policy_key');
 
 		$provider->get('unknown_policy_key');
+	}
+
+	public function testExposesMailProviderAvailabilityInResolvedStateMeta(): void {
+		$withProvider = $this->createProvider(true)->get(MailSenderStrategyPolicy::KEY);
+		$this->assertSame(['mailProviderAvailable' => true], $withProvider->resolvedStateMeta(new PolicyContext()));
+
+		$withoutProvider = $this->createProvider(false)->get(MailSenderStrategyPolicy::KEY);
+		$this->assertSame(['mailProviderAvailable' => false], $withoutProvider->resolvedStateMeta(new PolicyContext()));
+	}
+
+	public function testRequesterCannotBeSavedWithoutMailProvider(): void {
+		$definition = $this->createProvider(false)->get(MailSenderStrategyPolicy::KEY);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('The requester strategy requires an available mail provider');
+
+		$definition->validateValueForPersistence('requester', new PolicyContext());
+	}
+
+	public function testSystemCanBeSavedWithoutMailProvider(): void {
+		$definition = $this->createProvider(false)->get(MailSenderStrategyPolicy::KEY);
+
+		$definition->validateValueForPersistence('system', new PolicyContext());
+		$this->addToAssertionCount(1);
+	}
+
+	public function testRequesterCanBeSavedWithMailProvider(): void {
+		$definition = $this->createProvider(true)->get(MailSenderStrategyPolicy::KEY);
+
+		$definition->validateValueForPersistence('requester', new PolicyContext());
+		$this->addToAssertionCount(1);
+	}
+
+	public function testStoredRequesterValueStaysValidAtRuntimeWithoutMailProvider(): void {
+		$definition = $this->createProvider(false)->get(MailSenderStrategyPolicy::KEY);
+
+		$definition->validateValue('requester', new PolicyContext());
+		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/php/Unit/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicyTest.php
+++ b/tests/php/Unit/Service/Policy/Provider/MailSenderStrategy/MailSenderStrategyPolicyTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service\Policy\Provider\MailSenderStrategy;
+
+use OCA\Libresign\Service\Policy\Model\PolicyContext;
+use OCA\Libresign\Service\Policy\Provider\MailSenderStrategy\MailSenderStrategyPolicy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MailSenderStrategyPolicyTest extends TestCase {
+	public function testProviderBuildsDefinition(): void {
+		$provider = new MailSenderStrategyPolicy();
+		$this->assertSame([MailSenderStrategyPolicy::KEY], $provider->keys());
+
+		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
+		$this->assertSame('mail_sender_strategy', $definition->key());
+		$this->assertSame('system', $definition->defaultSystemValue());
+		$this->assertSame(['system', 'requester'], $definition->allowedValues(new PolicyContext()));
+		$this->assertSame('mail_sender_strategy', $definition->getAppConfigKey());
+	}
+
+	public function testProviderIsRestrictedToSystemScope(): void {
+		$provider = new MailSenderStrategyPolicy();
+		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
+
+		$this->assertSame(['system'], $definition->supportedScopes());
+		$this->assertTrue($definition->supportsScope('system'));
+		$this->assertFalse($definition->supportsScope('group'));
+		$this->assertFalse($definition->supportsScope('user'));
+		$this->assertFalse($definition->supportsUserPreference());
+		$this->assertFalse($definition->supportsGroupAdminDelegation());
+	}
+
+	#[DataProvider('provideRawValues')]
+	public function testNormalizeValueTrimsAndLowercases(mixed $rawValue, string $expected): void {
+		$provider = new MailSenderStrategyPolicy();
+		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
+
+		$this->assertSame($expected, $definition->normalizeValue($rawValue));
+	}
+
+	/** @return array<string, array{0: mixed, 1: string}> */
+	public static function provideRawValues(): array {
+		return [
+			'plain system' => ['system', 'system'],
+			'plain requester' => ['requester', 'requester'],
+			'uppercase with spaces' => ['  REQUESTER ', 'requester'],
+			'unknown value is kept for validation' => ['Someone-Else', 'someone-else'],
+			'empty value' => ['', ''],
+		];
+	}
+
+	#[DataProvider('provideValidStrategies')]
+	public function testValidateValueAcceptsKnownStrategies(string $strategy): void {
+		$provider = new MailSenderStrategyPolicy();
+		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
+
+		$definition->validateValue($definition->normalizeValue($strategy), new PolicyContext());
+		$this->addToAssertionCount(1);
+	}
+
+	/** @return array<string, array{0: string}> */
+	public static function provideValidStrategies(): array {
+		return [
+			'system' => ['system'],
+			'requester' => ['requester'],
+			'requester with different case' => ['Requester'],
+		];
+	}
+
+	#[DataProvider('provideInvalidValues')]
+	public function testValidateValueRejectsUnknownStrategies(mixed $value): void {
+		$provider = new MailSenderStrategyPolicy();
+		$definition = $provider->get(MailSenderStrategyPolicy::KEY);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid value for mail_sender_strategy');
+
+		$definition->validateValue($value, new PolicyContext());
+	}
+
+	/** @return array<string, array{0: mixed}> */
+	public static function provideInvalidValues(): array {
+		return [
+			'unknown strategy' => ['user_choice'],
+			'empty string' => [''],
+			'boolean' => [true],
+			'null' => [null],
+		];
+	}
+
+	public function testThrowsOnUnknownPolicyKey(): void {
+		$provider = new MailSenderStrategyPolicy();
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unknown policy key: unknown_policy_key');
+
+		$provider->get('unknown_policy_key');
+	}
+}


### PR DESCRIPTION
### Pull Request Description

Implements the `mail_sender_strategy` policy described in #7954 so LibreSign can send signature request notification emails either through the system mailer (current behavior) or through the mail account of the person who requested the signature.

**Backend**

- New `MailSenderStrategyPolicy` (`lib/Service/Policy/Provider/MailSenderStrategy/`), registered in `PolicyProviders`. Values: `system` (default) and `requester`. System scope only in this first step (`supportedScopes: ['system']`, no user preference, no group delegation), since per-user choice is out of scope.
- `MailService::notifyUnsignedUser()` and `notifySignDataUpdated()` now resolve the policy for the **requester** (`resolveForUserId()` on the file owner, so the same strategy applies to reminders sent from cron, where there is no session user).
- Under `requester`, the notification is sent through `OCP\Mail\Provider\IManager`: the service is looked up by the requester's email address (`findServiceByAddress()`) and must be able to send messages (`IMessageSend`). No other account of the requester is used: `services()` gives no way to tell which one is the main account, so guessing could send the request from the wrong one. The message reuses the existing `IEMailTemplate` (`renderSubject()`, `renderHtml()`, `renderText()`), so content and templating are unchanged.
- Fallback to `IMailer` (identical to the current code path) when there is no mail provider, the requester account is missing, no mail account matches the requester's email address (or the matching one cannot send messages), or provider sending throws. Logging: `info` for the "not available" cases, `warning` (with the exception) when provider sending fails. Errors from the final `IMailer` path keep raising `LibresignException` as before.

**Configuration vs. runtime (follow-up of the review in #7954)**

- The `requester` strategy can only be **saved** while a mail provider is registered (`OCP\Mail\Provider\IManager::has()`, independent of any specific app). This uses a new persistence-only hook in the policy framework, `IPolicyDefinition::validateValueForPersistence()`, called from the `PolicyService` save paths. Runtime resolution keeps using `validateValue()`, so an already stored `requester` value is not silently discarded by `DefaultPolicyResolver` when the environment changes later; instead `MailService` falls back at sending time.
- The availability is exposed as `meta.mailProviderAvailable` (OpenAPI spec and generated types updated) and the Policy Workbench editor disables the `requester` option with a hint when no provider is available.
- When the strategy is `requester` and the notification falls back to the system mailer, `Reply-To` is set to the requester's address, so replies still reach the person who requested the signature. The `system` strategy is unchanged.

**Frontend**

- Policy Workbench definition under `src/views/Settings/PolicyWorkbench/settings/mail-sender-strategy/` (radio editor with the two strategies), added to the `system-behavior` category in `realDefinitions.ts`.

**Tests**

- `MailSenderStrategyPolicyTest`: definition, scope restriction, normalization and validation, provider required on save (and stored value still valid at runtime), resolved meta.
- `PolicySpecTest`: the persistence-only validation hook.
- `MailServiceTest`: `system` strategy, successful `requester` sending (from/to/subject/html/plain), recipient label handling, every fallback path (no provider, unknown requester, missing account or email address, no account matching the address, matching account unable to send, provider failure, fallback failure) and the `Reply-To` behavior on fallback.
- `realDefinitions.spec.ts`, `mail-sender-strategy/*.spec.ts`: workbench card, definition callbacks, model and editor (including the disabled state).

Checks run locally: PHPUnit unit suite, psalm and php-cs-fixer on the changed files, `npm run lint`, `vue-tsc --noEmit`, vitest for the Policy Workbench suites.

### Manual verification

Devcontainer with Mailpit as the system mailer and **no** mail provider app installed, so the `requester` strategy exercises the fallback path end to end.

1. New card in the Policy Workbench (System behavior), default `System mailer`:

   ![Workbench card with the default value](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/01-workbench-card-default.png)

2. Rule editor with the two strategies:

   ![Rule editor options](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/03-rule-editor-options.png)

3. Selecting `Requester mail account` and saving the system rule:

   ![Requester selected](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/04-rule-editor-requester-selected.png)

   ![Policy dialog after saving](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/06-policy-dialog-requester.png)

4. Card after saving (`occ config:app:get libresign mail_sender_strategy` → `requester`):

   ![Workbench card with requester](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/05-workbench-card-requester.png)

5. Signature request sent through the API with the policy set to `requester`: the notification is still delivered, through the system mailer, and the fallback is logged at `info` level:

   ![Mailpit delivery](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/07-mailpit-fallback-delivery.png)

   ```json
   {"level": 1, "app": "libresign", "message": "No mail provider is available to send the notification as the requester, falling back to the system mailer.", "requester": "admin"}
   ```

6. Follow-up of the review: on the same instance (no mail provider), the `requester` option can no longer be configured. The editor disables it with a hint, and the API rejects it with `400`:

   ![Requester option disabled without a mail provider](https://raw.githubusercontent.com/maia-andre/libresign/assets/7954-mail-sender-strategy/7954/08-rule-editor-requester-disabled.png)

   ```
   POST /ocs/v2.php/apps/libresign/api/v1/policies/system/mail_sender_strategy  {"value":"requester"}
   HTTP 400  {"ocs":{"meta":{"status":"failure","statuscode":400},"data":{"error":"The requester strategy requires an available mail provider"}}}
   ```

   The screenshots in steps 3–5 were taken before this change; they show the rule saved while the check did not exist yet, which is exactly the "environment changed later" case that the runtime fallback (and now `Reply-To`) covers.

### Related Issue

Fixes #7954

### Pull Request Type

- Feature

### Pull request checklist

- [x] The policy supports `system` and `requester`
- [x] The policy is available in the backend and Policy Workbench
- [x] `system` preserves the current behavior
- [x] `requester` attempts provider-based sending
- [x] Falls back to `IMailer` when no provider, account or sending service is available, or when sending fails
- [x] `requester` cannot be configured while no mail provider is available (persistence-time check)
- [x] `Reply-To` set to the requester when falling back to the system mailer
- [x] Applied to `notifyUnsignedUser` and `notifySignDataUpdated`
- [x] Tests cover `system`, successful `requester` and fallback
- [x] AI-assisted: yes (see commit trailer)


