### PR TITLE
refactor(exception): keep the semantic error codes next to the classes that raise them

### DIFF
--- a/lib/Exception/LibresignException.php
+++ b/lib/Exception/LibresignException.php
@@ -14,13 +14,6 @@ use JsonSerializable;
  * @codeCoverageIgnore
  */
 class LibresignException extends \Exception implements JsonSerializable {
-	/**
-	 * Error codes follow the closest HTTP status with one extra digit
-	 * (401 -> 4010), so they are not mistaken for HTTP status codes.
-	 */
-	public const int CODE_INVALID_TOKEN = 4010;
-	public const int CODE_TWOFACTOR_GATEWAY_NOT_ENABLED = 5030;
-
 	#[\Override]
 	public function jsonSerialize(): mixed {
 		return ['message' => $this->getMessage()];

--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -25,6 +25,13 @@ use OCP\Files\NotFoundException;
 use OCP\IUser;
 
 abstract class AbstractIdentifyMethod implements IIdentifyMethod {
+	/**
+	 * Semantic error code of the invalid verification code error: the closest
+	 * HTTP status with one extra digit (401 -> 4010), so it is not mistaken
+	 * for an HTTP status code.
+	 */
+	public const int CODE_INVALID_TOKEN = 4010;
+
 	protected IdentifyMethod $entity;
 	protected string $name;
 	protected string $friendlyName;
@@ -257,13 +264,13 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		if ($code === null || $code === '') {
 			if ($this->codeSentByUser !== null) {
 				// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
-				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
+				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), self::CODE_INVALID_TOKEN);
 			}
 			return;
 		}
 		if (empty($this->codeSentByUser) || !$this->identifyService->getHasher()->verify($this->codeSentByUser, $code)) {
 			// TRANSLATORS Error shown when the verification code entered by the signer is incorrect.
-			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
+			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), self::CODE_INVALID_TOKEN);
 		}
 	}
 

--- a/lib/Service/TwofactorGatewayService.php
+++ b/lib/Service/TwofactorGatewayService.php
@@ -17,6 +17,12 @@ use Psr\Log\LoggerInterface;
 final class TwofactorGatewayService {
 	private const APP_ID = 'twofactor_gateway';
 	private const INTEGRATION_SERVICE_ID = 'OCA\\TwoFactorGateway\\Service\\GatewayDirectIntegrationService';
+	/**
+	 * Semantic error code of the "gateway app not enabled" error: the closest
+	 * HTTP status with one extra digit (503 -> 5030), so it is not mistaken
+	 * for an HTTP status code.
+	 */
+	public const int CODE_NOT_ENABLED = 5030;
 
 	public function __construct(
 		private ContainerInterface $container,
@@ -89,7 +95,7 @@ final class TwofactorGatewayService {
 	 */
 	private function resolveIntegrationService(): object {
 		if (!$this->isEnabled()) {
-			throw new LibresignException('App Two-Factor Gateway is not enabled.', LibresignException::CODE_TWOFACTOR_GATEWAY_NOT_ENABLED);
+			throw new LibresignException('App Two-Factor Gateway is not enabled.', self::CODE_NOT_ENABLED);
 		}
 
 		try {

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
@@ -12,6 +12,7 @@ use OCA\Libresign\Db\IdentifyMethod;
 use OCA\Libresign\Db\SignRequest;
 use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\IdentifyMethod\AbstractIdentifyMethod;
 use OCA\Libresign\Service\IdentifyMethod\IdentifyService;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\EmailToken;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\TokenService;
@@ -291,7 +292,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('654321');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
+		$this->expectExceptionCode(AbstractIdentifyMethod::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}
@@ -306,7 +307,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('123456');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
+		$this->expectExceptionCode(AbstractIdentifyMethod::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/TokenServiceTest.php
@@ -52,7 +52,7 @@ final class TokenServiceTest extends TestCase {
 			->method('generate');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionCode(LibresignException::CODE_TWOFACTOR_GATEWAY_NOT_ENABLED);
+		$this->expectExceptionCode(TwofactorGatewayService::CODE_NOT_ENABLED);
 
 		$this->createService()->sendCodeByGateway('+5511999999999', 'sms');
 	}


### PR DESCRIPTION
Refs: #8117 (follow-up of #8103)

## 📝 Summary

In #8117 @vitormattos asked to keep each semantic error code close to the class that produces the error, instead of collecting them in `LibresignException`, which is what #8172 already does (`PdfParser::CODE_INVALID_PDF`, `PdfValidator::CODE_DOCMDP_RESTRICTED`). The two constants introduced by #8103 were the only ones still living in `LibresignException`, so this PR moves them:

| Before | After |
| --- | --- |
| `LibresignException::CODE_INVALID_TOKEN` | `AbstractIdentifyMethod::CODE_INVALID_TOKEN` (4010) |
| `LibresignException::CODE_TWOFACTOR_GATEWAY_NOT_ENABLED` | `TwofactorGatewayService::CODE_NOT_ENABLED` (5030) |

Values, messages and the thrown exception class are unchanged, so nothing changes for API clients. `LibresignException` has no error-code constants left.

## 🧪 How to test

1. `vendor/bin/phpunit -c tests/php/phpunit.xml tests/php/Unit/Service/IdentifyMethod/SignatureMethod/` — `EmailTokenTest` and `TokenServiceTest` assert the codes through their new owners (89 tests).
2. `git grep 'LibresignException::CODE_'` returns nothing.

## ⚙️ API / Back‑end changes

- [x] Constants moved to the classes that throw the exceptions; no behavior change
- [x] Unit tests updated
- [ ] Capabilities updated (if applicable) – N/A
- [ ] Documentation updated (if applicable) – N/A
- [ ] API documentation updated with the command `composer openapi` if necessary – N/A

### 🚧 Tasks

- [ ] Backport notes: `stable35` has the same files as `main` (cherry-pick applies clean). `stable32`–`stable34` only have `CODE_INVALID_TOKEN` (untyped constant, from the adapted backports #8164–#8166) and no `TwofactorGatewayService`, so they need the same adaptation as before: move that single constant to `AbstractIdentifyMethod` and update `EmailTokenTest`. I can open those manually if you want them.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
