### PR TITLE
ci: adjust workflow template synchronization

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -6,7 +6,8 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 
-# This workflow will update all workflow templates
+# This workflow updates selected workflow templates from nextcloud/.github
+# LibreSign-specific changes are kept in `workflow.yml.patch` files and reapplied after syncing
 # Additionally it will reapply `workflow.yml.patch` files after syncing and only then commit the result
 name: Update workflows
 on:

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -11,8 +11,6 @@
 name: Update workflows
 on:
   workflow_dispatch:
-  schedule:
-      - cron: "5 2 * * 0"
 
 permissions:
   contents: read
@@ -21,17 +19,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        branches:
-          - ${{ github.event.repository.default_branch }}
-          - 'stable35'
-          - 'stable34'
-          - 'stable33'
-          - 'stable32'
-
-    name: Update workflows in ${{ matrix.branches }}
+    name: Update workflows in ${{ github.event.repository.default_branch }}
 
     permissions:
       contents: write
@@ -55,16 +43,28 @@ jobs:
         with:
           persist-credentials: false
           path: target
-          ref: ${{ matrix.branches }}
+          ref: ${{ github.event.repository.default_branch }}
 
-      - name: Copy all workflow templates
+      - name: Copy selected workflow templates
         run: |
           echo 'SUMMARY<<EOF' >> $GITHUB_ENV
           draft_only=0
-          for workflow in ./source/workflow-templates/*.yml; do
+
+          workflows=(
+            "lint-eslint.yml"
+            "lint-typescript.yml"
+            "node-test.yml"
+            "npm-build.yml"
+            "phpunit-mariadb.yml"
+            "phpunit-mysql.yml"
+            "phpunit-pgsql.yml"
+            "phpunit-sqlite.yml"
+          )
+
+          for filename in "${workflows[@]}"; do
+            workflow="./source/workflow-templates/$filename"
             echo "❓ Looking for $workflow"
             if [ -f "$workflow" ]; then
-              filename=$(basename "$workflow")
               target_file="./target/.github/workflows/$filename"
 
               # Only copy if the file exists in the target repository
@@ -130,8 +130,8 @@ jobs:
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>
           path: target
           signoff: true
-          branch: 'automated/noid/${{ matrix.branches }}-update-workflows'
-          title: '[${{ matrix.branches }}] ci(actions): Update workflow templates from organization template repository'
+          branch: 'automated/noid/${{ github.event.repository.default_branch }}-update-workflows'
+          title: '[${{ github.event.repository.default_branch }}] ci(actions): Update workflow templates from organization template repository'
           draft: ${{ env.DRAFT_ONLY == 1 }}
           add-paths: .github/workflows/*.yml,.github/actions-lock.txt
           body: |


### PR DESCRIPTION
Make workflow template synchronization manual and limit it to selected workflows on the default branch.

This avoids automatically creating PRs for unsupported or LibreSign-specific workflow changes.
