### PR TITLE
Fix external PDF signature validation

### DIFF
--- a/lib/Handler/SignEngine/Pkcs12Handler.php
+++ b/lib/Handler/SignEngine/Pkcs12Handler.php
@@ -19,11 +19,9 @@ use OCA\Libresign\Service\Crl\CrlService;
 use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\Signature\PdfSignatureValidationService;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Exception\UnsignedPdfException;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationReason;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationResult;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationState;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Parser\PdfSignatureExtractor;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\Exception\UnexpectedValueException;
 use OCP\Files\File;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -162,7 +160,11 @@ class Pkcs12Handler extends SignEngineHandler {
 			return $result;
 		}
 
-		$decoded = ASN1::decodeBER($signature);
+		try {
+			$decoded = ASN1::decodeBER($signature);
+		} catch (UnexpectedValueException) {
+			return [];
+		}
 		$result = $this->extractTimestampData($decoded, $result);
 
 		$chain = $this->extractCertificateChain($signature);
@@ -336,12 +338,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		}
 
 		if (isset($validation['signatureValidation']) && is_array($validation['signatureValidation'])) {
-			$signatureValidation = $validation['signatureValidation'];
-
-			// Keep legacy OpenSSL result when native validator reports this known false-positive.
-			if (!$this->isDigestMismatchSignatureValidation($validation)) {
-				$leaf['signature_validation'] = $signatureValidation;
-			}
+			$leaf['signature_validation'] = $validation['signatureValidation'];
 		}
 
 		if (isset($validation['certificateValidation']) && is_array($validation['certificateValidation'])) {
@@ -357,21 +354,6 @@ class Pkcs12Handler extends SignEngineHandler {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * signer engines can produce signatures that the native validator currently flags as digest mismatch.
-	 * In this case we preserve the legacy validation computed from the PKCS#7 signature.
-	 */
-	private function isDigestMismatchSignatureValidation(array $validation): bool {
-		$rawSignatureValidation = $validation['raw']['signature'] ?? null;
-		if ($rawSignatureValidation instanceof ValidationResult) {
-			return $rawSignatureValidation->reasonCode === ValidationReason::DIGEST_MISMATCH
-				|| $rawSignatureValidation->state === ValidationState::DIGEST_MISMATCH;
-		}
-
-		$signatureValidation = $validation['signatureValidation'] ?? null;
-		return is_array($signatureValidation) && ($signatureValidation['id'] ?? null) === 3;
 	}
 
 	/**

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Handler\SignEngine;
 
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1\Element;
-use OCA\Libresign\Vendor\phpseclib3\Math\BigInteger;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Constructed;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Element;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Types\BaseType;
+use OCA\Libresign\Vendor\phpseclib4\Math\BigInteger;
 
 class TSA {
 	private static bool $areOidsInitialized = false;
@@ -38,8 +40,8 @@ class TSA {
 
 	private function processContentCandidate($content, ?string &$cmsDer): array {
 		try {
-			if ($content instanceof Element) {
-				return $this->decodeWithCache($cmsDer = $content->element);
+			if ($content instanceof Element && $content->value !== '') {
+				return $this->decodeWithCache($cmsDer = $content->value);
 			} elseif (is_string($content)) {
 				return $this->decodeWithCache($cmsDer = $content);
 			} elseif (is_array($content)) {
@@ -76,12 +78,12 @@ class TSA {
 	}
 
 	private function extractTimestampAuthorityName($timestampElement): array {
-		if (!$timestampElement instanceof Element || !is_string($timestampElement->element)) {
+		if (!$timestampElement instanceof Element || $timestampElement->value === '') {
 			return [];
 		}
 
 		try {
-			$decoded = $this->decodeWithCache($timestampElement->element);
+			$decoded = $this->decodeWithCache($timestampElement->value);
 			return ($decoded[0] ?? null) ? $this->extractCertificateHints([$decoded[0]]) : [];
 		} catch (\Throwable) {
 			return [];
@@ -165,12 +167,7 @@ class TSA {
 
 				$tst = null;
 				if ($tstNode && ($tstNode['type'] ?? null) === ASN1::TYPE_SEQUENCE) {
-					ASN1::setTimeFormat('Y-m-d\TH:i:s\Z');
-					$tst = ASN1::asn1map($tstNode, self::$timestampInfoStructure ??= $this->buildTimestampInfoStructure());
-
-					if (!is_array($tst)) {
-						$tst = $this->parseTstInfoFallback($tstInfoOctets);
-					}
+					$tst = $this->parseTstInfoFallback($tstInfoOctets);
 				}
 			} catch (\Throwable) {
 				$tst = $this->parseTstInfoFallback($tstInfoOctets);
@@ -245,19 +242,35 @@ class TSA {
 	}
 
 	public function getSigninTime($root): ?\DateTime {
-		$signingTime = null;
-		if ($values = $this->getAttributeValuesSetAfterOID($root, self::TIMESTAMP_OIDS['SIGNING_TIME'])) {
-			foreach ($values as $v) {
-				$t = $v['type'] ?? null;
-				if ($t === ASN1::TYPE_UTC_TIME || $t === ASN1::TYPE_GENERALIZED_TIME) {
-					$signingTime = $v['content'] ?? null;
-					if ($signingTime !== null) {
-						break;
-					}
-				}
+		$foundSigningTimeOid = false;
+		if (is_array($root) && isset($root['type'])) {
+			$root = [$root];
+		}
+
+		foreach ($this->walkAsn1Tree(is_array($root) ? $root : []) as $node) {
+			if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
+				&& $this->getNodeContent($node) === self::TIMESTAMP_OIDS['SIGNING_TIME']) {
+				$foundSigningTimeOid = true;
+				continue;
+			}
+
+			if (!$foundSigningTimeOid || !in_array($node['type'] ?? null, [ASN1::TYPE_UTC_TIME, ASN1::TYPE_GENERALIZED_TIME], true)) {
+				continue;
+			}
+
+			$signingTime = $this->getNodeContent($node);
+			if (!is_string($signingTime) || $signingTime === '') {
+				return null;
+			}
+
+			try {
+				return new \DateTime($signingTime);
+			} catch (\Exception) {
+				return null;
 			}
 		}
-		return $signingTime;
+
+		return null;
 	}
 
 	private function parseTstInfoFallback(string $tstInfoOctets): ?array {
@@ -279,8 +292,9 @@ class TSA {
 		foreach ($root['content'] as $child) {
 			$t = $child['type'] ?? null;
 
-			if (!$seenPolicy && $t === ASN1::TYPE_OBJECT_IDENTIFIER && is_string($child['content'] ?? null)) {
-				$out['policy'] = $child['content'];
+			$nodeContent = $this->getNodeContent($child);
+			if (!$seenPolicy && $t === ASN1::TYPE_OBJECT_IDENTIFIER && is_string($nodeContent)) {
+				$out['policy'] = $nodeContent;
 				$seenPolicy = true;
 				continue;
 			}
@@ -310,8 +324,8 @@ class TSA {
 				continue;
 			}
 			if ($t === ASN1::TYPE_GENERALIZED_TIME || $t === ASN1::TYPE_UTC_TIME) {
-				if (is_string($child['content'] ?? null)) {
-					$out['genTime'] = $child['content'];
+				if (is_string($nodeContent)) {
+					$out['genTime'] = $nodeContent;
 				}
 			}
 		}
@@ -319,8 +333,9 @@ class TSA {
 		if (!$out['genTime']) {
 			foreach ($this->walkAsn1Tree([$root]) as $n) {
 				$tt = $n['type'] ?? null;
-				if (($tt === ASN1::TYPE_GENERALIZED_TIME || $tt === ASN1::TYPE_UTC_TIME) && is_string($n['content'] ?? null)) {
-					$out['genTime'] = $n['content'];
+				$nodeContent = $this->getNodeContent($n);
+				if (($tt === ASN1::TYPE_GENERALIZED_TIME || $tt === ASN1::TYPE_UTC_TIME) && is_string($nodeContent)) {
+					$out['genTime'] = $nodeContent;
 					break;
 				}
 			}
@@ -331,7 +346,7 @@ class TSA {
 	private function getAttributeValuesSetAfterOID(array $tree, string $oid): ?array {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
-			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && ($n['content'] ?? null) === $oid) {
+			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && $this->getNodeContent($n) === $oid) {
 				$seen = true;
 				continue;
 			}
@@ -346,16 +361,16 @@ class TSA {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
 			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& ($n['content'] ?? null) === $oid
+				&& $this->getNodeContent($n) === $oid
 			) {
 				$seen = true;
 				continue;
 			}
 			if ($seen
 				&& ($n['type'] ?? null) === $expectedType
-				&& is_string($n['content'] ?? null)
+				&& is_string($this->getNodeContent($n))
 			) {
-				return $n['content'];
+				return $this->getNodeContent($n);
 			}
 		}
 		return null;
@@ -366,18 +381,18 @@ class TSA {
 		$currentAttributeOid = null;
 
 		foreach ($this->walkAsn1Tree($asn1Tree) as $node) {
+			$nodeContent = $this->getNodeContent($node);
 			if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& isset($node['content'], self::CERTIFICATE_ATTRIBUTE_OIDS[$node['content']])) {
-				$currentAttributeOid = $node['content'];
+				&& is_string($nodeContent) && isset(self::CERTIFICATE_ATTRIBUTE_OIDS[$nodeContent])) {
+				$currentAttributeOid = $nodeContent;
 				continue;
 			}
 
 			if ($currentAttributeOid !== null
-				&& isset($node['content'])
-				&& is_string($node['content'])
-				&& $this->isStringValidUtf8($node['content'])
+				&& is_string($nodeContent)
+				&& $this->isStringValidUtf8($nodeContent)
 			) {
-				$certificateHints[self::CERTIFICATE_ATTRIBUTE_OIDS[$currentAttributeOid]] = $node['content'];
+				$certificateHints[self::CERTIFICATE_ATTRIBUTE_OIDS[$currentAttributeOid]] = $nodeContent;
 				$currentAttributeOid = null;
 			}
 		}
@@ -468,7 +483,7 @@ class TSA {
 			return null;
 		}
 
-		$resolved = ASN1::getOID($policyOid);
+		$resolved = ASN1::getNameFromOID($policyOid);
 		if ($resolved && $resolved !== $policyOid) {
 			return $resolved;
 		}
@@ -492,6 +507,9 @@ class TSA {
 		}
 
 		$decodedResult = ASN1::decodeBER($asn1Data);
+		if (isset($decodedResult['type'])) {
+			$decodedResult = [$decodedResult];
+		}
 		if ($decodedResult === null) {
 			$decodedResult = [];
 		}
@@ -504,6 +522,19 @@ class TSA {
 		return $decodedResult;
 	}
 
+	private function getNodeContent(array $node): mixed {
+		$content = $node['content'] ?? null;
+		if (!$content instanceof BaseType) {
+			return $content;
+		}
+
+		if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER) {
+			return ASN1::getOIDFromName((string)$content);
+		}
+
+		return (string)$content;
+	}
+
 	public static function clearCache(): void {
 		self::$asn1DecodingCache = [];
 	}
@@ -513,13 +544,44 @@ class TSA {
 
 		while (!empty($processingStack)) {
 			$currentNode = array_shift($processingStack);
+			if (!is_array($currentNode)) {
+				continue;
+			}
 			yield $currentNode;
 
 			foreach (['content', 'children'] as $childrenKey) {
 				if (isset($currentNode[$childrenKey]) && is_array($currentNode[$childrenKey])) {
 					array_unshift($processingStack, ...$currentNode[$childrenKey]);
+				} elseif ($childrenKey === 'content' && ($currentNode[$childrenKey] ?? null) instanceof Constructed) {
+					array_unshift($processingStack, ...$this->decodeConstructedChildren($currentNode[$childrenKey]));
 				}
 			}
 		}
+	}
+
+	/** @return list<array> */
+	private function decodeConstructedChildren(Constructed $node): array {
+		$encoded = $node->getEncodedWithoutHeader();
+		$children = [];
+		$offset = 0;
+
+		while ($offset < strlen($encoded)) {
+			try {
+				$child = ASN1::decodeBER(substr($encoded, $offset));
+			} catch (\Throwable) {
+				break;
+			}
+
+			$headerLength = $child['headerlength'] ?? null;
+			$length = $child['length'] ?? null;
+			if (!is_int($headerLength) || !is_int($length)) {
+				break;
+			}
+
+			$children[] = $child;
+			$offset += $headerLength + $length;
+		}
+
+		return $children;
 	}
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -222,6 +222,7 @@ namespace OCA\Libresign;
  *     sign_date?: ?string,
  *     sign_request_uuid?: string,
  *     hash_algorithm?: string,
+ *     covers_entire_document?: bool,
  *     me: bool,
  *     signingOrder?: non-negative-int,
  *     visibleElements: LibresignVisibleElement[],

--- a/lib/Service/File/CertificateSignersMergeService.php
+++ b/lib/Service/File/CertificateSignersMergeService.php
@@ -402,6 +402,10 @@ class CertificateSignersMergeService {
 		if (isset($endEntityCert['isLibreSignRootCA']) && !isset($signer->isLibreSignRootCA)) {
 			$signer->isLibreSignRootCA = $endEntityCert['isLibreSignRootCA'];
 		}
+
+		if (isset($endEntityCert['covers_entire_document']) && !isset($signer->covers_entire_document)) {
+			$signer->covers_entire_document = $endEntityCert['covers_entire_document'];
+		}
 	}
 
 	/**

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -397,6 +397,9 @@ class FileService {
 		}
 
 		if (!$this->file instanceof File) {
+			if ($this->certData) {
+				$this->signersLoader->loadSignersFromCertData($this->fileData, $this->certData, $this->options->getHost());
+			}
 			return;
 		}
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -3000,6 +3000,9 @@
                             "hash_algorithm": {
                                 "type": "string"
                             },
+                            "covers_entire_document": {
+                                "type": "boolean"
+                            },
                             "me": {
                                 "type": "boolean"
                             },

--- a/openapi.json
+++ b/openapi.json
@@ -2373,6 +2373,9 @@
                             "hash_algorithm": {
                                 "type": "string"
                             },
+                            "covers_entire_document": {
+                                "type": "boolean"
+                            },
                             "me": {
                                 "type": "boolean"
                             },

--- a/src/components/validation/SignerDetails.vue
+++ b/src/components/validation/SignerDetails.vue
@@ -17,7 +17,7 @@
 					:size="44" />
 			</template>
 			<template #subname>
-				<template v-if="!signer.signed">
+				<template v-if="!isSigned(signer)">
 					<strong>{{ t('libresign', 'Status:') }}</strong>
 					<span>{{ t('libresign', 'Not signed yet') }}</span>
 				</template>
@@ -30,7 +30,7 @@
 				</template>
 			</template>
 			<template #extra-actions>
-				<NcButton v-if="signer.signed" variant="tertiary"
+				<NcButton v-if="isSigned(signer)" variant="tertiary"
 					:aria-label="toggleDetailsAriaLabel"
 					@click.stop="toggleOpen">
 					<template #icon>
@@ -96,6 +96,14 @@
 				</template>
 				<template #name>
 					{{ getSignatureValidationMessage(signer) }}
+				</template>
+			</NcListItem>
+			<NcListItem v-if="signer.covers_entire_document === false" class="extra-chain" compact>
+				<template #icon>
+					<NcIconSvgWrapper :path="mdiAlertCircle" class="icon-warning" />
+				</template>
+				<template #name>
+					{{ getSignatureCoverageMessage() }}
 				</template>
 			</NcListItem>
 			<NcListItem v-if="signer.certificate_validation" class="extra-chain" compact>
@@ -310,8 +318,10 @@ type SignerModel = {
 	valid_from?: string | number
 	valid_to?: string | number
 	signed?: string | null
+	status?: number
 	signature_validation?: ValidationState
 	certificate_validation?: ValidationState
+	covers_entire_document?: boolean
 	crl_validation?: string
 	crl_revoked_at?: string
 	docmdp?: SignerDocMdp
@@ -366,10 +376,14 @@ const crlStatusMap: Record<string, CrlStatusMeta> = {
 }
 
 function toggleOpen() {
-	if (!props.signer?.signed) {
+	if (!isSigned(props.signer)) {
 		return
 	}
 	isOpen.value = !isOpen.value
+}
+
+function isSigned(signer: SignerModel): boolean {
+	return !!signer.signed || signer.status === 2
 }
 
 function getName(signer: SignerModel) {
@@ -428,6 +442,7 @@ function getValidityStatus(signer: SignerModel) {
 
 function hasValidationStatus(signer: SignerModel) {
 	return !!(signer.signature_validation || signer.certificate_validation || signer.crl_validation
+		|| signer.covers_entire_document === false
 		|| (signer.valid_from && signer.valid_to && signer.signed))
 }
 
@@ -438,6 +453,11 @@ function getSignatureValidationMessage(signer: SignerModel) {
 	}
 	// TRANSLATORS Fallback validation message when signature integrity check fails and backend does not provide custom detail.
 	return signer.signature_validation?.message || t('libresign', 'Document integrity check failed')
+}
+
+function getSignatureCoverageMessage() {
+	// TRANSLATORS Warning shown when extra bytes exist outside the PDF signature ByteRange.
+	return t('libresign', 'The signature does not cover the entire document')
 }
 
 function getCertificateTrustMessage(signer: SignerModel) {
@@ -560,6 +580,7 @@ defineExpose({
 	crlStatusMap,
 	toggleDetailsAriaLabel,
 	toggleOpen,
+	isSigned,
 	getName,
 	hasValidationIssues,
 	isRevokedStatus,
@@ -568,6 +589,7 @@ defineExpose({
 	getValidityStatus,
 	hasValidationStatus,
 	getSignatureValidationMessage,
+	getSignatureCoverageMessage,
 	getCertificateTrustMessage,
 	getValidityStatusAtSigning,
 	getCrlValidationIconPath,

--- a/src/services/validationDocument.ts
+++ b/src/services/validationDocument.ts
@@ -201,6 +201,47 @@ function isSignerDetailRecord(value: unknown): value is SignerDetailRecord {
 		&& isOptionalField(value, 'isLibreSignRootCA', fieldValue => typeof fieldValue === 'boolean')
 }
 
+function isCertificateSignerRecord(value: unknown): value is UnknownRecord {
+	if (!isRecord(value)) {
+		return false
+	}
+
+	return isString(value.displayName)
+		&& isSignerStatus(value.status)
+		&& isString(value.statusText)
+		&& isOptionalField(value, 'signed', isNullableString)
+		&& Array.isArray(value.chain)
+		&& isOptionalField(value, 'signature_validation', isValidationStatusInfo)
+		&& isOptionalField(value, 'certificate_validation', isValidationStatusInfo)
+}
+
+function normalizeCertificateSigner(value: UnknownRecord): SignerDetailRecord {
+	return {
+		...value,
+		signRequestId: 0,
+		displayName: value.displayName as string,
+		signed: isNullableString(value.signed) ? value.signed : null,
+		status: value.status as SignerDetailRecord['status'],
+		statusText: value.statusText as string,
+		description: null,
+		request_sign_date: '',
+		me: false,
+		visibleElements: [],
+	}
+}
+
+function normalizeSignerDetail(value: unknown): SignerDetailRecord | null {
+	if (isSignerDetailRecord(value)) {
+		return value
+	}
+
+	if (isCertificateSignerRecord(value)) {
+		return normalizeCertificateSigner(value)
+	}
+
+	return null
+}
+
 function isValidatedChildFileRecord(value: unknown): value is ValidatedChildFileRecord {
 	if (!isRecord(value)) {
 		return false
@@ -248,7 +289,7 @@ function isValidationDocumentRecord(data: unknown): data is ValidationFileRecord
 		return false
 	}
 
-	if (hasOwn(data, 'signers') && (!Array.isArray(data.signers) || !data.signers.every(isSignerDetailRecord))) {
+	if (hasOwn(data, 'signers') && (!Array.isArray(data.signers) || !data.signers.every(signer => normalizeSignerDetail(signer) !== null))) {
 		return false
 	}
 
@@ -358,20 +399,7 @@ export function toValidationDocument(data: unknown): ValidationDocumentState | n
 		? data.settings
 		: DEFAULT_VALIDATION_SETTINGS
 
-	const signers = (Array.isArray(data.signers) ? data.signers : []).map((signer) => {
-		const signRequestId = toInteger(signer.signRequestId)
-		const status = toInteger(signer.status)
-
-		if (signRequestId === null || status === null || !isSignerStatus(status)) {
-			return null
-		}
-
-		return {
-			...signer,
-			signRequestId,
-			status,
-		}
-	})
+	const signers = (Array.isArray(data.signers) ? data.signers : []).map(normalizeSignerDetail)
 
 	if (signers.some(signer => signer === null)) {
 		return null

--- a/src/tests/components/validation/SignerDetails.spec.ts
+++ b/src/tests/components/validation/SignerDetails.spec.ts
@@ -518,6 +518,14 @@ describe('SignerDetails.vue - Business Logic', () => {
 			wrapper.vm.toggleOpen()
 			expect(wrapper.vm.isOpen).toBe(false)
 		})
+
+		it('toggles when a certificate signer has signed status without a timestamp', () => {
+			wrapper = createWrapper({ signer: { signed: null, status: 2 } })
+
+			wrapper.vm.toggleOpen()
+
+			expect(wrapper.vm.isOpen).toBe(true)
+		})
 	})
 
 	describe('getSignatureValidationMessage method', () => {
@@ -536,6 +544,12 @@ describe('SignerDetails.vue - Business Logic', () => {
 		it('returns default message when no message provided', () => {
 			const signer = { signature_validation: { id: 2 } }
 			expect(wrapper.vm.getSignatureValidationMessage(signer)).toBe('Document integrity check failed')
+		})
+	})
+
+	describe('getSignatureCoverageMessage method', () => {
+		it('reports bytes outside the signed ByteRange', () => {
+			expect(wrapper.vm.getSignatureCoverageMessage()).toBe('The signature does not cover the entire document')
 		})
 	})
 

--- a/src/tests/services/validationDocument.spec.ts
+++ b/src/tests/services/validationDocument.spec.ts
@@ -143,6 +143,48 @@ describe('validationDocument', () => {
 		expect(normalized?.files[0]).not.toHaveProperty('file')
 	})
 
+	it('accepts certificate signers from an external signed PDF', () => {
+		const payload = createValidationPayload({
+			id: 0,
+			uuid: '',
+			status: FILE_STATUS.NOT_LIBRESIGN_FILE,
+			statusText: '',
+			nodeId: 0,
+			metadata: [],
+			files: [{
+				id: 0,
+				uuid: '',
+				name: 'external-signed.pdf',
+				status: FILE_STATUS.NOT_LIBRESIGN_FILE,
+				statusText: '',
+				nodeId: 0,
+				totalPages: 0,
+				size: 1163,
+				pdfVersion: '',
+				signers: [],
+				metadata: [],
+			}],
+			totalPages: 0,
+			size: 1163,
+			pdfVersion: '',
+			created_at: '',
+			requested_by: { userId: '', displayName: '' },
+			signers: [{
+				displayName: 'External signer',
+				status: SIGN_REQUEST_STATUS.SIGNED,
+				statusText: 'Signed',
+				signature_validation: { id: 1, label: 'Signature is valid.' },
+				certificate_validation: { id: 3, label: 'Certificate issuer is unknown.' },
+				chain: [{ subject: { CN: 'External signer' } }],
+			}],
+		})
+
+		const normalized = toValidationDocument(payload)
+
+		expect(normalized).not.toBeNull()
+		expect(normalized?.signers[0]?.displayName).toBe('External signer')
+	})
+
 	it('rejects payload with string values in numeric contract fields', () => {
 		const normalized = toValidationDocument(createValidationPayload({
 			id: '100',

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1996,6 +1996,7 @@ export type components = {
             sign_date?: string | null;
             sign_request_uuid?: string;
             hash_algorithm?: string;
+            covers_entire_document?: boolean;
             me: boolean;
             /** Format: int64 */
             signingOrder?: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1554,6 +1554,7 @@ export type components = {
             sign_date?: string | null;
             sign_request_uuid?: string;
             hash_algorithm?: string;
+            covers_entire_document?: boolean;
             me: boolean;
             /** Format: int64 */
             signingOrder?: number;

--- a/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
@@ -44,6 +44,8 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private CrlService&MockObject $crlService;
 	private PdfSignatureValidationService&MockObject $pdfSignatureValidationService;
 	private PdfSignatureExtractor $pdfSignatureExtractor;
+	private array $nativeValidation = [];
+	private int $nativeValidationCalls = 0;
 
 	#[\Override]
 	public function setUp(): void {
@@ -74,7 +76,11 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->docMdpHandler = $this->createMock(DocMdpHandler::class);
 		$this->crlService = $this->createMock(CrlService::class);
 		$this->pdfSignatureValidationService = $this->createMock(PdfSignatureValidationService::class);
-		$this->pdfSignatureValidationService->method('validateFromResource')->willReturn([]);
+		$this->pdfSignatureValidationService->method('validateFromResource')
+			->willReturnCallback(function (): array {
+				$this->nativeValidationCalls++;
+				return $this->nativeValidation;
+			});
 		$this->pdfSignatureExtractor = new PdfSignatureExtractor();
 	}
 
@@ -447,13 +453,12 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetCertificateChainProvidesNativePackageShape(): void {
-		$this->pdfSignatureValidationService->method('validateFromResource')
-			->willReturn([
+		$this->nativeValidation = [
 				[
 					'signatureValidation' => ['id' => 1, 'label' => 'Signature is valid.'],
 					'certificateValidation' => ['id' => 3, 'label' => 'Certificate issuer is unknown.'],
 				],
-			]);
+		];
 
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
@@ -492,9 +497,6 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetCertificateChainUsesNativeValidationServiceForEachSignature(): void {
-		$this->pdfSignatureValidationService->expects($this->once())
-			->method('validateFromResource');
-
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
 		$this->assertIsResource($resource);
@@ -502,14 +504,14 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$result = $handler->getCertificateChain($resource);
 		fclose($resource);
 
+		$this->assertSame(1, $this->nativeValidationCalls);
 		$this->assertNotEmpty($result);
 		$this->assertSame(1, $result[0]['chain'][0]['signature_validation']['id']);
 		$this->assertSame(3, $result[0]['chain'][0]['certificate_validation']['id']);
 	}
 
-	public function testGetCertificateChainDoesNotOverrideLegacySignatureValidationOnDigestMismatch(): void {
-		$this->pdfSignatureValidationService->method('validateFromResource')
-			->willReturn([
+	public function testGetCertificateChainUsesNativeDigestMismatchValidation(): void {
+		$this->nativeValidation = [
 				[
 					'signatureValidation' => [
 						'id' => 3,
@@ -517,7 +519,7 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 						'reason' => 'PDF content hash does not match signed digest',
 					],
 				],
-			]);
+		];
 
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
@@ -527,8 +529,8 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		fclose($resource);
 
 		$this->assertNotEmpty($result);
-		$this->assertSame(1, $result[0]['chain'][0]['signature_validation']['id']);
-		$this->assertSame('Signature is valid.', $result[0]['chain'][0]['signature_validation']['label']);
+		$this->assertSame(3, $result[0]['chain'][0]['signature_validation']['id']);
+		$this->assertSame('Digest mismatch.', $result[0]['chain'][0]['signature_validation']['label']);
 	}
 
 	public function testGetCertificateChainPropagatesUnexpectedNativeMetadataExtractionFailureAndResetsPolicyValidationContext(): void {

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Unit\Handler\SignEngine;
 
 use OCA\Libresign\Handler\SignEngine\TSA;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
 use PHPUnit\Framework\TestCase;
 
 class TSATest extends TestCase {
@@ -22,8 +22,8 @@ class TSATest extends TestCase {
 	public function testConstructorLoadsOIDs(): void {
 		$tsa = new TSA();
 
-		$this->assertEquals('2.16.840.1.101.3.4.2.1', ASN1::getOID('id-sha256'));
-		$this->assertEquals('1.3.14.3.2.26', ASN1::getOID('id-sha1'));
+		$this->assertEquals('2.16.840.1.101.3.4.2.1', ASN1::getOIDFromName('id-sha256'));
+		$this->assertEquals('1.3.14.3.2.26', ASN1::getOIDFromName('id-sha1'));
 	}
 
 	public function testExtractWithEmptyArray(): void {

--- a/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
@@ -162,6 +162,7 @@ final class CertificateSignersMergeServiceTest extends TestCase {
 			'uid' => 'email:signer@example.com',
 			'chain' => [[
 				'subject' => ['CN' => 'Signer User'],
+				'covers_entire_document' => false,
 				'validFrom_time_t' => 1769644731,
 				'validTo_time_t' => 1769731131,
 			]],
@@ -183,6 +184,7 @@ final class CertificateSignersMergeServiceTest extends TestCase {
 		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->valid_to);
 		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->chain[0]['valid_from']);
 		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->chain[0]['valid_to']);
+		$this->assertFalse($signer->covers_entire_document);
 	}
 
 	public function testMergeDoesNotExportTopLevelTsaWithTimestampData(): void {

--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -158,6 +158,38 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		self::assertArrayNotHasKey('file', $result['files'][0]);
 	}
 
+	public function testValidateExternalSignedPdfFromUploadLoadsCertificateSigners(): void {
+		$temporaryFile = tempnam(sys_get_temp_dir(), 'libresign-validation-');
+		self::assertNotFalse($temporaryFile);
+		file_put_contents($temporaryFile, file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid-signed.pdf'));
+		$certData = [['chain' => [['subject' => ['CN' => 'External signer']]]]];
+
+		$this->mimeService->method('getMimeType')->willReturn('application/pdf');
+		$this->pkcs12Handler->method('getCertificateChain')->willReturn($certData);
+		$this->fileMapper->method('getBySignedHash')
+			->willThrowException(new DoesNotExistException('Not a LibreSign file'));
+		$this->signersLoader->expects($this->once())
+			->method('loadSignersFromCertData')
+			->with($this->isInstanceOf(\stdClass::class), $certData, '');
+
+		try {
+			$result = $this->createFileService()
+				->setFileFromRequest([
+					'tmp_name' => $temporaryFile,
+					'name' => 'external-signed.pdf',
+					'size' => filesize($temporaryFile),
+				])
+				->showSigners()
+				->toArray();
+		} finally {
+			if (file_exists($temporaryFile)) {
+				unlink($temporaryFile);
+			}
+		}
+
+		self::assertSame(FileStatus::NOT_LIBRESIGN_FILE->value, $result['status']);
+	}
+
 	public function testValidateFileContentSkipsNonPdfFiles(): void {
 		$service = $this->createFileService();
 


### PR DESCRIPTION
Updates LibreSign validation to surface PDF signature integrity independently from LibreSign database ownership.

Depends on LibreSign/3rdparty#91.

Changes:
- updates the scoped PDF signature validator to v0.3.0 and phpseclib to v4;
- preserves certificate signers for uploaded PDFs without a LibreSign record;
- reports valid signatures, invalid signed content, and bytes outside the signed ByteRange separately;
- shows an explicit warning when the signature does not cover the entire document;
- ports PKCS#12 and TSA parsing to phpseclib 4.

Validation:
- focused PHP suites: 231 tests / 618 assertions;
- frontend validation and signer-details tests: 99 tests;
- TypeScript check passed;
- OpenAPI/TypeScript contracts regenerated;
- endpoint smoke-tested with unsigned, intact signed, modified signed, and trailing-byte PDFs.