### PR TITLE
test: cover CertificateChainService branches and the saveFile failure message

### DIFF
--- a/tests/php/Unit/Handler/CertificateEngine/CertificateHelperTest.php
+++ b/tests/php/Unit/Handler/CertificateEngine/CertificateHelperTest.php
@@ -26,13 +26,28 @@ final class CertificateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertSame($content, file_get_contents($filename));
 	}
 
-	public function testSaveFileWithError(): void {
-		$this->expectException(LibresignException::class);
-
+	#[DataProvider('dataSaveFileWithError')]
+	public function testSaveFileWithError(string $basename): void {
 		vfsStream::setup('home', 0444);
-		$filename = vfsStream::url('home/test.txt');
+		$filename = vfsStream::url('home/' . $basename);
 
-		@CertificateHelper::saveFile($filename, '');
+		try {
+			@CertificateHelper::saveFile($filename, '');
+			$this->fail('saveFile() must throw when the file cannot be written');
+		} catch (LibresignException $e) {
+			// The failure must describe the problem and end with the file that could not be written
+			$this->assertStringEndsWith(': ' . $filename, $e->getMessage());
+		}
+	}
+
+	public static function dataSaveFileWithError(): array {
+		return [
+			'plain name' => ['test.txt'],
+			'spaces' => ['my certificate.pem'],
+			'dots, dashes and underscores' => ['root-ca.v2_backup.crt'],
+			'regex metacharacters' => ['cert (copy) [1]+$.txt'],
+			'non-ascii' => ['certificado-ção.txt'],
+		];
 	}
 
 	#[DataProvider('dataProviderArrayToIni')]

--- a/tests/php/Unit/Service/File/CertificateChainServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateChainServiceTest.php
@@ -12,6 +12,7 @@ use OCA\Libresign\Db\File;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Service\File\CertificateChainService;
 use OCA\Libresign\Service\File\FileResponseOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -49,8 +50,7 @@ final class CertificateChainServiceTest extends TestCase {
 
 		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
 
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('chain', $result);
+		$this->assertSame($pkcs12->chain, $result);
 		$this->assertTrue($pkcs12->libreSignFlagSet);
 		$this->assertSame('requester', $pkcs12->policyUserIdForValidation);
 	}
@@ -82,5 +82,112 @@ final class CertificateChainServiceTest extends TestCase {
 		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
 
 		$this->assertSame([], $result);
+	}
+
+	#[DataProvider('dataGetCertificateChainSkipsValidation')]
+	public function testGetCertificateChainSkipsValidation(bool $validateFile, ?int $signedNodeId): void {
+		$fileNode = new class() {
+			public function fopen($mode) {
+				throw new \LogicException('The signed file must not be opened when validation is skipped.');
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId($signedNodeId);
+
+		$pkcs12 = $this->createMock(Pkcs12Handler::class);
+		$pkcs12->expects($this->never())->method('getCertificateChain');
+		$pkcs12->expects($this->never())->method('setIsLibreSignFile');
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$service = new CertificateChainService($pkcs12, $logger);
+		$options = new FileResponseOptions();
+		$options->validateFile($validateFile);
+
+		$this->assertSame([], $service->getCertificateChain($fileNode, $libreSignFile, $options));
+	}
+
+	public static function dataGetCertificateChainSkipsValidation(): array {
+		return [
+			'validation disabled' => [false, 1],
+			'missing signed node' => [true, null],
+		];
+	}
+
+	public function testGetCertificateChainDoesNotFlagLibreSignFileWhenHashDiffers(): void {
+		$content = 'content that was changed after signing';
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, $content);
+		rewind($stream);
+
+		$fileNode = new class($stream) {
+			public function __construct(
+				private $s,
+			) {
+			}
+
+			public function fopen($mode) {
+				return $this->s;
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId(1);
+		$libreSignFile->setSignedHash(hash('sha256', 'original content'));
+		$libreSignFile->setUserId('requester');
+
+		$pkcs12 = new PolicyAwarePkcs12HandlerDouble();
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$service = new CertificateChainService($pkcs12, $logger);
+		$options = new FileResponseOptions();
+		$options->validateFile(true);
+
+		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
+
+		$this->assertSame($pkcs12->chain, $result);
+		$this->assertFalse($pkcs12->libreSignFlagSet);
+		$this->assertSame('requester', $pkcs12->policyUserIdForValidation);
+		// The stream must be rewound after hashing so the handler reads the whole file
+		$this->assertSame($content, $pkcs12->receivedContent);
+		$this->assertFalse(is_resource($stream), 'The signed file stream must be closed after reading the chain');
+	}
+
+	public function testGetCertificateChainLogsWarningAndReturnsEmptyWhenHandlerFails(): void {
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, 'signed content');
+		rewind($stream);
+
+		$fileNode = new class($stream) {
+			public function __construct(
+				private $s,
+			) {
+			}
+
+			public function fopen($mode) {
+				return $this->s;
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId(1);
+		$libreSignFile->setSignedHash(hash('sha256', 'signed content'));
+
+		$pkcs12 = $this->createMock(Pkcs12Handler::class);
+		$pkcs12->method('getCertificateChain')
+			->willThrowException(new \RuntimeException('unable to parse the signature'));
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger
+			->expects($this->once())
+			->method('warning')
+			->with($this->identicalTo('Failed to load certificate chain: unable to parse the signature'));
+
+		$service = new CertificateChainService($pkcs12, $logger);
+		$options = new FileResponseOptions();
+		$options->validateFile(true);
+
+		$this->assertSame([], $service->getCertificateChain($fileNode, $libreSignFile, $options));
 	}
 }

--- a/tests/php/Unit/Service/File/PolicyAwarePkcs12HandlerDouble.php
+++ b/tests/php/Unit/Service/File/PolicyAwarePkcs12HandlerDouble.php
@@ -13,6 +13,12 @@ use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 final class PolicyAwarePkcs12HandlerDouble extends Pkcs12Handler {
 	public ?string $policyUserIdForValidation = null;
 	public bool $libreSignFlagSet = false;
+	public ?string $receivedContent = null;
+	/** One entry per signature found in the file, as the real handler returns */
+	public array $chain = [
+		['chain' => [['name' => 'first signer']]],
+		['chain' => [['name' => 'second signer']]],
+	];
 
 	public function __construct() {
 	}
@@ -27,6 +33,7 @@ final class PolicyAwarePkcs12HandlerDouble extends Pkcs12Handler {
 	}
 
 	public function getCertificateChain($resource): array {
-		return ['chain' => []];
+		$this->receivedContent = is_resource($resource) ? stream_get_contents($resource) : null;
+		return $this->chain;
 	}
 }


### PR DESCRIPTION
### Pull Request Description

Tests-only PR for #8053 covering two related certificate-handling helpers.

**`lib/Service/File/CertificateChainService.php`**

Infection scoped to this file, running only `CertificateChainServiceTest` (`--threads=4`, 60 s timeout):

| | mutants | killed | escaped | Covered Code MSI |
|---|---|---|---|---|
| before | 22 | 17 | 5 | 77% |
| after | 27 | 25 | 2 | 92% |

New tests:

- the two early returns (`validateFile` disabled / file without signed node) through a data provider — the file must not even be opened, which kills the `||` → `&&` mutant;
- hash mismatch: the chain is still returned and the policy user is still set, but `setIsLibreSignFile()` must not be called;
- handler failure: a warning with the underlying message is logged and an empty array is returned;
- the stream is rewound before the handler reads it and closed afterwards. `PolicyAwarePkcs12HandlerDouble` now records what it read and returns two signature entries, as the real handler does, so the `ArrayOneItem` mutant on the return is detected. The existing success test asserts the full array instead of a `chain` key that the real handler does not return at the top level.

The two remaining escaped mutants are `fread($resource, 8192 ± 1)`: any buffer size produces the same hash, so they are equivalent.

**`lib/Handler/CertificateEngine/CertificateHelper.php`**

Infection scoped to this file, running only `CertificateHelperTest` (`--threads=1`, 60 s timeout):

| | mutants | killed | escaped | Covered Code MSI |
|---|---|---|---|---|
| before | 30 | 27 | 3 | 90% |
| after | 30 | 30 | 0 | 100% |

The three escaped mutants were all on the `saveFile()` failure message (concatenation order and operand removal). `testSaveFileWithError` now asserts the message **shape** — a description, a colon, then the file that could not be written — rather than its wording, following the discussion in #8117.

Notes on the measurements: the runs use the class's own tests so they are reproducible in a couple of minutes; with the whole unit suite and Infection's default 10 s timeout the `CertificateHelper` numbers are polluted by false timeouts (the test process boots Nextcloud) and, with several threads, by test classes extending `OCA\Libresign\Tests\Unit\TestCase` racing on the shared `/tmp/libresign__original` backup. Nothing in this PR changes that; I can open a separate note if it is useful.

### Related Issue

Ref #8053

### Pull Request Type

- Test

### Pull request checklist

- [x] Tests pass locally (PHPUnit + Infection)
- [x] AI-assisted: yes (see commit trailer)
