### PR TITLE
test: support filtered collaborator search

### DIFF
--- a/tests/php/Unit/Controller/IdentifyControllerTest.php
+++ b/tests/php/Unit/Controller/IdentifyControllerTest.php
@@ -42,6 +42,10 @@ class FakeCollaboratorSearch implements ISearch {
 		return [['exact' => [], 'wide' => []], false];
 	}
 
+	public function filteredSearch(string $search, array $shareTypes, bool $lookup, ?string $itemType, ?string $itemId, int $limit, int $offset): array {
+		return $this->search($search, $shareTypes, $lookup, $limit, $offset);
+	}
+
 	public function registerPlugin(array $pluginInfo): void {
 	}
 }


### PR DESCRIPTION
Fixed:


 PHP Fatal error:  Class OCA\Libresign\Tests\Unit\Controller\FakeCollaboratorSearch contains 1 abstract method and must therefore be declared abstract or implement the remaining method (OCP\Collaboration\Collaborators\ISearch::filteredSearch) in /home/runner/work/libresign/libresign/apps/libresign/tests/php/Unit/Controller/IdentifyControllerTest.php on line 30
