### PR TITLE
fix: restore Nextcloud 32 files integration

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\AppInfo;
 
-use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files\Event\LoadSidebar;
 use OCA\Libresign\Activity\Listener as ActivityListener;
 use OCA\Libresign\Capabilities;
@@ -67,7 +66,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(SignedEvent::class, SignedCallbackListener::class);
 
 		// Files newFile listener
-		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
+		$context->registerEventListener('OCA\\Files\\Event\\LoadAdditionalScriptsEvent', LoadAdditionalListener::class);
 
 		// Activity listeners
 		$context->registerEventListener(SendSignNotificationEvent::class, ActivityListener::class);

--- a/lib/Listener/LoadAdditionalListener.php
+++ b/lib/Listener/LoadAdditionalListener.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Listener;
 
-use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCP\App\IAppManager;
@@ -18,9 +17,11 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
 /**
- * @template-implements IEventListener<LoadAdditionalScriptsEvent>
+ * @template-implements IEventListener<Event>
  */
 class LoadAdditionalListener implements IEventListener {
+	private const FILES_LOAD_ADDITIONAL_SCRIPTS_EVENT = 'OCA\\Files\\Event\\LoadAdditionalScriptsEvent';
+
 	public function __construct(
 		private IAppManager $appManager,
 		private CertificateEngineFactory $certificateEngineFactory,
@@ -29,7 +30,7 @@ class LoadAdditionalListener implements IEventListener {
 	}
 	#[\Override]
 	public function handle(Event $event): void {
-		if (!($event instanceof LoadAdditionalScriptsEvent)) {
+		if (!is_a($event, self::FILES_LOAD_ADDITIONAL_SCRIPTS_EVENT)) {
 			return;
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/dialogs": "^7.3.0",
         "@nextcloud/event-bus": "^3.3.3",
-        "@nextcloud/files": "^4.0.0",
+        "@nextcloud/files": "^3.12.2",
         "@nextcloud/initial-state": "^3.0.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/logger": "^3.0.3",
@@ -2118,6 +2118,66 @@
         "node": "^20 || ^22 || ^24"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
+        "is-svg": "^6.1.0",
+        "typescript-event-target": "^1.1.2",
+        "webdav": "^5.9.0"
+      },
+      "engines": {
+        "node": "^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/files": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
+        "cancelable-promise": "^4.3.1",
+        "is-svg": "^6.1.0",
+        "typescript-event-target": "^1.1.1",
+        "webdav": "^5.8.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/sharing": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
+      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/initial-state": "^3.0.0",
+        "is-svg": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "@nextcloud/files": "^3.12.0"
+      }
+    },
     "node_modules/@nextcloud/eslint-config": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@nextcloud/eslint-config/-/eslint-config-8.4.2.tgz",
@@ -2205,32 +2265,10 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
-      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/auth": "^2.5.3",
-        "@nextcloud/capabilities": "^1.2.1",
-        "@nextcloud/l10n": "^3.4.1",
-        "@nextcloud/logger": "^3.0.3",
-        "@nextcloud/paths": "^3.0.0",
-        "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.3.0",
-        "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.2",
-        "webdav": "^5.9.0"
-      },
-      "engines": {
-        "node": "^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/files/node_modules/@nextcloud/files": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
       "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
       "license": "AGPL-3.0-or-later",
-      "optional": true,
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2424,53 +2462,6 @@
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/upload/node_modules/@nextcloud/files": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
-      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/auth": "^2.5.3",
-        "@nextcloud/capabilities": "^1.2.1",
-        "@nextcloud/l10n": "^3.4.1",
-        "@nextcloud/logger": "^3.0.3",
-        "@nextcloud/paths": "^3.0.0",
-        "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.3.0",
-        "cancelable-promise": "^4.3.1",
-        "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.1",
-        "webdav": "^5.8.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/upload/node_modules/@nextcloud/files/node_modules/@nextcloud/paths": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.1.0.tgz",
-      "integrity": "sha512-vtFYA/kthaUDzu6KejTOL1OwnOy7/yynq5zdB/UBpYacAWjUX5Ddh4OMWx3rEavkBJ9/QGhrFryNJLjNfe8OQA==",
-      "license": "GPL-3.0-or-later",
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/upload/node_modules/@nextcloud/files/node_modules/@nextcloud/sharing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/initial-state": "^3.0.0",
-        "is-svg": "^6.1.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      },
-      "optionalDependencies": {
-        "@nextcloud/files": "^3.12.0"
       }
     },
     "node_modules/@nextcloud/upload/node_modules/@nextcloud/paths": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/dialogs": "^7.3.0",
     "@nextcloud/event-bus": "^3.3.3",
-    "@nextcloud/files": "^4.0.0",
+    "@nextcloud/files": "^3.12.2",
     "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/logger": "^3.0.3",

--- a/src/actions/openInLibreSignAction.js
+++ b/src/actions/openInLibreSignAction.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2020-2024 LibreCode coop and contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { registerFileAction, getSidebar } from '@nextcloud/files'
+import { FileAction, registerFileAction } from '@nextcloud/files'
 import { getCapabilities } from '@nextcloud/capabilities'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
@@ -11,6 +11,9 @@ import EditNameDialog from '../components/Common/EditNameDialog.vue'
 
 // eslint-disable-next-line import/no-unresolved
 import SvgIcon from '../../img/app-dark.svg?raw'
+
+const getNodes = input => Array.isArray(input) ? input : input?.nodes ?? []
+const getNode = input => Array.isArray(input) ? input[0] : input?.nodes?.[0] ?? input
 
 /**
  * Prompts user for envelope name via dialog
@@ -27,12 +30,13 @@ async function promptEnvelopeName() {
 	return envelopeName
 }
 
-export const action = {
+export const action = new FileAction({
 	id: 'open-in-libresign',
 	displayName: () => t('libresign', 'Open in LibreSign'),
 	iconSvgInline: () => SvgIcon,
 
-	enabled({ nodes }) {
+	enabled(input) {
+		const nodes = getNodes(input)
 		const getNodeMime = (node) => node?.mime || node?.mimetype || ''
 
 		if (!loadState('libresign', 'certificate_ok', false)) {
@@ -62,10 +66,11 @@ export const action = {
 	/**
 	 * Single file or folder: open in sidebar
 	 */
-	async exec({ nodes }) {
-		const sidebar = getSidebar()
-		const node = nodes[0]
-		await sidebar.open(node, 'libresign')
+	async exec(input) {
+		const node = getNode(input)
+		const sidebar = window.OCA.Files.Sidebar
+		sidebar.close()
+		await sidebar.open(node.path)
 		sidebar.setActiveTab('libresign')
 		return null
 	},
@@ -74,11 +79,12 @@ export const action = {
 	 * Multiple files: prepare envelope data and delegate to sidebar
 	 * Similar to exec, but passes multiple files to the sidebar for processing
 	 */
-	async execBatch({ nodes }) {
+	async execBatch(input) {
+		const nodes = getNodes(input)
 		const getNodeFileId = (node) => node?.fileid ?? node?.id
 
 		if (nodes.length === 1) {
-			await this.exec({ nodes })
+			await this.exec(nodes[0])
 			return [null]
 		}
 
@@ -106,15 +112,16 @@ export const action = {
 			uuid: null,
 		}
 
-		const sidebar = getSidebar()
+		const sidebar = window.OCA.Files.Sidebar
 		const firstNode = nodes[0]
-		await sidebar.open(firstNode, 'libresign')
+		sidebar.close()
+		await sidebar.open(firstNode.path)
 		sidebar.setActiveTab('libresign')
 
 		return new Array(nodes.length).fill(null)
 	},
 
 	order: -1000,
-}
+})
 
 registerFileAction(action)

--- a/src/actions/showStatusInlineAction.js
+++ b/src/actions/showStatusInlineAction.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2025 LibreCode coop and contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { registerFileAction, getSidebar } from '@nextcloud/files'
+import { FileAction, registerFileAction } from '@nextcloud/files'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 
@@ -11,11 +11,14 @@ import { getStatusLabel, getStatusSvgInline } from '../utils/fileStatus.js'
 
 const getNodeId = (node) => node?.fileid ?? node?.id
 const getNodeMime = (node) => node?.mime || node?.mimetype || ''
+const getNodes = input => Array.isArray(input) ? input : input?.nodes ?? []
+const getNode = input => Array.isArray(input) ? input[0] : input?.nodes?.[0] ?? input
 
-const action = {
+const action = new FileAction({
 	id: 'show-status-inline',
 	displayName: () => '',
-	title: ({ nodes }) => {
+	title: (input) => {
+		const nodes = getNodes(input)
 		const node = nodes?.[0]
 		if (!node || !node.attributes) return ''
 
@@ -28,15 +31,16 @@ const action = {
 
 		return t('libresign', 'original file')
 	},
-	exec: async ({ nodes }) => {
-		const sidebar = getSidebar()
-		const node = nodes?.[0]
+	exec: async (input) => {
+		const node = getNode(input)
 		if (!node) return null
-		sidebar.open(node, 'libresign')
+		const sidebar = window.OCA.Files.Sidebar
+		await sidebar.open(node.path)
 		sidebar.setActiveTab('libresign')
 		return null
 	},
-	iconSvgInline: ({ nodes }) => {
+	iconSvgInline: (input) => {
+		const nodes = getNodes(input)
 		const node = nodes?.[0]
 		if (!node || !node.attributes) return ''
 
@@ -50,7 +54,8 @@ const action = {
 		return getStatusSvgInline(FILE_STATUS.DRAFT) || ''
 	},
 	inline: () => true,
-	enabled: ({ nodes }) => {
+	enabled: (input) => {
+		const nodes = getNodes(input)
 		const certificateOk = loadState('libresign', 'certificate_ok')
 		const allHaveStatus = nodes?.every(node => node.attributes?.['libresign-signature-status'] !== undefined)
 
@@ -65,6 +70,6 @@ const action = {
 		return allPdfOrFolder
 	},
 	order: -1,
-}
+})
 
 registerFileAction(action)

--- a/src/init.ts
+++ b/src/init.ts
@@ -4,7 +4,7 @@
  */
 
 import axios from '@nextcloud/axios'
-import { addNewFileMenuEntry, Permission, getSidebar } from '@nextcloud/files'
+import { addNewFileMenuEntry, Permission } from '@nextcloud/files'
 import type { NewMenuEntry, IFolder, INode } from '@nextcloud/files'
 import { registerDavProperty } from '@nextcloud/files/dav'
 import { getClient, getDefaultPropfind, getRootPath, resultToNode } from '@nextcloud/files/dav'
@@ -78,8 +78,8 @@ addNewFileMenuEntry({
 			const node = resultToNode(result.data)
 
 			// Open sidebar with LibreSign tab
-			const sidebar = getSidebar()
-			await sidebar.open(node, 'libresign')
+			const sidebar = (window.OCA.Files as { Sidebar: { open: (path: string) => Promise<void>; setActiveTab: (tabId: string) => void } }).Sidebar
+			await sidebar.open(node.path)
 			sidebar.setActiveTab('libresign')
 		}
 

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -8,7 +8,7 @@ import { createApp, type App as VueApp } from 'vue'
 
 import { loadState } from '@nextcloud/initial-state'
 import { t, n } from '@nextcloud/l10n'
-import { FileType, registerSidebarTab } from '@nextcloud/files'
+import { FileType } from '@nextcloud/files'
 
 import LibreSignLogoDarkSvg from '../img/app-dark.svg?raw'
 
@@ -42,6 +42,8 @@ interface SidebarNode {
 	mime?: string
 	mimetype?: string
 	attributes?: Record<string, unknown>
+	isDirectory?: () => boolean
+	get?: (key: string) => unknown
 }
 
 interface SidebarContext {
@@ -54,20 +56,23 @@ interface TabComponentInstance {
 }
 
 function mapNodeToFileInfo(node: SidebarNode = {}): FileInfo {
-	const name = node.basename || node.displayname || node.name || ''
-	const dirname = node.dirname || (node.path ? node.path.substring(0, node.path.lastIndexOf('/')) : '')
+	const getValue = (key: string) => node.get?.(key) ?? node[key as keyof SidebarNode]
+	const path = String(getValue('path') ?? '')
+	const name = String(getValue('basename') || getValue('displayname') || getValue('name') || '')
+	const dirname = String(getValue('dirname') || (path ? path.substring(0, path.lastIndexOf('/')) : ''))
+	const type = String(getValue('type') ?? '')
 	return {
-		id: node.fileid ?? node.id ?? '',
+		id: (getValue('fileid') ?? getValue('id') ?? '') as number | string,
 		name,
 		path: dirname,
-		type: node.type || '',
-		attributes: node.attributes || {},
+		type,
+		attributes: getValue('attributes') as Record<string, unknown> || {},
 		isDirectory() {
-			return node.type === FileType.Folder || node.type === 'folder'
+			return node.isDirectory?.() ?? (type === FileType.Folder || type === 'folder')
 		},
 		get(key: string) {
 			if (key === 'mimetype') {
-				return node.mime || node.mimetype
+				return getValue('mime') as string || getValue('mimetype') as string
 			}
 			return undefined
 		},
@@ -191,31 +196,65 @@ function isEnabled(context: SidebarContext | null | undefined) {
 	}
 
 	const node = context.node
-	const mimetype = node.mime || node.mimetype || ''
-	const isFolder = node.type === FileType.Folder || node.type === 'folder'
+	const fileInfo = mapNodeToFileInfo(node)
+	const mimetype = fileInfo.get('mimetype') || ''
+	const isFolder = fileInfo.isDirectory()
 
 	if (isFolder) {
-		const hasLibreSignStatus = node.attributes?.['libresign-signature-status'] !== undefined
+		const hasLibreSignStatus = fileInfo.attributes['libresign-signature-status'] !== undefined
 		if (hasLibreSignStatus) {
-			window.OCA.Libresign.fileInfo = mapNodeToFileInfo(node)
+			window.OCA.Libresign.fileInfo = fileInfo
 			return true
 		}
 		return false
 	}
 
-	window.OCA.Libresign.fileInfo = mapNodeToFileInfo(node)
+	window.OCA.Libresign.fileInfo = fileInfo
 
 	return mimetype === 'application/pdf'
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function registerLibresignSidebarTab() {
 	setupCustomElement()
-	registerSidebarTab({
+
+	const sidebar = (window.OCA?.Files as {
+		Sidebar?: {
+			Tab: new (config: Record<string, unknown>) => unknown
+			registerTab: (tab: unknown) => void
+		}
+	} | undefined)?.Sidebar
+	if (!sidebar?.registerTab || !sidebar?.Tab) {
+		return
+	}
+
+	let tabElement: LibreSignSidebarTabElement | null = null
+	sidebar.registerTab(new sidebar.Tab({
 		id: 'libresign',
 		order: 95,
-		displayName: t('libresign', 'LibreSign'),
+		name: t('libresign', 'LibreSign'),
+		icon: 'icon-rename',
 		iconSvgInline: LibreSignLogoDarkSvg,
-		enabled: isEnabled,
-		tagName,
-	})
-})
+		enabled: (input: SidebarNode | SidebarContext) => isEnabled({ node: (input as SidebarContext).node ?? input as SidebarNode }),
+		async mount(element: Element, node: SidebarNode) {
+			tabElement = document.createElement(tagName) as LibreSignSidebarTabElement
+			tabElement.node = node
+			element.appendChild(tabElement)
+			await tabElement.setActive(true)
+		},
+		update(node: SidebarNode) {
+			if (tabElement) {
+				tabElement.node = node
+			}
+		},
+		destroy() {
+			tabElement?.remove()
+			tabElement = null
+		},
+	}))
+}
+
+if (document.readyState === 'loading') {
+	window.addEventListener('DOMContentLoaded', registerLibresignSidebarTab, { once: true })
+} else {
+	registerLibresignSidebarTab()
+}

--- a/src/tests/actions/openInLibreSignAction.spec.ts
+++ b/src/tests/actions/openInLibreSignAction.spec.ts
@@ -350,6 +350,15 @@ describe('openInLibreSignAction rules', () => {
 
 			expect(result).toBeNull()
 		})
+
+		it('accepts a raw node as the action input', async () => {
+			const node = { type: 'file', mime: 'application/pdf', path: '/raw.pdf' }
+
+			await action.exec(node as unknown as { nodes: unknown })
+
+			expect(mockSidebar.close).toHaveBeenCalled()
+			expect(mockSidebar.open).toHaveBeenCalledWith('/raw.pdf')
+		})
 	})
 
 	describe('execBatch execution for multiple files', () => {
@@ -412,6 +421,15 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 			expect(mockSidebar.open).toHaveBeenCalled()
 			expect(mockSidebar.setActiveTab).toHaveBeenCalledWith('libresign')
+		})
+
+		it('delegates a single-node batch to exec', async () => {
+			const node = { type: 'file', mime: 'application/pdf', path: '/single.pdf' }
+
+			const result = await action.execBatch([node] as unknown as { nodes: unknown })
+
+			expect(result).toEqual([null])
+			expect(mockSidebar.open).toHaveBeenCalledWith('/single.pdf')
 		})
 
 		it('creates correct pending envelope structure', async () => {
@@ -512,10 +530,12 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 
 		it('has displayName function', () => {
 			expect(typeof action.displayName).toBe('function')
+			expect((action.displayName as () => string)()).toBe('Open in LibreSign')
 		})
 
 		it('has iconSvgInline function', () => {
 			expect(typeof action.iconSvgInline).toBe('function')
+			expect((action.iconSvgInline as () => string)()).toContain('<svg')
 		})
 	})
 })

--- a/src/tests/actions/openInLibreSignAction.spec.ts
+++ b/src/tests/actions/openInLibreSignAction.spec.ts
@@ -26,6 +26,7 @@ vi.mock('@nextcloud/logger', () => ({
 }))
 
 const mockSidebar = {
+	close: vi.fn(),
 	open: vi.fn(),
 	setActiveTab: vi.fn(),
 }
@@ -92,7 +93,7 @@ vi.mock('@nextcloud/vue/functions/dialog', () => ({
 describe('openInLibreSignAction rules', () => {
 	let action: {
 		id: string
-		order: number
+		order?: number
 		displayName: unknown
 		iconSvgInline: unknown
 		enabled: (context: { nodes: unknown }) => boolean
@@ -121,6 +122,8 @@ describe('openInLibreSignAction rules', () => {
 
 	beforeEach(async () => {
 		vi.clearAllMocks()
+		window.OCA = window.OCA ?? {}
+		window.OCA.Files = { Sidebar: mockSidebar }
 		mockSidebar.open.mockClear()
 		mockSidebar.setActiveTab.mockClear()
 
@@ -134,7 +137,7 @@ describe('openInLibreSignAction rules', () => {
 		getCapabilities.mockReturnValue(mockCapabilities)
 
 		const module = await import('../../actions/openInLibreSignAction.js')
-		action = module.action
+		action = module.action as unknown as typeof action
 	})
 
 	afterEach(() => {
@@ -283,7 +286,7 @@ describe('openInLibreSignAction rules', () => {
 				{ type: 'file', mime: 'application/pdf', id: 1000, dirname: '/Test' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -320,11 +323,11 @@ describe('openInLibreSignAction rules', () => {
 		})
 
 		it('opens sidebar with file', async () => {
-			const node = { type: 'file', mime: 'application/pdf', fileid: 123 }
+			const node = { type: 'file', mime: 'application/pdf', fileid: 123, path: '/test.pdf' }
 
 			await action.exec({ nodes: [node] })
 
-			expect(mockSidebar.open).toHaveBeenCalledWith(node, 'libresign')
+			expect(mockSidebar.open).toHaveBeenCalledWith(node.path)
 			expect(mockSidebar.setActiveTab).toHaveBeenCalledWith('libresign')
 		})
 
@@ -333,11 +336,12 @@ describe('openInLibreSignAction rules', () => {
 				type: 'folder',
 				attributes: { 'libresign-signature-status': 'signed' },
 				fileid: 456,
+				path: '/signed',
 			}
 
 			await action.exec({ nodes: [node] })
 
-			expect(mockSidebar.open).toHaveBeenCalledWith(node, 'libresign')
+			expect(mockSidebar.open).toHaveBeenCalledWith(node.path)
 		})
 
 		it('returns null after execution', async () => {
@@ -402,7 +406,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/Docs' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -416,7 +420,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/Docs' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -433,7 +437,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/Documents/Contracts' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -447,7 +451,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -461,7 +465,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				{ type: 'file', mime: 'application/pdf', fileid: 2, dirname: '/Docs/' },
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 
@@ -487,7 +491,7 @@ let spawnDialog: typeof import('@nextcloud/vue/functions/dialog').spawnDialog
 				},
 			]
 
-			window.OCA = { Libresign: {} }
+			window.OCA = { ...window.OCA, Libresign: {} }
 
 			await action.execBatch({ nodes })
 

--- a/src/tests/actions/showStatusInlineAction.spec.ts
+++ b/src/tests/actions/showStatusInlineAction.spec.ts
@@ -43,6 +43,13 @@ describe('showStatusInlineAction', () => {
 		mockRegisterFileAction = vi.fn()
 		mockGetSidebar = vi.fn()
 		mockLoadState = vi.fn(() => true)
+		window.OCA = window.OCA ?? {}
+		window.OCA.Files = {
+			Sidebar: {
+				open: vi.fn(),
+				setActiveTab: vi.fn(),
+			},
+		}
 
 		// Setup mocks with fresh state
 		vi.doMock('@nextcloud/files', () => ({
@@ -219,12 +226,12 @@ describe('showStatusInlineAction', () => {
 				open: vi.fn(),
 				setActiveTab: vi.fn(),
 			}
-			mockGetSidebar.mockReturnValue(mockSidebar)
+			window.OCA.Files = { Sidebar: mockSidebar }
 
-			const node = { fileid: 123, name: 'test.pdf' }
+			const node = { fileid: 123, name: 'test.pdf', path: '/test.pdf' }
 			const result = await action.exec({ nodes: [node] })
 
-			expect(mockSidebar.open).toHaveBeenCalledWith(node, 'libresign')
+			expect(mockSidebar.open).toHaveBeenCalledWith(node.path)
 			expect(mockSidebar.setActiveTab).toHaveBeenCalledWith('libresign')
 			expect(result).toBe(null)
 		})
@@ -358,4 +365,3 @@ describe('showStatusInlineAction', () => {
 		})
 	})
 })
-

--- a/src/tests/init.spec.ts
+++ b/src/tests/init.spec.ts
@@ -159,6 +159,8 @@ function setupFileInputInterception(fileName: string, mimeType = 'application/pd
 describe('init.ts', () => {
 	beforeEach(async () => {
 		vi.clearAllMocks()
+		window.OCA = window.OCA ?? {}
+		window.OCA.Files = { Sidebar: mockSidebar }
 
 		// Reset stat mock to return valid data for resultToNode
 		mockStat.mockResolvedValue({ data: { filename: '/files/testuser/Documents/test.pdf' } })

--- a/src/tests/tab.spec.ts
+++ b/src/tests/tab.spec.ts
@@ -121,16 +121,68 @@ describe('tab.ts', () => {
 		})
 	})
 
+	it('enabled() accepts raw nodes and maps values exposed through get()', () => {
+		mockLoadState.mockReturnValue(true)
+		const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as {
+			enabled: (node: Record<string, unknown>) => boolean
+		}
+		const values: Record<string, unknown> = {
+			id: 'legacy-id',
+			displayname: 'Contract.pdf',
+			path: '/Documents/Contract.pdf',
+			type: 'file',
+			mimetype: 'application/pdf',
+			attributes: { custom: true },
+		}
+
+		expect(tabConfig.enabled({
+			get: (key: string) => values[key],
+			isDirectory: () => false,
+		})).toBe(true)
+		expect(window.OCA.Libresign.fileInfo).toMatchObject({
+			id: 'legacy-id',
+			name: 'Contract.pdf',
+			path: '/Documents',
+			attributes: { custom: true },
+		})
+		const fileInfo = window.OCA.Libresign.fileInfo as { get: (key: string) => unknown }
+		expect(fileInfo.get('unknown')).toBeUndefined()
+	})
+
+	it('mounts, updates, and destroys the registered sidebar tab', async () => {
+		const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as {
+			mount: (element: Element, node: Record<string, unknown>) => Promise<void>
+			update: (node: Record<string, unknown>) => void
+			destroy: () => void
+		}
+		const host = document.createElement('div')
+		document.body.appendChild(host)
+
+		await tabConfig.mount(host, { fileid: 1, path: '/first.pdf', mime: 'application/pdf' })
+		await vi.waitFor(() => expect(mockVueApp.mount).toHaveBeenCalledOnce())
+		tabConfig.update({ fileid: 2, path: '/second.pdf', mime: 'application/pdf' })
+
+		expect(host.querySelector('libresign-files-sidebar-tab')).not.toBeNull()
+		expect(mockMountedInstance.update).toHaveBeenLastCalledWith(expect.objectContaining({
+			id: 2,
+			name: '',
+			path: '',
+		}))
+
+		tabConfig.destroy()
+		expect(host.querySelector('libresign-files-sidebar-tab')).toBeNull()
+		expect(mockVueApp.unmount).toHaveBeenCalledOnce()
+	})
+
 	it('lazy mounts Vue only when custom element is connected and unmounts on disconnect', async () => {
 		const TabElement = window.customElements.get('libresign-files-sidebar-tab')
 		expect(TabElement).toBeDefined()
 		expect(mockCreateApp).not.toHaveBeenCalled()
-		expect(appFilesTabModuleLoaded).not.toHaveBeenCalled()
 
 		const element = document.createElement('libresign-files-sidebar-tab')
 		document.body.appendChild(element)
 
-		await vi.waitFor(() => expect(appFilesTabModuleLoaded).toHaveBeenCalledOnce())
+		await vi.waitFor(() => expect(mockCreateApp).toHaveBeenCalledOnce())
 		expect(mockCreateApp).toHaveBeenCalledOnce()
 		expect(mockVueApp.mount).toHaveBeenCalledOnce()
 

--- a/src/tests/tab.spec.ts
+++ b/src/tests/tab.spec.ts
@@ -52,28 +52,42 @@ vi.mock('../../img/app-dark.svg?raw', () => ({ default: '<svg />' }))
 vi.mock('../style/icons.scss', () => ({}))
 
 beforeAll(async () => {
+	window.OCA = window.OCA ?? {}
+	window.OCA.Files = {
+		Sidebar: {
+			Tab: class Tab {
+				constructor(config: Record<string, unknown>) {
+					Object.assign(this, config)
+				}
+			},
+			registerTab: mockRegisterSidebarTab,
+		},
+	}
 	await import('../tab')
 })
 
 beforeEach(() => {
-	vi.clearAllMocks()
+	mockLoadState.mockClear()
+	mockCreatePinia.mockClear()
+	mockCreateApp.mockClear()
+	mockVueApp.use.mockClear()
+	mockVueApp.mount.mockClear()
+	mockVueApp.unmount.mockClear()
+	mockMountedInstance.update.mockClear()
+	appFilesTabModuleLoaded.mockClear()
 	window.OCA = window.OCA ?? {}
 	window.OCA.Libresign = {}
 })
 
 describe('tab.ts', () => {
-	it('registers LibreSign sidebar tab on DOMContentLoaded', () => {
-		window.dispatchEvent(new Event('DOMContentLoaded'))
-
+	it('registers LibreSign sidebar tab when loaded after DOMContentLoaded', () => {
 		expect(mockRegisterSidebarTab).toHaveBeenCalledOnce()
-		const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as { id: string; tagName: string }
-		expect(tabConfig.id).toBe('libresign')
-		expect(tabConfig.tagName).toBe('libresign-files-sidebar-tab')
+	const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as { id: string }
+	expect(tabConfig.id).toBe('libresign')
 	})
 
 	it('enabled() returns false when certificate is not configured', () => {
 		mockLoadState.mockReturnValue(false)
-		window.dispatchEvent(new Event('DOMContentLoaded'))
 		const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as {
 			enabled: (context: { node: Record<string, unknown> }) => boolean
 		}
@@ -83,7 +97,6 @@ describe('tab.ts', () => {
 
 	it('enabled() accepts signed folders and maps file info into OCA.Libresign', () => {
 		mockLoadState.mockReturnValue(true)
-		window.dispatchEvent(new Event('DOMContentLoaded'))
 		const tabConfig = mockRegisterSidebarTab.mock.calls[0][0] as {
 			enabled: (context: { node: Record<string, unknown> }) => boolean
 		}
@@ -109,8 +122,6 @@ describe('tab.ts', () => {
 	})
 
 	it('lazy mounts Vue only when custom element is connected and unmounts on disconnect', async () => {
-		window.dispatchEvent(new Event('DOMContentLoaded'))
-
 		const TabElement = window.customElements.get('libresign-files-sidebar-tab')
 		expect(TabElement).toBeDefined()
 		expect(mockCreateApp).not.toHaveBeenCalled()


### PR DESCRIPTION
Resolves: # <!-- Add the related issue number, if available -->

## 📝 Summary

Restores LibreSign integration with the Files app on Nextcloud 32.

LibreSign 12.4.8 was built against `@nextcloud/files` 4.x and used Files APIs introduced with Nextcloud 33, including `getSidebar()` and the newer file-action callback contracts. Nextcloud 32 provides `@nextcloud/files` 3.12.x and the legacy `OCA.Files.Sidebar` API. As a result, the LibreSign context-menu actions and sidebar tab were not registered correctly.

This PR:

- Pins `@nextcloud/files` to the Nextcloud 32-compatible 3.12.x release.
- Uses the legacy `FileAction` callback contracts.
- Opens and registers sidebar tabs through `OCA.Files.Sidebar`.
- Supports the legacy `FileInfo` object passed by the Nextcloud 32 sidebar.
- Handles scripts loaded before or after `DOMContentLoaded`.
- Restores the Files integration event registration without resolving the Files event class too early.
- Updates the focused frontend tests for the Nextcloud 32 contracts.

## 🧪 How to test

1. Install this branch as LibreSign on Nextcloud 32.
2. Configure a working LibreSign certificate engine:
   ```bash
   php occ libresign:configure:openssl \
     --cn="LibreSign Test Root CA" \
     --o="LibreSign Test" \
     --ou="Development" \
     --c="DE"
   ```
3. Confirm the configuration:
   ```bash
   php occ libresign:configure:check
   ```
4. Open the Nextcloud Files app and perform a hard refresh.
5. Open the context menu for a PDF.
6. Confirm that **Open in LibreSign** is displayed.
7. Open the details sidebar for a PDF.
8. Confirm that the **LibreSign** sidebar tab is displayed.
9. Select **Open in LibreSign** and confirm that the sidebar opens with the LibreSign tab active.
10. Confirm that non-PDF files do not display the LibreSign action or tab.