### PR TITLE
ci: use the docker-compose Dependabot ecosystem for the devcontainer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,8 @@ updates:
     schedule:
       interval: daily
 
-  # Maintain the Nextcloud image used by the devcontainer
-  - package-ecosystem: "docker"
+  # Maintain the images used by the devcontainer (docker-compose.yml)
+  - package-ecosystem: "docker-compose"
     directory: "/.devcontainer"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Resolves: #8121

## 📝 Summary

The Dependabot entry added in #8033 for `/.devcontainer` uses the `docker` ecosystem, which only reads Dockerfiles and Kubernetes manifests. The devcontainer declares its images in `docker-compose.yml`, so every daily job failed with `No Dockerfiles nor Kubernetes YAML found in /.devcontainer` (e.g. https://github.com/LibreSign/libresign/actions/runs/33188239975) and the `ghcr.io/librecodecoop/nextcloud-dev:8.3` tag was never checked.

This switches the entry to the dedicated `docker-compose` ecosystem. Nothing else changes.

Side effect to be aware of: Dependabot will now also see `mariadb:10.6` in the same file and may propose MariaDB updates. If major bumps are not wanted there, an `ignore` rule for `mariadb` with `update-types: ["version-update:semver-major"]` can be added — I left it out to keep this PR to the fix, happy to add it if preferred. `axllent/mailpit`, `redis` and `nextcloud-dev-nginx:latest` carry no version tag and are skipped.

## 🧪 How to test

Dependabot version updates only run from the default branch, so this cannot be exercised from a fork PR. After merge, the next scheduled job should show up as `docker-compose in /.devcontainer` (instead of `docker in /.devcontainer`) under Insights → Dependency graph → Dependabot, without the "No Dockerfiles" error, and open a PR whenever a newer `nextcloud-dev` tag exists.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
