### PR TITLE
[stable32] ci: use the docker-compose Dependabot ecosystem for the devcontainer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,8 @@ updates:
     schedule:
       interval: daily
 
-  # Maintain the Nextcloud image used by the devcontainer
-  - package-ecosystem: "docker"
+  # Maintain the images used by the devcontainer (docker-compose.yml)
+  - package-ecosystem: "docker-compose"
     directory: "/.devcontainer"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Backport of #8123 