### PR TITLE
[stable34] refactor(exception): keep the semantic error codes next to the classes that raise them

### DIFF
--- a/lib/Exception/LibresignException.php
+++ b/lib/Exception/LibresignException.php
@@ -14,12 +14,6 @@ use JsonSerializable;
  * @codeCoverageIgnore
  */
 class LibresignException extends \Exception implements JsonSerializable {
-	/**
-	 * Error codes follow the closest HTTP status with one extra digit
-	 * (401 -> 4010), so they are not mistaken for HTTP status codes.
-	 */
-	public const CODE_INVALID_TOKEN = 4010;
-
 	#[\Override]
 	public function jsonSerialize(): mixed {
 		return ['message' => $this->getMessage()];

--- a/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
+++ b/lib/Service/IdentifyMethod/AbstractIdentifyMethod.php
@@ -24,6 +24,13 @@ use OCP\Files\NotFoundException;
 use OCP\IUser;
 
 abstract class AbstractIdentifyMethod implements IIdentifyMethod {
+	/**
+	 * Semantic error code of the invalid verification code error: the closest
+	 * HTTP status with one extra digit (401 -> 4010), so it is not mistaken
+	 * for an HTTP status code.
+	 */
+	public const CODE_INVALID_TOKEN = 4010;
+
 	protected IdentifyMethod $entity;
 	protected string $name;
 	protected string $friendlyName;
@@ -236,12 +243,12 @@ abstract class AbstractIdentifyMethod implements IIdentifyMethod {
 		$code = $this->getEntity()->getCode();
 		if ($code === null || $code === '') {
 			if ($this->codeSentByUser !== null) {
-				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
+				throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), self::CODE_INVALID_TOKEN);
 			}
 			return;
 		}
 		if (empty($this->codeSentByUser) || !$this->identifyService->getHasher()->verify($this->codeSentByUser, $code)) {
-			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), LibresignException::CODE_INVALID_TOKEN);
+			throw new LibresignException($this->identifyService->getL10n()->t('Invalid code.'), self::CODE_INVALID_TOKEN);
 		}
 	}
 

--- a/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
+++ b/tests/php/Unit/Service/IdentifyMethod/SignatureMethod/EmailTokenTest.php
@@ -10,6 +10,7 @@ namespace OCA\Libresign\Tests\Unit\Service\IdentifyMethod\SignatureMethod;
 
 use OCA\Libresign\Db\IdentifyMethod;
 use OCA\Libresign\Exception\LibresignException;
+use OCA\Libresign\Service\IdentifyMethod\AbstractIdentifyMethod;
 use OCA\Libresign\Service\IdentifyMethod\IdentifyService;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\EmailToken;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\TokenService;
@@ -85,7 +86,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('654321');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
+		$this->expectExceptionCode(AbstractIdentifyMethod::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}
@@ -100,7 +101,7 @@ final class EmailTokenTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$instance->setCodeSentByUser('123456');
 
 		$this->expectException(LibresignException::class);
-		$this->expectExceptionCode(LibresignException::CODE_INVALID_TOKEN);
+		$this->expectExceptionCode(AbstractIdentifyMethod::CODE_INVALID_TOKEN);
 
 		$instance->validateToSign();
 	}


### PR DESCRIPTION
Backport of #8196 