### PR TITLE
Test: Improve mutation coverage for AccountPhonePlugin test classes

### DIFF
--- a/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
@@ -104,7 +104,6 @@ class AccountPhonePluginTest extends TestCase {
 		array $currentUser,
 		array $users,
 		array $searchQuery,
-		array $excludeGroups,
 		array $pagination,
 		bool $shouldHaveMore,
 		int $expectedCount
@@ -198,72 +197,13 @@ class AccountPhonePluginTest extends TestCase {
 		);
 
 		$searchResult = new SearchResult();
-		$hasMore = $plugin->search($searchQuery['normalized'], $pagination['limit'], $pagination['offset'], $searchResult);
+		$hasMore = $plugin->search($searchQuery['number'], $pagination['limit'], $pagination['offset'], $searchResult);
 
 		$results = $searchResult->asArray();
 		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
 
 		$this->assertSame($shouldHaveMore, $hasMore);
 		$this->assertCount($expectedCount, $items);
-	}
-
-	public function testSearchAppliesPagination(): void {
-		$appConfig = $this->applyAppConfig([
-			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-		]);
-
-		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')
-			->willReturn([
-				'+12025550001' => 'target1',
-				'+12025550002' => 'target2',
-				'+12025550003' => 'target3',
-			]);
-
-		$currentUser = $this->createStub(IUser::class);
-		$currentUser->method('getUID')->willReturn('current');
-
-		$userSession = $this->createStub(IUserSession::class);
-		$userSession->method('getUser')->willReturn($currentUser);
-
-		$user = $this->createStub(IUser::class);
-		$user->method('isEnabled')->willReturn(true);
-		$user->method('getDisplayName')->willReturn('Target User');
-
-		$userManager = $this->createStub(IUserManager::class);
-		$userManager->method('get')->willReturn($user);
-
-		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
-
-		$knownUserService = $this->createStub(KnownUserService::class);
-		$knownUserService->method('isKnownToUser')->willReturn(true);
-
-		$context = new SignerSearchContext();
-		$context->set('sms', '+12025550001', '+12025550001');
-
-		$searchNormalizer = $this->createMock(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')
-			->willReturn('+12025550001');
-
-		$plugin = new AccountPhonePlugin(
-			$appConfig,
-			$accountManager,
-			$groupManager,
-			$userSession,
-			$knownUserService,
-			$userManager,
-			$context,
-			$searchNormalizer,
-		);
-
-		$searchResult = new SearchResult();
-		$hasMore = $plugin->search('+12025550001', 1, 1, $searchResult);
-
-		$results = $searchResult->asArray();
-		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
-		$this->assertCount(1, $items);
-		$this->assertTrue($hasMore);
 	}
 
 	public function testSearchFallsBackToUserIdWhenDisplayNameEmpty(): void {
@@ -376,15 +316,13 @@ class AccountPhonePluginTest extends TestCase {
 		$this->assertSame(AccountPhonePlugin::TYPE_SIGNER_ACCOUNT_PHONE, $items[0]['value']['shareType']);
 	}
 
-	public function testSearchFiltersUsersWithInvalidPhoneNumbers(): void {
+	public function testSearchNonNormalizedWideMatches(): void {
 		$appConfig = $this->applyAppConfig([
 			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
 		]);
 
-		// Return user with phone number that cannot be normalized
 		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')
-			->willReturn(['999999999' => 'target']);
+		$accountManager->method('searchUsers')->willReturn(['+1 (202) 555-1234' => 'target']);
 
 		$currentUser = $this->createStub(IUser::class);
 		$currentUser->method('getUID')->willReturn('current');
@@ -407,12 +345,10 @@ class AccountPhonePluginTest extends TestCase {
 		$knownUserService->method('isKnownToUser')->willReturn(true);
 
 		$context = new SignerSearchContext();
-		$context->set('sms', '999999999', '999999999');
+		$context->set('sms', '+1 (202) 555-1234', '+1 (202) 555-1234');
 
-		$searchNormalizer = $this->createMock(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')
-			->with('999999999', 'sms')
-			->willReturn(null); // Cannot normalize
+		$searchNormalizer = $this->createStub(SearchNormalizer::class);
+		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('+12025551234');
 
 		$plugin = new AccountPhonePlugin(
 			$appConfig,
@@ -426,11 +362,206 @@ class AccountPhonePluginTest extends TestCase {
 		);
 
 		$searchResult = new SearchResult();
-		$plugin->search('999999999', 10, 0, $searchResult);
+		$plugin->search('+1 (202) 555-1234', 10, 0, $searchResult);
 
 		$results = $searchResult->asArray();
-		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
-		$this->assertCount(0, $items); // User should be filtered out
+		$this->assertSame([], $results['exact']['account-phone'] ?? []);
+		$this->assertCount(1, $results['account-phone'] ?? []);
+	}
+
+	public function testSearchTrimmed(): void {
+		$appConfig = $this->applyAppConfig([
+			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+		]);
+
+		$accountManager = $this->createStub(IAccountManager::class);
+		$accountManager->method('searchUsers')->willReturn(['    +12025551234   ' => 'target']);
+
+		$currentUser = $this->createStub(IUser::class);
+		$currentUser->method('getUID')->willReturn('current');
+
+		$userSession = $this->createStub(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
+
+		$user = $this->createStub(IUser::class);
+		$user->method('getUID')->willReturn('target');
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getDisplayName')->willReturn('Target User');
+
+		$userManager = $this->createStub(IUserManager::class);
+		$userManager->method('get')->willReturn($user);
+
+		$groupManager = $this->createStub(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
+
+		$knownUserService = $this->createStub(KnownUserService::class);
+		$knownUserService->method('isKnownToUser')->willReturn(true);
+
+		$context = new SignerSearchContext();
+		$context->set('sms', '    +12025551234   ', '+12025551234');
+
+		$searchNormalizer = $this->createStub(SearchNormalizer::class);
+		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('+12025551234');
+
+		$plugin = new AccountPhonePlugin(
+			$appConfig,
+			$accountManager,
+			$groupManager,
+			$userSession,
+			$knownUserService,
+			$userManager,
+			$context,
+			$searchNormalizer,
+		);
+
+		$searchResult = new SearchResult();
+		$plugin->search('    +12025551234   ', 10, 0, $searchResult);
+
+		$results = $searchResult->asArray();
+		$this->assertSame([], $results['account-phone'] ?? []);
+		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
+	}
+
+	public function testSearchDoesNotQueryAccountsWhenEnumerationAndFullMatchDisabled(): void {
+		$appConfig = $this->applyAppConfig([
+			'shareapi_allow_share_dialog_user_enumeration' => 'no',
+			'shareapi_restrict_user_enumeration_full_match' => 'no',
+		]);
+
+		$accountManager = $this->createMock(IAccountManager::class);
+		$accountManager->expects($this->never())->method('searchUsers');
+
+		$currentUser = $this->createStub(IUser::class);
+		$currentUser->method('getUID')->willReturn('current');
+
+		$userSession = $this->createStub(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
+
+		$context = new SignerSearchContext();
+		$context->set('sms', '+12025551234', '+12025551234');
+
+		$plugin = new AccountPhonePlugin(
+			$appConfig,
+			$accountManager,
+			$this->createStub(IGroupManager::class),
+			$userSession,
+			$this->createStub(KnownUserService::class),
+			$this->createStub(IUserManager::class),
+			$context,
+			$this->createStub(SearchNormalizer::class),
+		);
+
+		$searchResult = new SearchResult();
+		$hasMore = $plugin->search('+12025551234', 10, 0, $searchResult);
+
+		$this->assertFalse($hasMore);
+		$this->assertArrayNotHasKey('account-phone', $searchResult->asArray());
+	}
+
+	public function testSearchExactMatchIgnoresCaseOnNormalizedValue(): void {
+		$appConfig = $this->applyAppConfig([
+			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+		]);
+
+		$accountManager = $this->createStub(IAccountManager::class);
+		$accountManager->method('searchUsers')->willReturn(['AbCdEf' => 'target']);
+
+		$currentUser = $this->createStub(IUser::class);
+		$currentUser->method('getUID')->willReturn('current');
+
+		$userSession = $this->createStub(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
+
+		$user = $this->createStub(IUser::class);
+		$user->method('getUID')->willReturn('target');
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getDisplayName')->willReturn('Someone Else');
+
+		$userManager = $this->createStub(IUserManager::class);
+		$userManager->method('get')->willReturn($user);
+
+		$groupManager = $this->createStub(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
+
+		$knownUserService = $this->createStub(KnownUserService::class);
+		$knownUserService->method('isKnownToUser')->willReturn(true);
+
+		$context = new SignerSearchContext();
+		$context->set('sms', 'AbCdEf', 'AbCdEf');
+
+		$searchNormalizer = $this->createStub(SearchNormalizer::class);
+		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('aBcDeF');
+
+		$plugin = new AccountPhonePlugin(
+			$appConfig,
+			$accountManager,
+			$groupManager,
+			$userSession,
+			$knownUserService,
+			$userManager,
+			$context,
+			$searchNormalizer,
+		);
+
+		$searchResult = new SearchResult();
+		$plugin->search('AbCdEf', 10, 0, $searchResult);
+
+		$results = $searchResult->asArray();
+		$this->assertSame([], $results['account-phone'] ?? []);
+		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
+	}
+
+	public function testSearchExactMatchIgnoresCaseOnLabel(): void {
+		$appConfig = $this->applyAppConfig([
+			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+		]);
+
+		$accountManager = $this->createStub(IAccountManager::class);
+		$accountManager->method('searchUsers')->willReturn(['AbCdEf' => 'target']);
+
+		$currentUser = $this->createStub(IUser::class);
+		$currentUser->method('getUID')->willReturn('current');
+
+		$userSession = $this->createStub(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUser);
+
+		$user = $this->createStub(IUser::class);
+		$user->method('getUID')->willReturn('target');
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getDisplayName')->willReturn('aBcDeF');
+
+		$userManager = $this->createStub(IUserManager::class);
+		$userManager->method('get')->willReturn($user);
+
+		$groupManager = $this->createStub(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
+
+		$knownUserService = $this->createStub(KnownUserService::class);
+		$knownUserService->method('isKnownToUser')->willReturn(true);
+
+		$context = new SignerSearchContext();
+		$context->set('sms', 'AbCdEf', 'AbCdEf');
+
+		$searchNormalizer = $this->createStub(SearchNormalizer::class);
+		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('999999999');
+
+		$plugin = new AccountPhonePlugin(
+			$appConfig,
+			$accountManager,
+			$groupManager,
+			$userSession,
+			$knownUserService,
+			$userManager,
+			$context,
+			$searchNormalizer,
+		);
+
+		$searchResult = new SearchResult();
+		$plugin->search('AbCdEf', 10, 0, $searchResult);
+
+		$results = $searchResult->asArray();
+		$this->assertSame([], $results['account-phone'] ?? []);
+		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
 	}
 
 	public static function providerSearchScenarios(): array {
@@ -467,84 +598,64 @@ class AccountPhonePluginTest extends TestCase {
 				'userEnabled' => true,
 				'expectedCount' => 1,
 			],
-			'restrict to group without common group' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_restrict_user_enumeration_to_group' => 'yes',
-				],
-				'knownUser' => false,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['engineering'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
-			'restrict to group with common group' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_restrict_user_enumeration_to_group' => 'yes',
-				],
-				'knownUser' => false,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => true,
-				'expectedCount' => 1,
-			],
-			'restrict to phone not known' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_restrict_user_enumeration_to_phone' => 'yes',
-				],
-				'knownUser' => false,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
-			'share with group only without common group' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_only_share_with_group_members' => 'yes',
-				],
-				'knownUser' => true,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['engineering'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
-			'disabled user filtered' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-				],
-				'knownUser' => true,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => false,
-				'expectedCount' => 0,
-			],
-			'exclude group list removes allowed groups' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_only_share_with_group_members' => 'yes',
-					'shareapi_only_share_with_group_members_exclude_group_list' => ['sales'],
-				],
-				'knownUser' => true,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
 		];
 	}
 
 	public static function providerSearchScenariosWithMultipleInputs(): array {
 		return [
-			'disabled user filtered' => [
+			'Test empty search' => [
+				'method' => 'sms',
+				'config' => [],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [],
+				'searchQuery' => [
+					'number' => '',
+					'normalized' => ''
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 0,
+			],
+			'Test non normalized search' => [
+				'method' => 'sms',
+				'config' => [],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [],
+				'searchQuery' => [
+					'number' => '+120255500O3',
+					'normalized' => ''
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 0,
+			],
+			'Apply pagination' => [
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
@@ -554,10 +665,255 @@ class AccountPhonePluginTest extends TestCase {
 					'displayName' => 'Current User',
 					'isEnabled' => true,
 					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550001',
+							'normalized' => '+12025550001',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'pagination' => [
+					'limit' => 2,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => true,
+				'expectedCount' => 2,	
+			],
+			'Edge pagination' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550001',
+							'normalized' => '+12025550001',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'pagination' => [
+					'limit' => 2,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,	
+			],
+			'Filter disabled users' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					// The order of the elements here matters
+					// So, putting the target element bettwen excluded one help us
+					// to identify early returns of the search (which shouldn't happen here)
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550001',
+							'normalized' => '+12025550001',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => false,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'pagination' => [
+					'limit' => 2,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
+			],
+			'Filter invalid phones' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					// The order of the elements here matters
+					// So, putting the target element bettwen excluded one help us
+					// to identify early returns of the search (which shouldn't happen here)
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+999999999',
+							'normalized' => null,
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '111111111',
+							'normalized' => null,
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 1,
+			],
+			'Enumeration but no full match' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_only_share_with_group_members' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
 					'groups' => ['sales'],
 					'numberMap' => [
 						'number' => '',
-						'normalized' => null,
+						'normalized' => '',
 					],
 				],
 				'users' => [
@@ -573,19 +929,389 @@ class AccountPhonePluginTest extends TestCase {
 						'groups' => ['sales'],
 					],
 					[
-						'uid' => 'excluded1',
-						'displayName' => 'Excluded User 1',
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
 						'numberMap' => [
 							'number' => '+12025550003',
 							'normalized' => '+12025550003',
 						],
-						'isEnabled' => false,
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,	
+			],
+			'No enumeration but full match' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'no',
+					'shareapi_restrict_user_enumeration_full_match' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550001',
+							'normalized' => '+12025550001',
+						],
+						'isEnabled' => true,
 						'isKnown' => true,
 						'groups' => ['sales'],
 					],
 					[
 						'uid' => 'target2',
 						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'target3',
+						'displayName' => 'Target User 3',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 3,	
+			],
+			'Filter unknown phones' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_restrict_user_enumeration_to_phone' => 'yes',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => [],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => false,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => false,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 1,
+			],
+			'Filter disallowed groups' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_restrict_user_enumeration_to_group' => 'yes',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members_exclude_group_list' => ['engineering'],
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales', 'engineering'],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550005',
+							'normalized' => '+12025550005',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
+			],
+			'Restrict to common group' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_restrict_user_enumeration_to_group' => 'yes',
+					'shareapi_only_share_with_group_members' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales', 'engineering'],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550005',
+							'normalized' => '+12025550005',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
+			],
+			'Filter group-only users mid-list' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_only_share_with_group_members' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => ['number' => '+12025550001', 'normalized' => '+12025550001'],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => ['number' => '+12025550002', 'normalized' => '+12025550002'],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => ['number' => '+12025550003', 'normalized' => '+12025550003'],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001',
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
+			],
+			'Restrict and exclude own group' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_restrict_user_enumeration_to_group' => 'yes',
+					'shareapi_only_share_with_group_members' => 'yes',
+					'shareapi_only_share_with_group_members_exclude_group_list' => ['sales'],
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
 						'numberMap' => [
 							'number' => '+12025550002',
 							'normalized' => '+12025550002',
@@ -594,18 +1320,50 @@ class AccountPhonePluginTest extends TestCase {
 						'isKnown' => true,
 						'groups' => ['sales'],
 					],
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales', 'engineering'],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550005',
+							'normalized' => '+12025550005',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['engineering'],
+					],
 				],
 				'searchQuery' => [
-					'number' => '+12025550001',
-					'normalized' => '+12025550001'
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
 				],
-				'excludeGroups' => [],
 				'pagination' => [
-					'limit' => 2,
+					'limit' => 10,
 					'offset' => 0,
 				],
 				'shouldHaveMore' => false,
-				'expectedCount' => 2,
+				'expectedCount' => 0,
 			],
 		];
 	}

--- a/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
@@ -97,6 +97,116 @@ class AccountPhonePluginTest extends TestCase {
 		$this->assertCount($expectedCount, $items);
 	}
 
+	#[DataProvider('providerSearchScenariosWithMultipleInputs')]
+	public function testSearchRespectsEnumerationRulesWithMultipleInputs(
+		string $method,
+		array $config,
+		array $currentUser,
+		array $users,
+		array $searchQuery,
+		array $excludeGroups,
+		array $pagination,
+		bool $shouldHaveMore,
+		int $expectedCount
+	): void {
+		$appConfig = $this->applyAppConfig($config);
+
+		$usersByUid = array_column($users, null, 'uid');
+		$userStubs = [];
+		$groupsByUid = [];
+		$searchedUsers = [];
+		foreach ($users as $userData) {
+			$uid = $userData['uid'];
+			$stub = $this->createStub(IUser::class);
+			$stub->method('getUID')->willReturn($uid);
+			$stub->method('isEnabled')->willReturn($userData['isEnabled']);
+			$stub->method('getDisplayName')->willReturn($userData['displayName']);
+
+			$userStubs[$uid] = $stub;
+			$groupsByUid[$uid] = $userData['groups'];
+			$searchedUsers[$userData['numberMap']['number']] = $uid;
+		}
+
+		$accountManager = $this->createStub(IAccountManager::class);
+		$accountManager->method('searchUsers')
+			->willReturn($searchedUsers);
+
+		$currentUserStub = $this->createStub(IUser::class);
+		$currentUserStub->method('getUID')->willReturn($currentUser['uid']);
+		$currentUserStub->method('isEnabled')->willReturn($currentUser['isEnabled']);
+		$currentUserStub->method('getDisplayName')->willReturn($currentUser['displayName']);
+
+		$userSession = $this->createStub(IUserSession::class);
+		$userSession->method('getUser')->willReturn($currentUserStub);
+
+		$userManager = $this->createStub(IUserManager::class);
+		$userManager->method('get')
+			->willReturnCallback(function (string $uid) use ($currentUser, $currentUserStub, $userStubs): IUser {
+				if ($uid === $currentUser['uid']) {
+					return $currentUserStub;
+				}
+
+				return $userStubs[$uid] ?? null;
+			});
+
+		$groupManager = $this->createStub(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')
+			->willReturnCallback(function ($subject) use ($currentUserStub, $userStubs, $currentUser, $groupsByUid): array {
+				if ($subject === $currentUserStub) {
+					return $currentUser['groups'];
+				}
+				foreach ($userStubs as $uid => $stub) {
+					if ($subject === $stub) {
+						return $groupsByUid[$uid];
+					}
+				}
+				return [];
+			});
+
+		$knownUserService = $this->createStub(KnownUserService::class);
+		$knownUserService->method('isKnownToUser')
+			->willReturnCallback(function (string $current, string $target) use ($usersByUid): bool {
+				return $usersByUid[$target]['isKnown'];
+			});
+
+		$context = new SignerSearchContext();
+		$context->set($method, $searchQuery['number'], $searchQuery['normalized']);
+
+		$searchNormalizer = $this->createMock(SearchNormalizer::class);
+		$searchNormalizer->method('tryNormalizePhoneNumber')
+			->willReturnCallback(function (string $number) use ($currentUser, $users) {
+				if ($number === $currentUser['numberMap']['number']) {
+					return $currentUser['numberMap']['normalized'];
+				}
+				foreach($users as $userData) {
+					if($number === $userData['numberMap']['number']) {
+						return $userData['numberMap']['normalized'];
+					}
+				}
+				return null;
+			});			
+
+		$plugin = new AccountPhonePlugin(
+			$appConfig,
+			$accountManager,
+			$groupManager,
+			$userSession,
+			$knownUserService,
+			$userManager,
+			$context,
+			$searchNormalizer,
+		);
+
+		$searchResult = new SearchResult();
+		$hasMore = $plugin->search($searchQuery['normalized'], $pagination['limit'], $pagination['offset'], $searchResult);
+
+		$results = $searchResult->asArray();
+		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
+
+		$this->assertSame($shouldHaveMore, $hasMore);
+		$this->assertCount($expectedCount, $items);
+	}
+
 	public function testSearchAppliesPagination(): void {
 		$appConfig = $this->applyAppConfig([
 			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
@@ -428,6 +538,74 @@ class AccountPhonePluginTest extends TestCase {
 				'targetGroups' => ['sales'],
 				'userEnabled' => true,
 				'expectedCount' => 0,
+			],
+		];
+	}
+
+	public static function providerSearchScenariosWithMultipleInputs(): array {
+		return [
+			'disabled user filtered' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'isEnabled' => true,
+					'isKnown' => true,
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => null,
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'target1',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550001',
+							'normalized' => '+12025550001',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => false,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'target2',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => ['sales'],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550001',
+					'normalized' => '+12025550001'
+				],
+				'excludeGroups' => [],
+				'pagination' => [
+					'limit' => 2,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
 			],
 		];
 	}

--- a/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
@@ -38,7 +38,7 @@ class AccountPhonePluginTest extends TestCase {
 		$usersByUid = array_column($users, null, 'uid');
 		$userStubs = [];
 		$searchedUsers = [];
-		
+
 		$groupsByUid = array_column($users, 'groups', 'uid');
 		$groupsByUid[$currentUser['uid']] = $currentUser['groups'];
 
@@ -54,7 +54,7 @@ class AccountPhonePluginTest extends TestCase {
 			$stub->method('getUID')->willReturn($uid);
 			$stub->method('isEnabled')->willReturn($userData['isEnabled']);
 			$stub->method('getDisplayName')->willReturn($userData['displayName']);
-			
+
 			$userStubs[$uid] = $stub;
 			$searchedUsers[$userData['numberMap']['number']] = $uid;
 		}
@@ -78,7 +78,7 @@ class AccountPhonePluginTest extends TestCase {
 
 		$groupManager = $this->createStub(IGroupManager::class);
 		$groupManager->method('getUserGroupIds')
-			->willReturnCallback(fn(IUser $user) => $groupsByUid[$user->getUID()] ?? []);
+			->willReturnCallback(fn (IUser $user) => $groupsByUid[$user->getUID()] ?? []);
 
 		$knownUserService = $this->createStub(KnownUserService::class);
 		$knownUserService->method('isKnownToUser')
@@ -89,7 +89,7 @@ class AccountPhonePluginTest extends TestCase {
 
 		$searchNormalizer = $this->createMock(SearchNormalizer::class);
 		$searchNormalizer->method('tryNormalizePhoneNumber')
-    		->willReturnCallback(fn(string $number) => $numberMap[$number] ?? null);
+			->willReturnCallback(fn (string $number) => $numberMap[$number] ?? null);
 
 		$plugin = new AccountPhonePlugin(
 			$appConfig,

--- a/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php
@@ -26,113 +26,45 @@ class AccountPhonePluginTest extends TestCase {
 	public function testSearchRespectsEnumerationRules(
 		string $method,
 		array $config,
-		bool $knownUser,
-		array $currentGroups,
-		array $targetGroups,
-		bool $userEnabled,
-		int $expectedCount,
-	): void {
-		$appConfig = $this->applyAppConfig($config);
-
-		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')
-			->with(IAccountManager::PROPERTY_PHONE, ['+12025551234'])
-			->willReturn(['+12025551234' => 'target']);
-
-		$currentUser = $this->createStub(IUser::class);
-		$currentUser->method('getUID')->willReturn('current');
-
-		$userSession = $this->createStub(IUserSession::class);
-		$userSession->method('getUser')->willReturn($currentUser);
-
-		$user = $this->createStub(IUser::class);
-		$user->method('getUID')->willReturn('target');
-		$user->method('isEnabled')->willReturn($userEnabled);
-		$user->method('getDisplayName')->willReturn('Target User');
-
-		$userManager = $this->createStub(IUserManager::class);
-		$userManager->method('get')
-			->willReturnCallback(fn (string $uid) => $uid === 'target' ? $user : ($uid === 'current' ? $currentUser : null));
-
-		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')
-			->willReturnCallback(function ($subject) use ($currentUser, $user, $currentGroups, $targetGroups): array {
-				if ($subject === $currentUser) {
-					return $currentGroups;
-				}
-				if ($subject === $user || $subject === 'target') {
-					return $targetGroups;
-				}
-				return [];
-			});
-
-		$knownUserService = $this->createStub(KnownUserService::class);
-		$knownUserService->method('isKnownToUser')
-			->with('current', 'target')
-			->willReturn($knownUser);
-
-		$context = new SignerSearchContext();
-		$context->set($method, '+12025551234', '+12025551234');
-
-		$searchNormalizer = $this->createMock(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')
-			->willReturn('+12025551234');
-
-		$plugin = new AccountPhonePlugin(
-			$appConfig,
-			$accountManager,
-			$groupManager,
-			$userSession,
-			$knownUserService,
-			$userManager,
-			$context,
-			$searchNormalizer,
-		);
-
-		$searchResult = new SearchResult();
-		$plugin->search('+12025551234', 10, 0, $searchResult);
-
-		$results = $searchResult->asArray();
-		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
-		$this->assertCount($expectedCount, $items);
-	}
-
-	#[DataProvider('providerSearchScenariosWithMultipleInputs')]
-	public function testSearchRespectsEnumerationRulesWithMultipleInputs(
-		string $method,
-		array $config,
 		array $currentUser,
 		array $users,
 		array $searchQuery,
 		array $pagination,
 		bool $shouldHaveMore,
-		int $expectedCount
+		int $expectedCount,
 	): void {
 		$appConfig = $this->applyAppConfig($config);
 
 		$usersByUid = array_column($users, null, 'uid');
 		$userStubs = [];
-		$groupsByUid = [];
 		$searchedUsers = [];
+		
+		$groupsByUid = array_column($users, 'groups', 'uid');
+		$groupsByUid[$currentUser['uid']] = $currentUser['groups'];
+
+		$numberMap = array_column(
+			array_column(array_merge([$currentUser], $users), 'numberMap'),
+			'normalized',
+			'number'
+		);
+
 		foreach ($users as $userData) {
 			$uid = $userData['uid'];
 			$stub = $this->createStub(IUser::class);
 			$stub->method('getUID')->willReturn($uid);
 			$stub->method('isEnabled')->willReturn($userData['isEnabled']);
 			$stub->method('getDisplayName')->willReturn($userData['displayName']);
-
+			
 			$userStubs[$uid] = $stub;
-			$groupsByUid[$uid] = $userData['groups'];
 			$searchedUsers[$userData['numberMap']['number']] = $uid;
 		}
-
 		$accountManager = $this->createStub(IAccountManager::class);
 		$accountManager->method('searchUsers')
+			->with(IAccountManager::PROPERTY_PHONE, [$searchQuery['normalized']])
 			->willReturn($searchedUsers);
 
 		$currentUserStub = $this->createStub(IUser::class);
 		$currentUserStub->method('getUID')->willReturn($currentUser['uid']);
-		$currentUserStub->method('isEnabled')->willReturn($currentUser['isEnabled']);
 		$currentUserStub->method('getDisplayName')->willReturn($currentUser['displayName']);
 
 		$userSession = $this->createStub(IUserSession::class);
@@ -140,50 +72,24 @@ class AccountPhonePluginTest extends TestCase {
 
 		$userManager = $this->createStub(IUserManager::class);
 		$userManager->method('get')
-			->willReturnCallback(function (string $uid) use ($currentUser, $currentUserStub, $userStubs): IUser {
-				if ($uid === $currentUser['uid']) {
-					return $currentUserStub;
-				}
-
-				return $userStubs[$uid] ?? null;
-			});
+			->willReturnCallback(fn (string $uid) => (
+				$uid === $currentUser['uid'] ? $currentUserStub : ($userStubs[$uid] ?? null)
+			));
 
 		$groupManager = $this->createStub(IGroupManager::class);
 		$groupManager->method('getUserGroupIds')
-			->willReturnCallback(function ($subject) use ($currentUserStub, $userStubs, $currentUser, $groupsByUid): array {
-				if ($subject === $currentUserStub) {
-					return $currentUser['groups'];
-				}
-				foreach ($userStubs as $uid => $stub) {
-					if ($subject === $stub) {
-						return $groupsByUid[$uid];
-					}
-				}
-				return [];
-			});
+			->willReturnCallback(fn(IUser $user) => $groupsByUid[$user->getUID()] ?? []);
 
 		$knownUserService = $this->createStub(KnownUserService::class);
 		$knownUserService->method('isKnownToUser')
-			->willReturnCallback(function (string $current, string $target) use ($usersByUid): bool {
-				return $usersByUid[$target]['isKnown'];
-			});
+			->willReturnCallback(fn (string $current, string $target) => $usersByUid[$target]['isKnown'] ?? false);
 
 		$context = new SignerSearchContext();
 		$context->set($method, $searchQuery['number'], $searchQuery['normalized']);
 
 		$searchNormalizer = $this->createMock(SearchNormalizer::class);
 		$searchNormalizer->method('tryNormalizePhoneNumber')
-			->willReturnCallback(function (string $number) use ($currentUser, $users) {
-				if ($number === $currentUser['numberMap']['number']) {
-					return $currentUser['numberMap']['normalized'];
-				}
-				foreach($users as $userData) {
-					if($number === $userData['numberMap']['number']) {
-						return $userData['numberMap']['normalized'];
-					}
-				}
-				return null;
-			});			
+    		->willReturnCallback(fn(string $number) => $numberMap[$number] ?? null);
 
 		$plugin = new AccountPhonePlugin(
 			$appConfig,
@@ -201,7 +107,6 @@ class AccountPhonePluginTest extends TestCase {
 
 		$results = $searchResult->asArray();
 		$items = array_merge($results['account-phone'] ?? [], $results['exact']['account-phone'] ?? []);
-
 		$this->assertSame($shouldHaveMore, $hasMore);
 		$this->assertCount($expectedCount, $items);
 	}
@@ -209,8 +114,9 @@ class AccountPhonePluginTest extends TestCase {
 	public function testSearchFallsBackToUserIdWhenDisplayNameEmpty(): void {
 		$appConfig = $this->applyAppConfig([
 			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+			'shareapi_restrict_user_enumeration_to_group' => 'no',
+			'shareapi_only_share_with_group_members' => 'no',
 		]);
-
 		$accountManager = $this->createStub(IAccountManager::class);
 		$accountManager->method('searchUsers')
 			->willReturn(['+12025551234' => 'target']);
@@ -230,7 +136,7 @@ class AccountPhonePluginTest extends TestCase {
 		$userManager->method('get')->willReturn($user);
 
 		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
+		$groupManager->method('getUserGroupIds')->willReturn([]);
 
 		$knownUserService = $this->createStub(KnownUserService::class);
 		$knownUserService->method('isKnownToUser')->willReturn(true);
@@ -240,7 +146,7 @@ class AccountPhonePluginTest extends TestCase {
 
 		$searchNormalizer = $this->createMock(SearchNormalizer::class);
 		$searchNormalizer->method('tryNormalizePhoneNumber')
-			->willReturn('+12025550001');
+			->willReturn('+12025551234');
 
 		$plugin = new AccountPhonePlugin(
 			$appConfig,
@@ -264,6 +170,8 @@ class AccountPhonePluginTest extends TestCase {
 	public function testSearchAddsAccountPhoneShareType(): void {
 		$appConfig = $this->applyAppConfig([
 			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+			'shareapi_restrict_user_enumeration_to_group' => 'no',
+			'shareapi_only_share_with_group_members' => 'no',
 		]);
 
 		$accountManager = $this->createStub(IAccountManager::class);
@@ -319,6 +227,8 @@ class AccountPhonePluginTest extends TestCase {
 	public function testSearchNonNormalizedWideMatches(): void {
 		$appConfig = $this->applyAppConfig([
 			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+			'shareapi_restrict_user_enumeration_to_group' => 'no',
+			'shareapi_only_share_with_group_members' => 'no',
 		]);
 
 		$accountManager = $this->createStub(IAccountManager::class);
@@ -362,64 +272,11 @@ class AccountPhonePluginTest extends TestCase {
 		);
 
 		$searchResult = new SearchResult();
-		$plugin->search('+1 (202) 555-1234', 10, 0, $searchResult);
+		$plugin->search('  +1 (202) 555-1234   ', 10, 0, $searchResult);
 
 		$results = $searchResult->asArray();
 		$this->assertSame([], $results['exact']['account-phone'] ?? []);
 		$this->assertCount(1, $results['account-phone'] ?? []);
-	}
-
-	public function testSearchTrimmed(): void {
-		$appConfig = $this->applyAppConfig([
-			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-		]);
-
-		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')->willReturn(['    +12025551234   ' => 'target']);
-
-		$currentUser = $this->createStub(IUser::class);
-		$currentUser->method('getUID')->willReturn('current');
-
-		$userSession = $this->createStub(IUserSession::class);
-		$userSession->method('getUser')->willReturn($currentUser);
-
-		$user = $this->createStub(IUser::class);
-		$user->method('getUID')->willReturn('target');
-		$user->method('isEnabled')->willReturn(true);
-		$user->method('getDisplayName')->willReturn('Target User');
-
-		$userManager = $this->createStub(IUserManager::class);
-		$userManager->method('get')->willReturn($user);
-
-		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
-
-		$knownUserService = $this->createStub(KnownUserService::class);
-		$knownUserService->method('isKnownToUser')->willReturn(true);
-
-		$context = new SignerSearchContext();
-		$context->set('sms', '    +12025551234   ', '+12025551234');
-
-		$searchNormalizer = $this->createStub(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('+12025551234');
-
-		$plugin = new AccountPhonePlugin(
-			$appConfig,
-			$accountManager,
-			$groupManager,
-			$userSession,
-			$knownUserService,
-			$userManager,
-			$context,
-			$searchNormalizer,
-		);
-
-		$searchResult = new SearchResult();
-		$plugin->search('    +12025551234   ', 10, 0, $searchResult);
-
-		$results = $searchResult->asArray();
-		$this->assertSame([], $results['account-phone'] ?? []);
-		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
 	}
 
 	public function testSearchDoesNotQueryAccountsWhenEnumerationAndFullMatchDisabled(): void {
@@ -458,218 +315,106 @@ class AccountPhonePluginTest extends TestCase {
 		$this->assertArrayNotHasKey('account-phone', $searchResult->asArray());
 	}
 
-	public function testSearchExactMatchIgnoresCaseOnNormalizedValue(): void {
-		$appConfig = $this->applyAppConfig([
-			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-		]);
-
-		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')->willReturn(['AbCdEf' => 'target']);
-
-		$currentUser = $this->createStub(IUser::class);
-		$currentUser->method('getUID')->willReturn('current');
-
-		$userSession = $this->createStub(IUserSession::class);
-		$userSession->method('getUser')->willReturn($currentUser);
-
-		$user = $this->createStub(IUser::class);
-		$user->method('getUID')->willReturn('target');
-		$user->method('isEnabled')->willReturn(true);
-		$user->method('getDisplayName')->willReturn('Someone Else');
-
-		$userManager = $this->createStub(IUserManager::class);
-		$userManager->method('get')->willReturn($user);
-
-		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
-
-		$knownUserService = $this->createStub(KnownUserService::class);
-		$knownUserService->method('isKnownToUser')->willReturn(true);
-
-		$context = new SignerSearchContext();
-		$context->set('sms', 'AbCdEf', 'AbCdEf');
-
-		$searchNormalizer = $this->createStub(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('aBcDeF');
-
-		$plugin = new AccountPhonePlugin(
-			$appConfig,
-			$accountManager,
-			$groupManager,
-			$userSession,
-			$knownUserService,
-			$userManager,
-			$context,
-			$searchNormalizer,
-		);
-
-		$searchResult = new SearchResult();
-		$plugin->search('AbCdEf', 10, 0, $searchResult);
-
-		$results = $searchResult->asArray();
-		$this->assertSame([], $results['account-phone'] ?? []);
-		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
-	}
-
-	public function testSearchExactMatchIgnoresCaseOnLabel(): void {
-		$appConfig = $this->applyAppConfig([
-			'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-		]);
-
-		$accountManager = $this->createStub(IAccountManager::class);
-		$accountManager->method('searchUsers')->willReturn(['AbCdEf' => 'target']);
-
-		$currentUser = $this->createStub(IUser::class);
-		$currentUser->method('getUID')->willReturn('current');
-
-		$userSession = $this->createStub(IUserSession::class);
-		$userSession->method('getUser')->willReturn($currentUser);
-
-		$user = $this->createStub(IUser::class);
-		$user->method('getUID')->willReturn('target');
-		$user->method('isEnabled')->willReturn(true);
-		$user->method('getDisplayName')->willReturn('aBcDeF');
-
-		$userManager = $this->createStub(IUserManager::class);
-		$userManager->method('get')->willReturn($user);
-
-		$groupManager = $this->createStub(IGroupManager::class);
-		$groupManager->method('getUserGroupIds')->willReturn(['sales']);
-
-		$knownUserService = $this->createStub(KnownUserService::class);
-		$knownUserService->method('isKnownToUser')->willReturn(true);
-
-		$context = new SignerSearchContext();
-		$context->set('sms', 'AbCdEf', 'AbCdEf');
-
-		$searchNormalizer = $this->createStub(SearchNormalizer::class);
-		$searchNormalizer->method('tryNormalizePhoneNumber')->willReturn('999999999');
-
-		$plugin = new AccountPhonePlugin(
-			$appConfig,
-			$accountManager,
-			$groupManager,
-			$userSession,
-			$knownUserService,
-			$userManager,
-			$context,
-			$searchNormalizer,
-		);
-
-		$searchResult = new SearchResult();
-		$plugin->search('AbCdEf', 10, 0, $searchResult);
-
-		$results = $searchResult->asArray();
-		$this->assertSame([], $results['account-phone'] ?? []);
-		$this->assertCount(1, $results['exact']['account-phone'] ?? []);
-	}
-
 	public static function providerSearchScenarios(): array {
 		return [
-			'non phone method' => [
+			'Email search' => [
 				'method' => 'email',
-				'config' => [],
-				'knownUser' => false,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
-			'enumeration disabled and no full match' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'no',
-					'shareapi_restrict_user_enumeration_full_match' => 'no',
-				],
-				'knownUser' => true,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['sales'],
-				'userEnabled' => true,
-				'expectedCount' => 0,
-			],
-			'enumeration allowed without restrictions' => [
-				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
 				],
-				'knownUser' => false,
-				'currentGroups' => ['sales'],
-				'targetGroups' => ['engineering'],
-				'userEnabled' => true,
-				'expectedCount' => 1,
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'groups' => [],
+					'numberMap' => ['number' => '', 'normalized' => ''],
+				],
+				'users' => [
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User',
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+						'numberMap' => ['number' => '+12025551234', 'normalized' => '+12025551234'],
+					],
+				],
+				'searchQuery' => ['number' => 'johnDoe@email.com', 'normalized' => ''],
+				'pagination' => ['limit' => 10, 'offset' => 0],
+				'shouldHaveMore' => false,
+				'expectedCount' => 0,
 			],
-		];
-	}
-
-	public static function providerSearchScenariosWithMultipleInputs(): array {
-		return [
 			'Test empty search' => [
 				'method' => 'sms',
 				'config' => [],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
+					'numberMap' => ['number' => '+12025551234', 'normalized' => '+12025551234'],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded',
+						'displayName' => 'Excluded User',
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+						'numberMap' => ['number' => '+12025550003', 'normalized' => '+12025550003'],
 					],
 				],
-				'users' => [],
-				'searchQuery' => [
-					'number' => '',
-					'normalized' => ''
-				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
+				'searchQuery' => ['number' => '', 'normalized' => ''],
+				'pagination' => ['limit' => 10, 'offset' => 0],
 				'shouldHaveMore' => false,
 				'expectedCount' => 0,
 			],
-			'Test non normalized search' => [
+			'Non trimmed search' => [
 				'method' => 'sms',
-				'config' => [],
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
+				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
+					'numberMap' => ['number' => '+12025550003', 'normalized' => '+12025550003'],
+				],
+				'users' => [
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User',
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+						'numberMap' => ['number' => '+12025550003', 'normalized' => '+12025550003'],
 					],
 				],
-				'users' => [],
-				'searchQuery' => [
-					'number' => '+120255500O3',
-					'normalized' => ''
-				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
+				'searchQuery' => ['number' => '      +12025550003     ', 'normalized' => '+12025550003'],
+				'pagination' => ['limit' => 10, 'offset' => 0],
 				'shouldHaveMore' => false,
-				'expectedCount' => 0,
+				'expectedCount' => 1,
 			],
 			'Apply pagination' => [
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
+					'numberMap' => ['number' => '', 'normalized' => ''],
 				],
 				'users' => [
 					[
@@ -710,28 +455,24 @@ class AccountPhonePluginTest extends TestCase {
 					'number' => '+12025550001',
 					'normalized' => '+12025550001'
 				],
-				'pagination' => [
-					'limit' => 2,
-					'offset' => 0,
-				],
+				'pagination' => ['limit' => 2, 'offset' => 0],
 				'shouldHaveMore' => true,
-				'expectedCount' => 2,	
+				'expectedCount' => 2,
 			],
 			'Edge pagination' => [
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
+					'numberMap' => ['number' => '', 'normalized' => ''],
 				],
 				'users' => [
 					[
@@ -762,27 +503,24 @@ class AccountPhonePluginTest extends TestCase {
 					'normalized' => '+12025550001'
 				],
 				'pagination' => [
-					'limit' => 2,
-					'offset' => 0,
-				],
+					'limit' => 2, 'offset' => 0],
 				'shouldHaveMore' => false,
-				'expectedCount' => 2,	
+				'expectedCount' => 2,
 			],
 			'Filter disabled users' => [
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
+					'numberMap' => ['number' => '', 'normalized' => ''],
 				],
 				'users' => [
 					// The order of the elements here matters
@@ -826,10 +564,7 @@ class AccountPhonePluginTest extends TestCase {
 					'number' => '+12025550001',
 					'normalized' => '+12025550001'
 				],
-				'pagination' => [
-					'limit' => 2,
-					'offset' => 0,
-				],
+				'pagination' => ['limit' => 2, 'offset' => 0],
 				'shouldHaveMore' => false,
 				'expectedCount' => 2,
 			],
@@ -837,12 +572,14 @@ class AccountPhonePluginTest extends TestCase {
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'no',
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => [],
 					'numberMap' => [
 						'number' => '',
@@ -898,81 +635,17 @@ class AccountPhonePluginTest extends TestCase {
 				'shouldHaveMore' => false,
 				'expectedCount' => 1,
 			],
-			'Enumeration but no full match' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
-					'shareapi_restrict_user_enumeration_full_match' => 'no',
-					'shareapi_only_share_with_group_members' => 'yes',
-				],
-				'currentUser' => [
-					'uid' => 'current',
-					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
-					'groups' => ['sales'],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
-				],
-				'users' => [
-					[
-						'uid' => 'target1',
-						'displayName' => 'Target User 1',
-						'numberMap' => [
-							'number' => '+12025550001',
-							'normalized' => '+12025550001',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['sales'],
-					],
-					[
-						'uid' => 'target2',
-						'displayName' => 'Target User 2',
-						'numberMap' => [
-							'number' => '+12025550003',
-							'normalized' => '+12025550003',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['sales'],
-					],
-					[
-						'uid' => 'excluded1',
-						'displayName' => 'Excluded User 1',
-						'numberMap' => [
-							'number' => '+12025550002',
-							'normalized' => '+12025550002',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => [],
-					],
-				],
-				'searchQuery' => [
-					'number' => '+12025550001',
-					'normalized' => '+12025550001'
-				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
-				'shouldHaveMore' => false,
-				'expectedCount' => 2,	
-			],
 			'No enumeration but full match' => [
 				'method' => 'sms',
 				'config' => [
 					'shareapi_allow_share_dialog_user_enumeration' => 'no',
 					'shareapi_restrict_user_enumeration_full_match' => 'yes',
+					'shareapi_only_share_with_group_members' => 'yes',
+					'shareapi_only_share_with_group_members_exclude_group_list' => [],
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => ['sales'],
 					'numberMap' => [
 						'number' => '',
@@ -984,8 +657,8 @@ class AccountPhonePluginTest extends TestCase {
 						'uid' => 'target1',
 						'displayName' => 'Target User 1',
 						'numberMap' => [
-							'number' => '+12025550001',
-							'normalized' => '+12025550001',
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
 						],
 						'isEnabled' => true,
 						'isKnown' => true,
@@ -1002,17 +675,6 @@ class AccountPhonePluginTest extends TestCase {
 						'isKnown' => true,
 						'groups' => ['sales'],
 					],
-					[
-						'uid' => 'target3',
-						'displayName' => 'Target User 3',
-						'numberMap' => [
-							'number' => '+12025550002',
-							'normalized' => '+12025550002',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => [],
-					],
 				],
 				'searchQuery' => [
 					'number' => '+12025550001',
@@ -1023,20 +685,22 @@ class AccountPhonePluginTest extends TestCase {
 					'offset' => 0,
 				],
 				'shouldHaveMore' => false,
-				'expectedCount' => 3,	
+				'expectedCount' => 2,
 			],
 			'Filter unknown phones' => [
 				'method' => 'sms',
 				'config' => [
-					'shareapi_restrict_user_enumeration_to_phone' => 'yes',
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
 					'shareapi_restrict_user_enumeration_to_group' => 'no',
+					'shareapi_restrict_user_enumeration_to_phone' => 'yes',
+					'shareapi_only_share_with_group_members' => 'no',
+					'shareapi_only_share_with_group_members_exclude_group_list' => [],
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
-					'groups' => [],
+					'groups' => ['sales'],
 					'numberMap' => [
 						'number' => '',
 						'normalized' => '',
@@ -1052,7 +716,7 @@ class AccountPhonePluginTest extends TestCase {
 						],
 						'isEnabled' => true,
 						'isKnown' => false,
-						'groups' => [],
+						'groups' => ['sales'],
 					],
 					[
 						'uid' => 'target',
@@ -1088,31 +752,101 @@ class AccountPhonePluginTest extends TestCase {
 				'shouldHaveMore' => false,
 				'expectedCount' => 1,
 			],
+			'Filter phones and restrict by group' => [
+				'method' => 'sms',
+				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'no',
+					'shareapi_restrict_user_enumeration_to_group' => 'yes',
+					'shareapi_restrict_user_enumeration_to_phone' => 'yes',
+					'shareapi_only_share_with_group_members' => 'no',
+					'shareapi_only_share_with_group_members_exclude_group_list' => [],
+				],
+				'currentUser' => [
+					'uid' => 'current',
+					'displayName' => 'Current User',
+					'groups' => ['sales'],
+					'numberMap' => [
+						'number' => '',
+						'normalized' => '',
+					],
+				],
+				'users' => [
+					[
+						'uid' => 'excluded1',
+						'displayName' => 'Excluded User 1',
+						'numberMap' => [
+							'number' => '+12025550002',
+							'normalized' => '+12025550002',
+						],
+						'isEnabled' => true,
+						'isKnown' => false,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User 1',
+						'numberMap' => [
+							'number' => '+12025550003',
+							'normalized' => '+12025550003',
+						],
+						'isEnabled' => true,
+						'isKnown' => false,
+						'groups' => ['sales'],
+					],
+					[
+						'uid' => 'excluded2',
+						'displayName' => 'Excluded User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => false,
+						'groups' => [],
+					],
+					[
+						'uid' => 'target',
+						'displayName' => 'Target User 2',
+						'numberMap' => [
+							'number' => '+12025550004',
+							'normalized' => '+12025550004',
+						],
+						'isEnabled' => true,
+						'isKnown' => true,
+						'groups' => [],
+					],
+				],
+				'searchQuery' => [
+					'number' => '+12025550003',
+					'normalized' => '+12025550003'
+				],
+				'pagination' => [
+					'limit' => 10,
+					'offset' => 0,
+				],
+				'shouldHaveMore' => false,
+				'expectedCount' => 2,
+			],
 			'Filter disallowed groups' => [
 				'method' => 'sms',
 				'config' => [
-					'shareapi_restrict_user_enumeration_to_group' => 'yes',
-					'shareapi_restrict_user_enumeration_to_phone' => 'no',
+					'shareapi_only_share_with_group_members' => 'yes',
 					'shareapi_only_share_with_group_members_exclude_group_list' => ['engineering'],
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => ['sales'],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
+					'numberMap' => ['number' => '', 'normalized' => ''],
 				],
 				'users' => [
 					[
 						'uid' => 'excluded1',
 						'displayName' => 'Excluded User 1',
 						'numberMap' => [
-							'number' => '+12025550002',
-							'normalized' => '+12025550002',
+							'number' => '+1202555001',
+							'normalized' => '+1202555001',
 						],
 						'isEnabled' => true,
 						'isKnown' => true,
@@ -1122,8 +856,8 @@ class AccountPhonePluginTest extends TestCase {
 						'uid' => 'target1',
 						'displayName' => 'Target User 1',
 						'numberMap' => [
-							'number' => '+12025550003',
-							'normalized' => '+12025550003',
+							'number' => '+1202555002',
+							'normalized' => '+1202555002',
 						],
 						'isEnabled' => true,
 						'isKnown' => true,
@@ -1133,8 +867,8 @@ class AccountPhonePluginTest extends TestCase {
 						'uid' => 'excluded2',
 						'displayName' => 'Excluded User 2',
 						'numberMap' => [
-							'number' => '+12025550004',
-							'normalized' => '+12025550004',
+							'number' => '+1202555003',
+							'normalized' => '+1202555003',
 						],
 						'isEnabled' => true,
 						'isKnown' => true,
@@ -1144,8 +878,8 @@ class AccountPhonePluginTest extends TestCase {
 						'uid' => 'target2',
 						'displayName' => 'Target User 2',
 						'numberMap' => [
-							'number' => '+12025550005',
-							'normalized' => '+12025550005',
+							'number' => '+1202555004',
+							'normalized' => '+1202555004',
 						],
 						'isEnabled' => true,
 						'isKnown' => true,
@@ -1153,100 +887,26 @@ class AccountPhonePluginTest extends TestCase {
 					],
 				],
 				'searchQuery' => [
-					'number' => '+12025550003',
-					'normalized' => '+12025550003'
+					'number' => '+1202555001',
+					'normalized' => '+1202555001',
 				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
+				'pagination' => ['limit' => 10, 'offset' => 0],
 				'shouldHaveMore' => false,
 				'expectedCount' => 2,
 			],
-			'Restrict to common group' => [
+			'Filter group-only users' => [
 				'method' => 'sms',
 				'config' => [
+					'shareapi_allow_share_dialog_user_enumeration' => 'no',
+					'shareapi_only_share_with_group_members' => 'yes',
+					'shareapi_restrict_user_enumeration_to_phone' => 'no',
 					'shareapi_restrict_user_enumeration_to_group' => 'yes',
-					'shareapi_only_share_with_group_members' => 'yes',
+					'shareapi_restrict_user_enumeration_full_match' => 'yes',
+					'shareapi_only_share_with_group_members_exclude_group_list' => [],
 				],
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
-					'groups' => ['sales'],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
-				],
-				'users' => [
-					[
-						'uid' => 'excluded1',
-						'displayName' => 'Excluded User 1',
-						'numberMap' => [
-							'number' => '+12025550002',
-							'normalized' => '+12025550002',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['engineering'],
-					],
-					[
-						'uid' => 'target1',
-						'displayName' => 'Target User 1',
-						'numberMap' => [
-							'number' => '+12025550003',
-							'normalized' => '+12025550003',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['sales', 'engineering'],
-					],
-					[
-						'uid' => 'excluded2',
-						'displayName' => 'Excluded User 2',
-						'numberMap' => [
-							'number' => '+12025550004',
-							'normalized' => '+12025550004',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['engineering'],
-					],
-					[
-						'uid' => 'target2',
-						'displayName' => 'Target User 2',
-						'numberMap' => [
-							'number' => '+12025550005',
-							'normalized' => '+12025550005',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['sales'],
-					],
-				],
-				'searchQuery' => [
-					'number' => '+12025550003',
-					'normalized' => '+12025550003'
-				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
-				'shouldHaveMore' => false,
-				'expectedCount' => 2,
-			],
-			'Filter group-only users mid-list' => [
-				'method' => 'sms',
-				'config' => [
-					'shareapi_only_share_with_group_members' => 'yes',
-				],
-				'currentUser' => [
-					'uid' => 'current',
-					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => ['sales'],
 					'numberMap' => [
 						'number' => '',
@@ -1280,8 +940,8 @@ class AccountPhonePluginTest extends TestCase {
 					],
 				],
 				'searchQuery' => [
-					'number' => '+12025550001',
-					'normalized' => '+12025550001',
+					'number' => '+12025550000',
+					'normalized' => '+12025550000',
 				],
 				'pagination' => [
 					'limit' => 10,
@@ -1300,13 +960,8 @@ class AccountPhonePluginTest extends TestCase {
 				'currentUser' => [
 					'uid' => 'current',
 					'displayName' => 'Current User',
-					'isEnabled' => true,
-					'isKnown' => true,
 					'groups' => ['sales'],
-					'numberMap' => [
-						'number' => '',
-						'normalized' => '',
-					],
+					'numberMap' => ['number' => '', 'normalized' => ''],
 				],
 				'users' => [
 					[
@@ -1321,17 +976,6 @@ class AccountPhonePluginTest extends TestCase {
 						'groups' => ['sales'],
 					],
 					[
-						'uid' => 'target1',
-						'displayName' => 'Target User 1',
-						'numberMap' => [
-							'number' => '+12025550003',
-							'normalized' => '+12025550003',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['sales', 'engineering'],
-					],
-					[
 						'uid' => 'excluded2',
 						'displayName' => 'Excluded User 2',
 						'numberMap' => [
@@ -1342,26 +986,12 @@ class AccountPhonePluginTest extends TestCase {
 						'isKnown' => true,
 						'groups' => ['sales'],
 					],
-					[
-						'uid' => 'target2',
-						'displayName' => 'Target User 2',
-						'numberMap' => [
-							'number' => '+12025550005',
-							'normalized' => '+12025550005',
-						],
-						'isEnabled' => true,
-						'isKnown' => true,
-						'groups' => ['engineering'],
-					],
 				],
 				'searchQuery' => [
 					'number' => '+12025550003',
 					'normalized' => '+12025550003'
 				],
-				'pagination' => [
-					'limit' => 10,
-					'offset' => 0,
-				],
+				'pagination' => ['limit' => 10, 'offset' => 0],
 				'shouldHaveMore' => false,
 				'expectedCount' => 0,
 			],


### PR DESCRIPTION
Related to: #8053

## 📝 Summary

This pull request aims to increase the effectiveness of the `AccountPhonePluginTest` test class to increase mutation coverage. The initial tests, though quite effective, didn't consider edge cases that Infection revealed as the inputs only used one user as a target. In addition, some logic required exercising more configurations to ensure a proper sanitizing.

To reduce the number of the added tests, I modified the current `testSearchRespectsEnumerationRules` to mainly allow a list of users as well as a search query. This way, I could move the existent scenarios and still design new ones. Moreover, only 2 new tests were added besides the provider modification.

The first execution of Infection (prior to this PR) can be found [here](https://github.com/user-attachments/files/31803232/before.log).
The execution of Infection after the changes can be found [here](https://github.com/user-attachments/files/31803261/after.log).

| Metric | Before | After | Delta |
| :--- | :---: | :---: | :---: |
| Total Test Scenarios | 19 | 24 | +5 |
| Generated Mutants | 84 | 85 | +1 |
| Killed Mutants | 68 | 79 | +11 |
| Escaped Mutants | 16 | 6 | -10  |
| Mutation Code Coverage | 100% | 100% | 0% |
| Covered Code MSI | 80% | 92% | +12% |

The remaining 6 mutants were related to string formatting (mainly the use of `tolower()` function), string casting on `$uid` and JSON decoding depth. Since the class's primary usage is related to phone numbers, I considered they weren't valuable enough to make new tests.

## 🧪 How to test

Run the test suite:
```bash
composer test:unit -- --filter AccountPhonePluginTest
```
Expected result:
```bash
OK (17 tests, 33 assertions)
```

Run Infection:
```
composer mutation:test -- \
  lib/Collaboration/Collaborators/AccountPhonePlugin.php \
  tests/php/Unit/Collaboration/Collaborators/AccountPhonePluginTest.php \
  --show-mutations \
  --threads=1
```
> Note: I needed to force the use of only 1 thread as race conditions were happening with multiple ones. Ending with flaky results.

Expected results:
```bash
85 mutations were generated:
      79 mutants were killed by Test Framework
       6 covered mutants were not detected

Metrics:
         Mutation Code Coverage: 100%
         Covered Code MSI: 92%
```

## ⚙️ API / Back‑end changes

- [x] No mutation exclusions, disabled mutators, or threshold changes were added.
- [x] Modified current `testSearchRespectsEnumerationRules` data provider to support multiple users to exercise more boundary cases.
- [x] Unit tests added for more boundary checking
- [ ] Capabilities updated (not applicable)
- [ ] Documentation updated (not applicable)
- [ ] API documentation updated with the command `composer openapi` if necessary (not applicable)
## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
