### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -264,12 +264,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "dc4ab4e912b2e17899620609b41518f2fd8137df"
+                "reference": "b2883ab5ad6a7ab012cac0c42c1580083e2aae68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dc4ab4e912b2e17899620609b41518f2fd8137df",
-                "reference": "dc4ab4e912b2e17899620609b41518f2fd8137df",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b2883ab5ad6a7ab012cac0c42c1580083e2aae68",
+                "reference": "b2883ab5ad6a7ab012cac0c42c1580083e2aae68",
                 "shasum": ""
             },
             "require": {
@@ -305,7 +305,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-08-27T05:37:43+00:00"
+            "time": "2026-08-29T04:41:42+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency