### PR TITLE
ci: let the psalm baseline workflow fork and commit only the baseline

### DIFF
--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -62,6 +62,8 @@ jobs:
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development
+          # Required: re-enable pcntl_* functions that may be disabled via disable_functions
+          ini-values: disable_functions=
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -84,6 +86,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: apps/${{ env.APP_NAME }}
+          add-paths: tests/psalm-baseline.xml
           token: ${{ secrets.COMMAND_BOT_PAT }}
           commit-message: "chore: Update psalm baseline"
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
Resolves: #8122

## 📝 Summary

`update-psalm-baseline.yml` has been crashing on every scheduled run since around 2026-08-20: `psalm --threads=$(nproc)` forks its workers with `pcntl_fork()`, which the runner's php.ini lists in `disable_functions`. Because the step has `continue-on-error: true`, the job carried on and `create-pull-request` committed the only thing that had changed in the tree — the `composer.lock` rewrite from `composer require nextcloud/ocp:dev-*` — so the recent "Update psalm-baseline.xml" PRs (#8052, #8064, #8083, #8084, #8093, #8118, #8119) never contained baseline changes. Details and evidence in #8122.

Two lines, both with precedent in this repository:

- `ini-values: disable_functions=` on `setup-php`, as `psalm.yml` and the phpunit/behat/playwright/infection workflows already do, so Psalm can fork;
- `add-paths: tests/psalm-baseline.xml` on `create-pull-request`, so only the baseline is committed and no PR is opened when it did not change.

**Left out on purpose:** `team-reviewers: server-backend` still fails with `Reviews may only be requested from collaborators` and will keep marking the run as failed even after this fix. Removing it or pointing it to an existing team is an org-level decision, so it is not part of this PR.

## 🧪 How to test

Both versions were run on my fork via `workflow_dispatch`, with the fork's `main`/`stable32`–`stable34` synced to upstream:

- as-is: https://github.com/maia-andre/libresign/actions/runs/33266309373 — Psalm crashes with `pcntl_fork()` in all four jobs;
- with this change (plus a test-only step printing `git status` after Psalm, and the PR step disabled since the fork has no `COMMAND_BOT_PAT`): https://github.com/maia-andre/libresign/actions/runs/33266307137 — Psalm saves the baseline in all four jobs. Afterwards `main` has only `composer.lock` modified (so no PR would be opened), `stable32`/`stable33` only `tests/psalm-baseline.xml`, `stable34` both.

After merge, the next scheduled run (02:05 UTC) should open PRs only for branches whose baseline actually changed, containing only `tests/psalm-baseline.xml`. #8118 and #8119 only bump `composer.lock` and can be closed.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
