### PR TITLE
[stable32] test: cover CertificateChainService branches and the saveFile failure…

### DIFF
--- a/tests/php/Unit/Controller/IdentifyControllerTest.php
+++ b/tests/php/Unit/Controller/IdentifyControllerTest.php
@@ -40,6 +40,18 @@ class FakeCollaboratorSearch implements ISearch {
 		return [['exact' => [], 'wide' => []], false];
 	}
 
+	public function filteredSearch(
+		string $search,
+		array $shareTypes,
+		bool $lookup,
+		?string $itemType,
+		?string $itemId,
+		int $limit,
+		int $offset,
+	): array {
+		return $this->search($search, $shareTypes, $lookup, $limit, $offset);
+	}
+
 	public function registerPlugin(array $pluginInfo): void {
 	}
 }

--- a/tests/php/Unit/Handler/CertificateEngine/CertificateHelperTest.php
+++ b/tests/php/Unit/Handler/CertificateEngine/CertificateHelperTest.php
@@ -26,13 +26,27 @@ final class CertificateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertSame($content, file_get_contents($filename));
 	}
 
-	public function testSaveFileWithError(): void {
-		$this->expectException(LibresignException::class);
-
+	#[DataProvider('dataSaveFileWithError')]
+	public function testSaveFileWithError(string $basename): void {
 		vfsStream::setup('home', 0444);
-		$filename = vfsStream::url('home/test.txt');
+		$filename = vfsStream::url('home/' . $basename);
 
-		@CertificateHelper::saveFile($filename, '');
+		try {
+			@CertificateHelper::saveFile($filename, '');
+			$this->fail('saveFile() must throw when the file cannot be written');
+		} catch (LibresignException $e) {
+			$this->assertStringEndsWith(': ' . $filename, $e->getMessage());
+		}
+	}
+
+	public static function dataSaveFileWithError(): array {
+		return [
+			'plain name' => ['test.txt'],
+			'spaces' => ['my certificate.pem'],
+			'dots, dashes and underscores' => ['root-ca.v2_backup.crt'],
+			'regex metacharacters' => ['cert (copy) [1]+$.txt'],
+			'non-ascii' => ['certificado-ção.txt'],
+		];
 	}
 
 	#[DataProvider('dataProviderArrayToIni')]

--- a/tests/php/Unit/Service/File/CertificateChainServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateChainServiceTest.php
@@ -13,6 +13,7 @@ use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Service\File\CertificateChainService;
 use OCA\Libresign\Service\File\FileResponseOptions;
 use OCA\Libresign\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LoggerInterface;
 
 final class CertificateChainServiceTest extends TestCase {
@@ -37,9 +38,14 @@ final class CertificateChainServiceTest extends TestCase {
 		$libreSignFile->setSignedNodeId(1);
 		$libreSignFile->setSignedHash(hash('sha256', $content));
 
+		$chain = [
+			['chain' => [['name' => 'first signer']]],
+			['chain' => [['name' => 'second signer']]],
+		];
+
 		$pkcs12 = $this->createMock(Pkcs12Handler::class);
 		$pkcs12->expects($this->once())->method('setIsLibreSignFile');
-		$pkcs12->method('getCertificateChain')->willReturn(['chain' => []]);
+		$pkcs12->method('getCertificateChain')->willReturn($chain);
 
 		$logger = $this->createMock(LoggerInterface::class);
 
@@ -50,8 +56,7 @@ final class CertificateChainServiceTest extends TestCase {
 
 		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
 
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('chain', $result);
+		$this->assertSame($chain, $result);
 	}
 
 	public function testGetCertificateChainHandlesInvalidResourceGracefully(): void {
@@ -81,5 +86,129 @@ final class CertificateChainServiceTest extends TestCase {
 		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
 
 		$this->assertSame([], $result);
+	}
+
+	#[DataProvider('dataGetCertificateChainSkipsValidation')]
+	public function testGetCertificateChainSkipsValidation(bool $validateFile, ?int $signedNodeId): void {
+		$fileNode = new class() {
+			public function fopen($mode) {
+				throw new \LogicException('The signed file must not be opened when validation is skipped.');
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId($signedNodeId);
+
+		$pkcs12 = $this->createMock(Pkcs12Handler::class);
+		$pkcs12->expects($this->never())->method('getCertificateChain');
+		$pkcs12->expects($this->never())->method('setIsLibreSignFile');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$service = new CertificateChainService($pkcs12, $logger);
+
+		$options = new FileResponseOptions();
+		$options->validateFile($validateFile);
+
+		$this->assertSame([], $service->getCertificateChain($fileNode, $libreSignFile, $options));
+	}
+
+	public static function dataGetCertificateChainSkipsValidation(): array {
+		return [
+			'validation disabled' => [false, 1],
+			'missing signed node' => [true, null],
+		];
+	}
+
+	public function testGetCertificateChainDoesNotFlagLibreSignFileWhenHashDiffers(): void {
+		$content = 'content that was changed after signing';
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, $content);
+		rewind($stream);
+
+		$fileNode = new class($stream) {
+			public function __construct(
+				private $stream,
+			) {
+			}
+
+			public function fopen($mode) {
+				return $this->stream;
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId(1);
+		$libreSignFile->setSignedHash(hash('sha256', 'original content'));
+
+		$chain = [
+			['chain' => [['name' => 'first signer']]],
+			['chain' => [['name' => 'second signer']]],
+		];
+		$receivedContent = null;
+
+		$pkcs12 = $this->createMock(Pkcs12Handler::class);
+		$pkcs12->expects($this->never())->method('setIsLibreSignFile');
+		$pkcs12->method('getCertificateChain')
+			->willReturnCallback(function ($resource) use (&$receivedContent, $chain): array {
+				$receivedContent = stream_get_contents($resource);
+				return $chain;
+			});
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$service = new CertificateChainService($pkcs12, $logger);
+
+		$options = new FileResponseOptions();
+		$options->validateFile(true);
+
+		$result = $service->getCertificateChain($fileNode, $libreSignFile, $options);
+
+		$this->assertSame($chain, $result);
+		$this->assertSame($content, $receivedContent);
+		$this->assertFalse(
+			is_resource($stream),
+			'The signed file stream must be closed after reading the chain',
+		);
+	}
+
+	public function testGetCertificateChainLogsWarningAndReturnsEmptyWhenHandlerFails(): void {
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, 'signed content');
+		rewind($stream);
+
+		$fileNode = new class($stream) {
+			public function __construct(
+				private $stream,
+			) {
+			}
+
+			public function fopen($mode) {
+				return $this->stream;
+			}
+		};
+
+		$libreSignFile = new File();
+		$libreSignFile->setSignedNodeId(1);
+		$libreSignFile->setSignedHash(hash('sha256', 'signed content'));
+
+		$pkcs12 = $this->createMock(Pkcs12Handler::class);
+		$pkcs12->method('getCertificateChain')
+			->willThrowException(new \RuntimeException('unable to parse the signature'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger
+			->expects($this->once())
+			->method('warning')
+			->with($this->identicalTo('Failed to load certificate chain: unable to parse the signature'));
+
+		$service = new CertificateChainService($pkcs12, $logger);
+
+		$options = new FileResponseOptions();
+		$options->validateFile(true);
+
+		$this->assertSame([], $service->getCertificateChain($fileNode, $libreSignFile, $options));
 	}
 }


### PR DESCRIPTION
Backport of #8126 