### PR TITLE
docs: show the Digital Public Good recognition in the README and the App Store description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/LibreSign/libresign/badge.svg?branch=main)](https://coveralls.io/github/LibreSign/libresign?branch=main)
 [![REUSE status](https://api.reuse.software/badge/github.com/LibreSign/libresign)](https://api.reuse.software/info/github.com/LibreSign/libresign)
 [![Start contributing](https://img.shields.io/github/issues/LibreSign/libresign/good%20first%20issue?color=7057ff&label=Contribute)](https://github.com/LibreSign/libresign/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22)
+[![Verified DPG (Since 2025)](https://img.shields.io/badge/Verified-DPG%20(Since%20%202025)-3333AB?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEiIGhlaWdodD0iMzMiIHZpZXdCb3g9IjAgMCAzMSAzMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjIwMDggMjEuMzY3OEwxMC4xNzM2IDE4LjAxMjRMMTEuNTIxOSAxNi40MDAzTDEzLjk5MjggMTguNDU5TDE5LjYyNjkgMTIuMjExMUwyMS4xOTA5IDEzLjYxNkwxNC4yMDA4IDIxLjM2NzhaTTI0LjYyNDEgOS4zNTEyN0wyNC44MDcxIDMuMDcyOTdMMTguODgxIDUuMTg2NjJMMTUuMzMxNCAtMi4zMzA4MmUtMDVMMTEuNzgyMSA1LjE4NjYyTDUuODU2MDEgMy4wNzI5N0w2LjAzOTA2IDkuMzUxMjdMMCAxMS4xMTc3TDMuODQ1MjEgMTYuMDg5NUwwIDIxLjA2MTJMNi4wMzkwNiAyMi44Mjc3TDUuODU2MDEgMjkuMTA2TDExLjc4MjEgMjYuOTkyM0wxNS4zMzE0IDMyLjE3OUwxOC44ODEgMjYuOTkyM0wyNC44MDcxIDI5LjEwNkwyNC42MjQxIDIyLjgyNzdMMzAuNjYzMSAyMS4wNjEyTDI2LjgxNzYgMTYuMDg5NUwzMC42NjMxIDExLjExNzdMMjQuNjI0MSA5LjM1MTI3WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://digitalpublicgoods.net/r/libresign)
 
 # LibreSign
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,6 +7,8 @@
 
 It is built for teams that need clear signing rules, traceable actions, and workflows that follow internal processes and legal requirements.
 
+LibreSign has been a verified [Digital Public Good](https://digitalpublicgoods.net/r/libresign) since 2025.
+
 **What LibreSign enables**
 
 - Define signing order and signer roles


### PR DESCRIPTION
Resolves: #8125

## 📝 Summary

LibreSign is listed in the [Digital Public Goods Registry](https://www.digitalpublicgoods.net/r/libresign) since 2025, but nothing in the repository or in the app metadata mentions it (follow-up of #8104, as suggested by @vitormattos). The reasoning behind each choice is in #8125.

- **README**: adds the official DPGA badge to the existing badge row, linking to the LibreSign entry in the DPG Registry. It is the "Since" variant from the [DPG badge usage guide](https://github.com/DPGAlliance/dpg-resources/blob/main/docs/dpg-badge-usage.md) (CC0-licensed), the same format used by other verified DPGs such as Ghost, OpenMRS and Open Food Facts.
- **`appinfo/info.xml`**: adds one sentence to the `<description>` so the recognition is also visible in the Nextcloud App Store. Text with a link, no image: the badge URL embeds a ~2 KB base64 logo, and the in-app renderer of Settings › Apps does not render markdown images anyway (the existing Sponsor badge already shows there as raw markdown).

## 🧪 How to test

1. Open the rendered README of this branch: the "Verified DPG (Since 2025)" badge appears at the end of the badge row and links to the registry entry.
2. `appinfo/info.xml` still validates against the App Store schema (same check as the `Lint info.xml` workflow):
   ```bash
   wget -q https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd
   php -r '$d = new DOMDocument(); $d->load("appinfo/info.xml"); exit($d->schemaValidate("info.xsd") ? 0 : 1);'
   ```
3. In a dev instance, open **Settings › Apps › LibreSign › Description**: the new sentence shows with the link to the registry entry.

| README | Settings › Apps › Description |
| --- | --- |
| ![README with the Verified DPG badge](https://raw.githubusercontent.com/maia-andre/libresign/assets/8125-dpg-recognition/8125/01-readme-badge-github.png) | ![App description with the DPG sentence](https://raw.githubusercontent.com/maia-andre/libresign/assets/8125-dpg-recognition/8125/02-settings-apps-description.png) |

### 🚧 Tasks

- [ ] After merge: backport to `stable32`…`stable35` — releases are cut from the stable branches, so the App Store description only picks this change up via backport (cherry-pick is clean on all four).

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
