### PR TITLE
fix: external PDF signature validation

### DIFF
--- a/lib/Command/Developer/SignSetup.php
+++ b/lib/Command/Developer/SignSetup.php
@@ -12,10 +12,12 @@ use Exception;
 use OC\Core\Command\Base;
 use OCA\Libresign\Service\Install\InstallService;
 use OCA\Libresign\Service\Install\SignSetupService;
-use OCA\Libresign\Vendor\phpseclib3\Crypt\RSA;
-use OCA\Libresign\Vendor\phpseclib3\Exception\NoKeyLoadedException;
-use OCA\Libresign\Vendor\phpseclib3\File\X509;
+use OCA\Libresign\Vendor\phpseclib4\Crypt\RSA;
+use OCA\Libresign\Vendor\phpseclib4\Exception\NoKeyLoadedException;
+use OCA\Libresign\Vendor\phpseclib4\Exception\UnexpectedValueException;
+use OCA\Libresign\Vendor\phpseclib4\File\X509;
 use OCP\IConfig;
+use SodiumException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -67,12 +69,12 @@ class SignSetup extends Base {
 			$output->writeln('Invalid private key');
 			return 1;
 		}
-		$x509 = new X509();
-		if ($x509->loadX509($keyBundle) === false) {
+		try {
+			$x509 = X509::load($keyBundle);
+		} catch (UnexpectedValueException|SodiumException) {
 			$output->writeln('Invalid certificate');
 			return 1;
 		}
-		$x509->setPrivateKey($rsa);
 		try {
 			$this->signSetupService->setCertificate($x509);
 			$this->signSetupService->setPrivateKey($rsa);

--- a/lib/Handler/CertificateEngine/AEngineHandler.php
+++ b/lib/Handler/CertificateEngine/AEngineHandler.php
@@ -834,14 +834,12 @@ abstract class AEngineHandler implements IEngineHandler {
 	#[\Override]
 	public function generateCrlDer(array $revokedCertificates, string $instanceId, int $generation, int $crlNumber): string {
 		$configPath = $this->getConfigPathByParams($instanceId, $generation);
-		$issuer = $this->loadCaIssuer($configPath);
-		$signedCrl = $this->createAndSignCrl($issuer, $revokedCertificates, $crlNumber);
-		$crlDerData = $this->saveCrlToDer($signedCrl, $configPath);
-
-		return $crlDerData;
+		[$issuer, $privateKey] = $this->loadCaIssuer($configPath);
+		return $this->createAndSignCrl($issuer, $privateKey, $revokedCertificates, $crlNumber);
 	}
 
-	private function loadCaIssuer(string $configPath): \OCA\Libresign\Vendor\phpseclib3\File\X509 {
+	/** @return array{0: \OCA\Libresign\Vendor\phpseclib4\File\X509, 1: \OCA\Libresign\Vendor\phpseclib4\Crypt\Common\PrivateKey} */
+	private function loadCaIssuer(string $configPath): array {
 		$caCertPath = $configPath . DIRECTORY_SEPARATOR . 'ca.pem';
 		$caKeyPath = $configPath . DIRECTORY_SEPARATOR . 'ca-key.pem';
 
@@ -858,94 +856,50 @@ abstract class AEngineHandler implements IEngineHandler {
 			throw new \RuntimeException('Failed to read CA certificate or private key');
 		}
 
-		$issuer = new \OCA\Libresign\Vendor\phpseclib3\File\X509();
-		$issuer->loadX509($caCert);
-		$caPrivateKey = \OCA\Libresign\Vendor\phpseclib3\Crypt\PublicKeyLoader::load($caKey);
+		$issuer = \OCA\Libresign\Vendor\phpseclib4\File\X509::load($caCert);
+		$caPrivateKey = \OCA\Libresign\Vendor\phpseclib4\Crypt\PublicKeyLoader::load($caKey);
 
-		if (!$caPrivateKey instanceof \OCA\Libresign\Vendor\phpseclib3\Crypt\Common\PrivateKey) {
+		if (!$caPrivateKey instanceof \OCA\Libresign\Vendor\phpseclib4\Crypt\Common\PrivateKey) {
 			$this->logger->error('Loaded key is not a private key', ['keyType' => $caPrivateKey::class]);
 			throw new \RuntimeException('Loaded key is not a private key');
 		}
 
-		$issuer->setPrivateKey($caPrivateKey);
-		return $issuer;
+		return [$issuer, $caPrivateKey];
 	}
 
-	private function createAndSignCrl(\OCA\Libresign\Vendor\phpseclib3\File\X509 $issuer, array $revokedCertificates, int $crlNumber): array {
+	private function createAndSignCrl(\OCA\Libresign\Vendor\phpseclib4\File\X509 $issuer, \OCA\Libresign\Vendor\phpseclib4\Crypt\Common\PrivateKey $privateKey, array $revokedCertificates, int $crlNumber): string {
 		$utcZone = new \DateTimeZone('UTC');
-		$crlToSign = new \OCA\Libresign\Vendor\phpseclib3\File\X509();
-		$crlToSign->setSerialNumber((string)$crlNumber, 10);
-		$crlToSign->setStartDate(new \DateTime('now', $utcZone));
-		$crlToSign->setEndDate(new \DateTime('+7 days', $utcZone));
+		$crl = new \OCA\Libresign\Vendor\phpseclib4\File\CRL();
+		$crl->copySigningX509Attributes($issuer);
+		$crl->setThisDate(new \DateTime('now', $utcZone));
+		$crl->setNextDate(new \DateTime('+7 days', $utcZone));
+		$crl->setExtension('id-ce-cRLNumber', new \OCA\Libresign\Vendor\phpseclib4\Math\BigInteger((string)$crlNumber));
 
-		$initialCrl = $crlToSign->signCRL($issuer, $crlToSign);
-		if ($initialCrl === false) {
-			$this->logger->error('Failed to create initial CRL structure');
-			throw new \RuntimeException('Failed to create initial CRL structure');
+		foreach ($revokedCertificates as $cert) {
+			$crl->revoke(
+				$this->createRevokedCertificateSerial((string)$cert->getSerialNumber()),
+				null,
+				$cert->getRevokedAt(),
+			);
 		}
 
-		if (!empty($revokedCertificates)) {
-			$savedCrl = $crlToSign->saveCRL($initialCrl);
-			if ($savedCrl === false) {
-				$this->logger->error('Failed to save initial CRL structure');
-				throw new \RuntimeException('Failed to save initial CRL structure');
-			}
-
-			$crlToSign->loadCRL($savedCrl);
-
-			$dateFormat = 'D, d M Y H:i:s O';
-			foreach ($revokedCertificates as $cert) {
-				$serialNumber = $cert->getSerialNumber();
-				$crlToSign->revoke(
-					$this->normalizeRevokedCertificateSerialForCrl((string)$serialNumber),
-					$cert->getRevokedAt()->format($dateFormat)
-				);
-			}
-
-			$signedCrl = $crlToSign->signCRL($issuer, $crlToSign);
-		} else {
-			$signedCrl = $initialCrl;
-		}
-
-		if ($signedCrl === false) {
-			$this->logger->error('Failed to sign CRL', ['crlNumber' => $crlNumber]);
+		$crl->identifySignatureAlgorithm($privateKey);
+		$signature = $privateKey->sign($crl);
+		if (!is_string($signature)) {
 			throw new \RuntimeException('Failed to sign CRL');
 		}
-
-		if (!isset($signedCrl['signatureAlgorithm'])) {
-			$signedCrl['signatureAlgorithm'] = ['algorithm' => 'sha256WithRSAEncryption'];
-		}
-
-		return $signedCrl;
+		$crl->setSignature($signature);
+		return $crl->toString(['binary' => true]);
 	}
 
-	private function normalizeRevokedCertificateSerialForCrl(string $serialNumber): string {
+	private function createRevokedCertificateSerial(string $serialNumber): \OCA\Libresign\Vendor\phpseclib4\Math\BigInteger {
 		$normalizedSerial = ltrim($serialNumber, '0') ?: '0';
 
 		if (ctype_digit($normalizedSerial)) {
-			return $normalizedSerial;
+			return new \OCA\Libresign\Vendor\phpseclib4\Math\BigInteger($normalizedSerial);
 		}
 
-		return (new \OCA\Libresign\Vendor\phpseclib3\Math\BigInteger($normalizedSerial, 16))->toString();
-	}
-
-	private function saveCrlToDer(array $signedCrl, string $configPath): string {
-		$crlDerPath = $configPath . DIRECTORY_SEPARATOR . 'crl.der';
-		$crlToSign = new \OCA\Libresign\Vendor\phpseclib3\File\X509();
-
-		$crlDerData = $crlToSign->saveCRL($signedCrl, \OCA\Libresign\Vendor\phpseclib3\File\X509::FORMAT_DER);
-
-		if ($crlDerData === false) {
-			$this->logger->error('Failed to save CRL in DER format');
-			throw new \RuntimeException('Failed to save CRL in DER format');
-		}
-
-		if (file_put_contents($crlDerPath, $crlDerData) === false) {
-			$this->logger->error('Failed to write CRL DER file', ['path' => $crlDerPath]);
-			throw new \RuntimeException('Failed to write CRL DER file');
-		}
-
-		return $crlDerData;
+		return new \OCA\Libresign\Vendor\phpseclib4\Math\BigInteger($normalizedSerial, 16);
 	}
 
 	#[\Override]

--- a/lib/Handler/SignEngine/Pkcs12Handler.php
+++ b/lib/Handler/SignEngine/Pkcs12Handler.php
@@ -19,11 +19,9 @@ use OCA\Libresign\Service\Crl\CrlService;
 use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\Signature\PdfSignatureValidationService;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Exception\UnsignedPdfException;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationReason;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationResult;
-use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationState;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Parser\PdfSignatureExtractor;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\Exception\UnexpectedValueException;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
 use OCP\Files\File;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -162,7 +160,11 @@ class Pkcs12Handler extends SignEngineHandler {
 			return $result;
 		}
 
-		$decoded = ASN1::decodeBER($signature);
+		try {
+			$decoded = ASN1::decodeBER($signature);
+		} catch (UnexpectedValueException) {
+			return [];
+		}
 		$result = $this->extractTimestampData($decoded, $result);
 
 		$chain = $this->extractCertificateChain($signature);
@@ -336,12 +338,7 @@ class Pkcs12Handler extends SignEngineHandler {
 		}
 
 		if (isset($validation['signatureValidation']) && is_array($validation['signatureValidation'])) {
-			$signatureValidation = $validation['signatureValidation'];
-
-			// Keep legacy OpenSSL result when native validator reports this known false-positive.
-			if (!$this->isDigestMismatchSignatureValidation($validation)) {
-				$leaf['signature_validation'] = $signatureValidation;
-			}
+			$leaf['signature_validation'] = $validation['signatureValidation'];
 		}
 
 		if (isset($validation['certificateValidation']) && is_array($validation['certificateValidation'])) {
@@ -357,21 +354,6 @@ class Pkcs12Handler extends SignEngineHandler {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * signer engines can produce signatures that the native validator currently flags as digest mismatch.
-	 * In this case we preserve the legacy validation computed from the PKCS#7 signature.
-	 */
-	private function isDigestMismatchSignatureValidation(array $validation): bool {
-		$rawSignatureValidation = $validation['raw']['signature'] ?? null;
-		if ($rawSignatureValidation instanceof ValidationResult) {
-			return $rawSignatureValidation->reasonCode === ValidationReason::DIGEST_MISMATCH
-				|| $rawSignatureValidation->state === ValidationState::DIGEST_MISMATCH;
-		}
-
-		$signatureValidation = $validation['signatureValidation'] ?? null;
-		return is_array($signatureValidation) && ($signatureValidation['id'] ?? null) === 3;
 	}
 
 	/**

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -348,7 +348,7 @@ class TSA {
 	private function getAttributeValuesSetAfterOID(array $tree, string $oid): ?array {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
-			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && $this->getNodeContent($n) === $oid) {
+			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && $this->matchesOid($this->getNodeContent($n), $oid)) {
 				$seen = true;
 				continue;
 			}
@@ -363,7 +363,7 @@ class TSA {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
 			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& $this->getNodeContent($n) === $oid
+				&& $this->matchesOid($this->getNodeContent($n), $oid)
 			) {
 				$seen = true;
 				continue;
@@ -376,6 +376,11 @@ class TSA {
 			}
 		}
 		return null;
+	}
+
+	private function matchesOid(mixed $candidate, string $expected): bool {
+		return is_string($candidate)
+			&& ASN1::getOIDFromName($candidate) === ASN1::getOIDFromName($expected);
 	}
 
 	private function extractCertificateHints(array $asn1Tree): array {

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Handler\SignEngine;
 
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1\Element;
-use OCA\Libresign\Vendor\phpseclib3\Math\BigInteger;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Constructed;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Element;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1\Types\BaseType;
+use OCA\Libresign\Vendor\phpseclib4\Math\BigInteger;
 
 class TSA {
 	private static bool $areOidsInitialized = false;
@@ -38,8 +40,8 @@ class TSA {
 
 	private function processContentCandidate($content, ?string &$cmsDer): array {
 		try {
-			if ($content instanceof Element) {
-				return $this->decodeWithCache($cmsDer = $content->element);
+			if ($content instanceof Element && $content->value !== '') {
+				return $this->decodeWithCache($cmsDer = $content->value);
 			} elseif (is_string($content)) {
 				return $this->decodeWithCache($cmsDer = $content);
 			} elseif (is_array($content)) {
@@ -76,12 +78,12 @@ class TSA {
 	}
 
 	private function extractTimestampAuthorityName($timestampElement): array {
-		if (!$timestampElement instanceof Element || !is_string($timestampElement->element)) {
+		if (!$timestampElement instanceof Element || $timestampElement->value === '') {
 			return [];
 		}
 
 		try {
-			$decoded = $this->decodeWithCache($timestampElement->element);
+			$decoded = $this->decodeWithCache($timestampElement->value);
 			return ($decoded[0] ?? null) ? $this->extractCertificateHints([$decoded[0]]) : [];
 		} catch (\Throwable) {
 			return [];
@@ -165,12 +167,7 @@ class TSA {
 
 				$tst = null;
 				if ($tstNode && ($tstNode['type'] ?? null) === ASN1::TYPE_SEQUENCE) {
-					ASN1::setTimeFormat('Y-m-d\TH:i:s\Z');
-					$tst = ASN1::asn1map($tstNode, self::$timestampInfoStructure ??= $this->buildTimestampInfoStructure());
-
-					if (!is_array($tst)) {
-						$tst = $this->parseTstInfoFallback($tstInfoOctets);
-					}
+					$tst = $this->parseTstInfoFallback($tstInfoOctets);
 				}
 			} catch (\Throwable) {
 				$tst = $this->parseTstInfoFallback($tstInfoOctets);
@@ -245,19 +242,35 @@ class TSA {
 	}
 
 	public function getSigninTime($root): ?\DateTime {
-		$signingTime = null;
-		if ($values = $this->getAttributeValuesSetAfterOID($root, self::TIMESTAMP_OIDS['SIGNING_TIME'])) {
-			foreach ($values as $v) {
-				$t = $v['type'] ?? null;
-				if ($t === ASN1::TYPE_UTC_TIME || $t === ASN1::TYPE_GENERALIZED_TIME) {
-					$signingTime = $v['content'] ?? null;
-					if ($signingTime !== null) {
-						break;
-					}
-				}
+		$foundSigningTimeOid = false;
+		if (is_array($root) && isset($root['type'])) {
+			$root = [$root];
+		}
+
+		foreach ($this->walkAsn1Tree(is_array($root) ? $root : []) as $node) {
+			if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
+				&& in_array($this->getNodeContent($node), [self::TIMESTAMP_OIDS['SIGNING_TIME'], 'signingTime', 'id-signingTime'], true)) {
+				$foundSigningTimeOid = true;
+				continue;
+			}
+
+			if (!$foundSigningTimeOid || !in_array($node['type'] ?? null, [ASN1::TYPE_UTC_TIME, ASN1::TYPE_GENERALIZED_TIME], true)) {
+				continue;
+			}
+
+			$signingTime = $this->getNodeContent($node);
+			if (!is_string($signingTime) || $signingTime === '') {
+				return null;
+			}
+
+			try {
+				return new \DateTime($signingTime);
+			} catch (\Exception) {
+				return null;
 			}
 		}
-		return $signingTime;
+
+		return null;
 	}
 
 	private function parseTstInfoFallback(string $tstInfoOctets): ?array {
@@ -279,8 +292,9 @@ class TSA {
 		foreach ($root['content'] as $child) {
 			$t = $child['type'] ?? null;
 
-			if (!$seenPolicy && $t === ASN1::TYPE_OBJECT_IDENTIFIER && is_string($child['content'] ?? null)) {
-				$out['policy'] = $child['content'];
+			$nodeContent = $this->getNodeContent($child);
+			if (!$seenPolicy && $t === ASN1::TYPE_OBJECT_IDENTIFIER && is_string($nodeContent)) {
+				$out['policy'] = $nodeContent;
 				$seenPolicy = true;
 				continue;
 			}
@@ -310,8 +324,8 @@ class TSA {
 				continue;
 			}
 			if ($t === ASN1::TYPE_GENERALIZED_TIME || $t === ASN1::TYPE_UTC_TIME) {
-				if (is_string($child['content'] ?? null)) {
-					$out['genTime'] = $child['content'];
+				if (is_string($nodeContent)) {
+					$out['genTime'] = $nodeContent;
 				}
 			}
 		}
@@ -319,8 +333,9 @@ class TSA {
 		if (!$out['genTime']) {
 			foreach ($this->walkAsn1Tree([$root]) as $n) {
 				$tt = $n['type'] ?? null;
-				if (($tt === ASN1::TYPE_GENERALIZED_TIME || $tt === ASN1::TYPE_UTC_TIME) && is_string($n['content'] ?? null)) {
-					$out['genTime'] = $n['content'];
+				$nodeContent = $this->getNodeContent($n);
+				if (($tt === ASN1::TYPE_GENERALIZED_TIME || $tt === ASN1::TYPE_UTC_TIME) && is_string($nodeContent)) {
+					$out['genTime'] = $nodeContent;
 					break;
 				}
 			}
@@ -331,7 +346,7 @@ class TSA {
 	private function getAttributeValuesSetAfterOID(array $tree, string $oid): ?array {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
-			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && ($n['content'] ?? null) === $oid) {
+			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER && $this->getNodeContent($n) === $oid) {
 				$seen = true;
 				continue;
 			}
@@ -346,16 +361,16 @@ class TSA {
 		$seen = false;
 		foreach ($this->walkAsn1Tree($tree) as $n) {
 			if (($n['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& ($n['content'] ?? null) === $oid
+				&& $this->getNodeContent($n) === $oid
 			) {
 				$seen = true;
 				continue;
 			}
 			if ($seen
 				&& ($n['type'] ?? null) === $expectedType
-				&& is_string($n['content'] ?? null)
+				&& is_string($this->getNodeContent($n))
 			) {
-				return $n['content'];
+				return $this->getNodeContent($n);
 			}
 		}
 		return null;
@@ -366,18 +381,18 @@ class TSA {
 		$currentAttributeOid = null;
 
 		foreach ($this->walkAsn1Tree($asn1Tree) as $node) {
+			$nodeContent = $this->getNodeContent($node);
 			if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& isset($node['content'], self::CERTIFICATE_ATTRIBUTE_OIDS[$node['content']])) {
-				$currentAttributeOid = $node['content'];
+				&& is_string($nodeContent) && isset(self::CERTIFICATE_ATTRIBUTE_OIDS[$nodeContent])) {
+				$currentAttributeOid = $nodeContent;
 				continue;
 			}
 
 			if ($currentAttributeOid !== null
-				&& isset($node['content'])
-				&& is_string($node['content'])
-				&& $this->isStringValidUtf8($node['content'])
+				&& is_string($nodeContent)
+				&& $this->isStringValidUtf8($nodeContent)
 			) {
-				$certificateHints[self::CERTIFICATE_ATTRIBUTE_OIDS[$currentAttributeOid]] = $node['content'];
+				$certificateHints[self::CERTIFICATE_ATTRIBUTE_OIDS[$currentAttributeOid]] = $nodeContent;
 				$currentAttributeOid = null;
 			}
 		}
@@ -468,7 +483,7 @@ class TSA {
 			return null;
 		}
 
-		$resolved = ASN1::getOID($policyOid);
+		$resolved = ASN1::getNameFromOID($policyOid);
 		if ($resolved && $resolved !== $policyOid) {
 			return $resolved;
 		}
@@ -492,6 +507,9 @@ class TSA {
 		}
 
 		$decodedResult = ASN1::decodeBER($asn1Data);
+		if (isset($decodedResult['type'])) {
+			$decodedResult = [$decodedResult];
+		}
 		if ($decodedResult === null) {
 			$decodedResult = [];
 		}
@@ -504,6 +522,15 @@ class TSA {
 		return $decodedResult;
 	}
 
+	private function getNodeContent(array $node): mixed {
+		$content = $node['content'] ?? null;
+		if (!$content instanceof BaseType) {
+			return $content;
+		}
+
+		return ASN1::convertToPrimitive($content);
+	}
+
 	public static function clearCache(): void {
 		self::$asn1DecodingCache = [];
 	}
@@ -513,13 +540,44 @@ class TSA {
 
 		while (!empty($processingStack)) {
 			$currentNode = array_shift($processingStack);
+			if (!is_array($currentNode)) {
+				continue;
+			}
 			yield $currentNode;
 
 			foreach (['content', 'children'] as $childrenKey) {
 				if (isset($currentNode[$childrenKey]) && is_array($currentNode[$childrenKey])) {
 					array_unshift($processingStack, ...$currentNode[$childrenKey]);
+				} elseif ($childrenKey === 'content' && ($currentNode[$childrenKey] ?? null) instanceof Constructed) {
+					array_unshift($processingStack, ...$this->decodeConstructedChildren($currentNode[$childrenKey]));
 				}
 			}
 		}
+	}
+
+	/** @return list<array> */
+	private function decodeConstructedChildren(Constructed $node): array {
+		$encoded = $node->getEncodedWithoutHeader();
+		$children = [];
+		$offset = 0;
+
+		while ($offset < strlen($encoded)) {
+			try {
+				$child = ASN1::decodeBER(substr($encoded, $offset));
+			} catch (\Throwable) {
+				break;
+			}
+
+			$headerLength = $child['headerlength'] ?? null;
+			$length = $child['length'] ?? null;
+			if (!is_int($headerLength) || !is_int($length)) {
+				break;
+			}
+
+			$children[] = $child;
+			$offset += $headerLength + $length;
+		}
+
+		return $children;
 	}
 }

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -167,7 +167,11 @@ class TSA {
 
 				$tst = null;
 				if ($tstNode && ($tstNode['type'] ?? null) === ASN1::TYPE_SEQUENCE) {
-					$tst = $this->parseTstInfoFallback($tstInfoOctets);
+					$mappedTst = ASN1::map($tstNode, self::$timestampInfoStructure ??= $this->buildTimestampInfoStructure());
+					$tst = $mappedTst instanceof Constructed ? $mappedTst->toArray(true) : null;
+					if (!is_array($tst)) {
+						$tst = $this->parseTstInfoFallback($tstInfoOctets);
+					}
 				}
 			} catch (\Throwable) {
 				$tst = $this->parseTstInfoFallback($tstInfoOctets);

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -175,7 +175,9 @@ class TSA {
 
 			if (is_array($tst)) {
 				$tsa['genTime'] = $tst['genTime'] ?? null;
-				$policyOid = $tst['policy'] ?? null;
+				$policyOid = isset($tst['policy']) && is_string($tst['policy'])
+					? ASN1::getOIDFromName($tst['policy'])
+					: null;
 				$tsa['policy'] = $policyOid;
 				$tsa['policyName'] = $this->resolveTsaPolicyName($policyOid);
 				$tsa['serialNumber'] = $this->bigToString($tst['serialNumber'] ?? null);

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -279,9 +279,12 @@ class TSA {
 		try {
 			$nodes = $this->decodeWithCache($tstInfoOctets);
 			$root = $nodes[0] ?? null;
-			if (!$root || ($root['type'] ?? null) !== ASN1::TYPE_SEQUENCE || !is_array($root['content'] ?? null)) {
+			if (!$root || ($root['type'] ?? null) !== ASN1::TYPE_SEQUENCE) {
 				return null;
 			}
+			$children = is_array($root['content'] ?? null)
+				? $root['content']
+				: (($root['content'] ?? null) instanceof Constructed ? $this->decodeConstructedChildren($root['content']) : []);
 		} catch (\Throwable) {
 			return null;
 		}
@@ -291,7 +294,7 @@ class TSA {
 		$seenMsgImprint = false;
 		$seenSerial = false;
 
-		foreach ($root['content'] as $child) {
+		foreach ($children as $child) {
 			$t = $child['type'] ?? null;
 
 			$nodeContent = $this->getNodeContent($child);

--- a/lib/Handler/SignEngine/TSA.php
+++ b/lib/Handler/SignEngine/TSA.php
@@ -42,6 +42,8 @@ class TSA {
 		try {
 			if ($content instanceof Element && $content->value !== '') {
 				return $this->decodeWithCache($cmsDer = $content->value);
+			} elseif ($content instanceof Constructed) {
+				return $this->decodeWithCache($cmsDer = $content->getEncoded());
 			} elseif (is_string($content)) {
 				return $this->decodeWithCache($cmsDer = $content);
 			} elseif (is_array($content)) {
@@ -131,6 +133,10 @@ class TSA {
 	}
 
 	public function extract(array $root): array {
+		if (isset($root['type'])) {
+			$root = [$root];
+		}
+
 		$cmsDer = null;
 		$tstInfoOctets = null;
 		$cnHints = [];
@@ -307,12 +313,18 @@ class TSA {
 				$seenPolicy = true;
 				continue;
 			}
-			if (!$seenMsgImprint && $t === ASN1::TYPE_SEQUENCE && is_array($child['content'] ?? null)) {
+			$messageImprintParts = is_array($child['content'] ?? null)
+				? $child['content']
+				: (($child['content'] ?? null) instanceof Constructed ? $this->decodeConstructedChildren($child['content']) : []);
+			if (!$seenMsgImprint && $t === ASN1::TYPE_SEQUENCE && $messageImprintParts !== []) {
 				$hasOID = false;
 				$hasOctet = false;
-				foreach ($child['content'] as $miPart) {
+				foreach ($messageImprintParts as $miPart) {
 					if (($miPart['type'] ?? null) === ASN1::TYPE_SEQUENCE) {
-						foreach (($miPart['content'] ?? []) as $algPart) {
+						$algorithmParts = is_array($miPart['content'] ?? null)
+							? $miPart['content']
+							: (($miPart['content'] ?? null) instanceof Constructed ? $this->decodeConstructedChildren($miPart['content']) : []);
+						foreach ($algorithmParts as $algPart) {
 							if (($algPart['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER) {
 								$hasOID = true;
 							}
@@ -359,8 +371,13 @@ class TSA {
 				$seen = true;
 				continue;
 			}
-			if ($seen && ($n['type'] ?? null) === ASN1::TYPE_SET && isset($n['content']) && is_array($n['content'])) {
-				return $n['content'];
+			if ($seen && ($n['type'] ?? null) === ASN1::TYPE_SET) {
+				if (is_array($n['content'] ?? null)) {
+					return $n['content'];
+				}
+				if (($n['content'] ?? null) instanceof Constructed) {
+					return $this->decodeConstructedChildren($n['content']);
+				}
 			}
 		}
 		return null;
@@ -396,9 +413,10 @@ class TSA {
 
 		foreach ($this->walkAsn1Tree($asn1Tree) as $node) {
 			$nodeContent = $this->getNodeContent($node);
+			$nodeOid = is_string($nodeContent) ? ASN1::getOIDFromName($nodeContent) : null;
 			if (($node['type'] ?? null) === ASN1::TYPE_OBJECT_IDENTIFIER
-				&& is_string($nodeContent) && isset(self::CERTIFICATE_ATTRIBUTE_OIDS[$nodeContent])) {
-				$currentAttributeOid = $nodeContent;
+				&& $nodeOid !== null && isset(self::CERTIFICATE_ATTRIBUTE_OIDS[$nodeOid])) {
+				$currentAttributeOid = $nodeOid;
 				continue;
 			}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -222,6 +222,7 @@ namespace OCA\Libresign;
  *     sign_date?: ?string,
  *     sign_request_uuid?: string,
  *     hash_algorithm?: string,
+ *     covers_entire_document?: bool,
  *     me: bool,
  *     signingOrder?: non-negative-int,
  *     visibleElements: LibresignVisibleElement[],

--- a/lib/Service/File/CertificateSignersMergeService.php
+++ b/lib/Service/File/CertificateSignersMergeService.php
@@ -402,6 +402,10 @@ class CertificateSignersMergeService {
 		if (isset($endEntityCert['isLibreSignRootCA']) && !isset($signer->isLibreSignRootCA)) {
 			$signer->isLibreSignRootCA = $endEntityCert['isLibreSignRootCA'];
 		}
+
+		if (isset($endEntityCert['covers_entire_document']) && !isset($signer->covers_entire_document)) {
+			$signer->covers_entire_document = $endEntityCert['covers_entire_document'];
+		}
 	}
 
 	/**

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -397,6 +397,9 @@ class FileService {
 		}
 
 		if (!$this->file instanceof File) {
+			if ($this->certData) {
+				$this->signersLoader->loadSignersFromCertData($this->fileData, $this->certData, $this->options->getHost());
+			}
 			return;
 		}
 

--- a/lib/Service/Install/SignSetupService.php
+++ b/lib/Service/Install/SignSetupService.php
@@ -17,10 +17,10 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Exception\SignatureDataNotFoundException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateHelper;
 use OCA\Libresign\Vendor\LibreSign\WhatOSAmI\OperatingSystem;
-use OCA\Libresign\Vendor\phpseclib3\Crypt\PublicKeyLoader;
-use OCA\Libresign\Vendor\phpseclib3\Crypt\RSA;
-use OCA\Libresign\Vendor\phpseclib3\Crypt\RSA\PrivateKey;
-use OCA\Libresign\Vendor\phpseclib3\File\X509;
+use OCA\Libresign\Vendor\phpseclib4\Crypt\PublicKeyLoader;
+use OCA\Libresign\Vendor\phpseclib4\Crypt\RSA;
+use OCA\Libresign\Vendor\phpseclib4\Crypt\RSA\PrivateKey;
+use OCA\Libresign\Vendor\phpseclib4\File\X509;
 use OCP\App\IAppManager;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IAppData;
@@ -121,9 +121,7 @@ class SignSetupService {
 		if (!$this->x509 instanceof x509) {
 			if (file_exists(__DIR__ . '/../../../build/tools/certificates/local/libresign.crt')) {
 				$x509 = file_get_contents(__DIR__ . '/../../../build/tools/certificates/local/libresign.crt');
-				$this->x509 = new X509();
-				$this->x509->loadX509($x509);
-				$this->x509->setPrivateKey($this->getPrivateKey());
+				$this->x509 = X509::load($x509);
 			} else {
 				$this->getDevelopCert();
 			}
@@ -376,21 +374,29 @@ class SignSetupService {
 
 		// Check if certificate is signed by Nextcloud Root Authority
 		$rootCertificatePublicKey = $this->getRootCertificatePublicKey();
-		$this->x509 = new X509();
+		$this->x509 = X509::load($certificate);
 
 		$rootCerts = $this->splitCerts($rootCertificatePublicKey);
-		foreach ($rootCerts as $rootCert) {
-			$this->x509->loadCA($rootCert);
-		}
-		$this->x509->loadX509($certificate);
-		if (!$this->x509->validateSignature()) {
-			throw new InvalidSignatureException('Certificate is not valid.');
+		$previousCAs = X509::getCAs();
+		X509::clearCAStore();
+		try {
+			foreach ($rootCerts as $rootCert) {
+				X509::addCA($rootCert);
+			}
+			if (!$this->x509->validateSignature()) {
+				throw new InvalidSignatureException('Certificate is not valid.');
+			}
+		} finally {
+			X509::clearCAStore();
+			foreach ($previousCAs as $previousCA) {
+				X509::addCA($previousCA);
+			}
 		}
 
 		// Verify if certificate has proper CN. "core" CN is always trusted.
 		if ($this->x509->getDN(X509::DN_OPENSSL)['CN'] !== Application::APP_ID && $this->x509->getDN(X509::DN_OPENSSL)['CN'] !== 'core') {
 			throw new InvalidSignatureException(
-				sprintf('Certificate is not valid for required scope. (Requested: %s, current: CN=%s)', Application::APP_ID, $this->x509->getDN(true)['CN'])
+				sprintf('Certificate is not valid for required scope. (Requested: %s, current: CN=%s)', Application::APP_ID, $this->x509->getDN(X509::DN_OPENSSL)['CN'])
 			);
 		}
 
@@ -401,8 +407,11 @@ class SignSetupService {
 		$x509 = $this->getLibresignAppCertificate();
 
 		// Check if the signature of the files is valid
-		$rsa = $x509->getPublicKey()
-			->withPadding(RSA::SIGNATURE_PSS);
+		$publicKey = $x509->getPublicKey();
+		if (!$publicKey instanceof RSA) {
+			throw new InvalidSignatureException('Certificate public key is not RSA.');
+		}
+		$rsa = $publicKey->withPadding(RSA::SIGNATURE_PSS);
 
 		$signatureData = $this->getSignatureData();
 		$signature = base64_decode((string)$signatureData['signature']);
@@ -548,7 +557,7 @@ class SignSetupService {
 		return [
 			'hashes' => $hashes,
 			'signature' => base64_encode((string)$signature),
-			'certificate' => $this->getCertificate()->saveX509($this->getCertificate()->getCurrentCert()),
+			'certificate' => $this->getCertificate()->toString(),
 		];
 	}
 
@@ -597,9 +606,7 @@ class SignSetupService {
 		openssl_pkey_export($privateKey, $privateKeyCert);
 
 		$this->privateKey = RSA::loadPrivateKey($privateKeyCert);
-		$this->x509 = new X509();
-		$this->x509->loadX509($rootCertificate);
-		$this->x509->setPrivateKey($this->privateKey);
+		$this->x509 = X509::load($rootCertificate);
 
 		$rootCertPath = __DIR__ . '/../../../build/tools/certificates/local/';
 		if (!is_dir($rootCertPath)) {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -3000,6 +3000,9 @@
                             "hash_algorithm": {
                                 "type": "string"
                             },
+                            "covers_entire_document": {
+                                "type": "boolean"
+                            },
                             "me": {
                                 "type": "boolean"
                             },

--- a/openapi.json
+++ b/openapi.json
@@ -2373,6 +2373,9 @@
                             "hash_algorithm": {
                                 "type": "string"
                             },
+                            "covers_entire_document": {
+                                "type": "boolean"
+                            },
                             "me": {
                                 "type": "boolean"
                             },

--- a/src/components/validation/SignerDetails.vue
+++ b/src/components/validation/SignerDetails.vue
@@ -17,7 +17,7 @@
 					:size="44" />
 			</template>
 			<template #subname>
-				<template v-if="!signer.signed">
+				<template v-if="!isSigned(signer)">
 					<strong>{{ t('libresign', 'Status:') }}</strong>
 					<span>{{ t('libresign', 'Not signed yet') }}</span>
 				</template>
@@ -30,7 +30,7 @@
 				</template>
 			</template>
 			<template #extra-actions>
-				<NcButton v-if="signer.signed" variant="tertiary"
+				<NcButton v-if="isSigned(signer)" variant="tertiary"
 					:aria-label="toggleDetailsAriaLabel"
 					@click.stop="toggleOpen">
 					<template #icon>
@@ -96,6 +96,14 @@
 				</template>
 				<template #name>
 					{{ getSignatureValidationMessage(signer) }}
+				</template>
+			</NcListItem>
+			<NcListItem v-if="signer.covers_entire_document === false" class="extra-chain" compact>
+				<template #icon>
+					<NcIconSvgWrapper :path="mdiAlertCircle" class="icon-warning" />
+				</template>
+				<template #name>
+					{{ getSignatureCoverageMessage() }}
 				</template>
 			</NcListItem>
 			<NcListItem v-if="signer.certificate_validation" class="extra-chain" compact>
@@ -310,8 +318,10 @@ type SignerModel = {
 	valid_from?: string | number
 	valid_to?: string | number
 	signed?: string | null
+	status?: number
 	signature_validation?: ValidationState
 	certificate_validation?: ValidationState
+	covers_entire_document?: boolean
 	crl_validation?: string
 	crl_revoked_at?: string
 	docmdp?: SignerDocMdp
@@ -366,10 +376,14 @@ const crlStatusMap: Record<string, CrlStatusMeta> = {
 }
 
 function toggleOpen() {
-	if (!props.signer?.signed) {
+	if (!isSigned(props.signer)) {
 		return
 	}
 	isOpen.value = !isOpen.value
+}
+
+function isSigned(signer: SignerModel): boolean {
+	return !!signer.signed || signer.status === 2
 }
 
 function getName(signer: SignerModel) {
@@ -428,6 +442,7 @@ function getValidityStatus(signer: SignerModel) {
 
 function hasValidationStatus(signer: SignerModel) {
 	return !!(signer.signature_validation || signer.certificate_validation || signer.crl_validation
+		|| signer.covers_entire_document === false
 		|| (signer.valid_from && signer.valid_to && signer.signed))
 }
 
@@ -438,6 +453,11 @@ function getSignatureValidationMessage(signer: SignerModel) {
 	}
 	// TRANSLATORS Fallback validation message when signature integrity check fails and backend does not provide custom detail.
 	return signer.signature_validation?.message || t('libresign', 'Document integrity check failed')
+}
+
+function getSignatureCoverageMessage() {
+	// TRANSLATORS Warning shown when extra bytes exist outside the PDF signature ByteRange.
+	return t('libresign', 'The signature does not cover the entire document')
 }
 
 function getCertificateTrustMessage(signer: SignerModel) {
@@ -560,6 +580,7 @@ defineExpose({
 	crlStatusMap,
 	toggleDetailsAriaLabel,
 	toggleOpen,
+	isSigned,
 	getName,
 	hasValidationIssues,
 	isRevokedStatus,
@@ -568,6 +589,7 @@ defineExpose({
 	getValidityStatus,
 	hasValidationStatus,
 	getSignatureValidationMessage,
+	getSignatureCoverageMessage,
 	getCertificateTrustMessage,
 	getValidityStatusAtSigning,
 	getCrlValidationIconPath,

--- a/src/services/validationDocument.ts
+++ b/src/services/validationDocument.ts
@@ -201,6 +201,47 @@ function isSignerDetailRecord(value: unknown): value is SignerDetailRecord {
 		&& isOptionalField(value, 'isLibreSignRootCA', fieldValue => typeof fieldValue === 'boolean')
 }
 
+function isCertificateSignerRecord(value: unknown): value is UnknownRecord {
+	if (!isRecord(value)) {
+		return false
+	}
+
+	return isString(value.displayName)
+		&& isSignerStatus(value.status)
+		&& isString(value.statusText)
+		&& isOptionalField(value, 'signed', isNullableString)
+		&& Array.isArray(value.chain)
+		&& isOptionalField(value, 'signature_validation', isValidationStatusInfo)
+		&& isOptionalField(value, 'certificate_validation', isValidationStatusInfo)
+}
+
+function normalizeCertificateSigner(value: UnknownRecord): SignerDetailRecord {
+	return {
+		...value,
+		signRequestId: 0,
+		displayName: value.displayName as string,
+		signed: isNullableString(value.signed) ? value.signed : null,
+		status: value.status as SignerDetailRecord['status'],
+		statusText: value.statusText as string,
+		description: null,
+		request_sign_date: '',
+		me: false,
+		visibleElements: [],
+	}
+}
+
+function normalizeSignerDetail(value: unknown): SignerDetailRecord | null {
+	if (isSignerDetailRecord(value)) {
+		return value
+	}
+
+	if (isCertificateSignerRecord(value)) {
+		return normalizeCertificateSigner(value)
+	}
+
+	return null
+}
+
 function isValidatedChildFileRecord(value: unknown): value is ValidatedChildFileRecord {
 	if (!isRecord(value)) {
 		return false
@@ -248,7 +289,7 @@ function isValidationDocumentRecord(data: unknown): data is ValidationFileRecord
 		return false
 	}
 
-	if (hasOwn(data, 'signers') && (!Array.isArray(data.signers) || !data.signers.every(isSignerDetailRecord))) {
+	if (hasOwn(data, 'signers') && (!Array.isArray(data.signers) || !data.signers.every(signer => normalizeSignerDetail(signer) !== null))) {
 		return false
 	}
 
@@ -358,20 +399,7 @@ export function toValidationDocument(data: unknown): ValidationDocumentState | n
 		? data.settings
 		: DEFAULT_VALIDATION_SETTINGS
 
-	const signers = (Array.isArray(data.signers) ? data.signers : []).map((signer) => {
-		const signRequestId = toInteger(signer.signRequestId)
-		const status = toInteger(signer.status)
-
-		if (signRequestId === null || status === null || !isSignerStatus(status)) {
-			return null
-		}
-
-		return {
-			...signer,
-			signRequestId,
-			status,
-		}
-	})
+	const signers = (Array.isArray(data.signers) ? data.signers : []).map(normalizeSignerDetail)
 
 	if (signers.some(signer => signer === null)) {
 		return null

--- a/src/tests/components/validation/SignerDetails.spec.ts
+++ b/src/tests/components/validation/SignerDetails.spec.ts
@@ -518,6 +518,14 @@ describe('SignerDetails.vue - Business Logic', () => {
 			wrapper.vm.toggleOpen()
 			expect(wrapper.vm.isOpen).toBe(false)
 		})
+
+		it('toggles when a certificate signer has signed status without a timestamp', () => {
+			wrapper = createWrapper({ signer: { signed: null, status: 2 } })
+
+			wrapper.vm.toggleOpen()
+
+			expect(wrapper.vm.isOpen).toBe(true)
+		})
 	})
 
 	describe('getSignatureValidationMessage method', () => {
@@ -536,6 +544,12 @@ describe('SignerDetails.vue - Business Logic', () => {
 		it('returns default message when no message provided', () => {
 			const signer = { signature_validation: { id: 2 } }
 			expect(wrapper.vm.getSignatureValidationMessage(signer)).toBe('Document integrity check failed')
+		})
+	})
+
+	describe('getSignatureCoverageMessage method', () => {
+		it('reports bytes outside the signed ByteRange', () => {
+			expect(wrapper.vm.getSignatureCoverageMessage()).toBe('The signature does not cover the entire document')
 		})
 	})
 

--- a/src/tests/services/validationDocument.spec.ts
+++ b/src/tests/services/validationDocument.spec.ts
@@ -143,6 +143,48 @@ describe('validationDocument', () => {
 		expect(normalized?.files[0]).not.toHaveProperty('file')
 	})
 
+	it('accepts certificate signers from an external signed PDF', () => {
+		const payload = createValidationPayload({
+			id: 0,
+			uuid: '',
+			status: FILE_STATUS.NOT_LIBRESIGN_FILE,
+			statusText: '',
+			nodeId: 0,
+			metadata: [],
+			files: [{
+				id: 0,
+				uuid: '',
+				name: 'external-signed.pdf',
+				status: FILE_STATUS.NOT_LIBRESIGN_FILE,
+				statusText: '',
+				nodeId: 0,
+				totalPages: 0,
+				size: 1163,
+				pdfVersion: '',
+				signers: [],
+				metadata: [],
+			}],
+			totalPages: 0,
+			size: 1163,
+			pdfVersion: '',
+			created_at: '',
+			requested_by: { userId: '', displayName: '' },
+			signers: [{
+				displayName: 'External signer',
+				status: SIGN_REQUEST_STATUS.SIGNED,
+				statusText: 'Signed',
+				signature_validation: { id: 1, label: 'Signature is valid.' },
+				certificate_validation: { id: 3, label: 'Certificate issuer is unknown.' },
+				chain: [{ subject: { CN: 'External signer' } }],
+			}],
+		})
+
+		const normalized = toValidationDocument(payload)
+
+		expect(normalized).not.toBeNull()
+		expect(normalized?.signers[0]?.displayName).toBe('External signer')
+	})
+
 	it('rejects payload with string values in numeric contract fields', () => {
 		const normalized = toValidationDocument(createValidationPayload({
 			id: '100',

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -1996,6 +1996,7 @@ export type components = {
             sign_date?: string | null;
             sign_request_uuid?: string;
             hash_algorithm?: string;
+            covers_entire_document?: boolean;
             me: boolean;
             /** Format: int64 */
             signingOrder?: number;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1554,6 +1554,7 @@ export type components = {
             sign_date?: string | null;
             sign_request_uuid?: string;
             hash_algorithm?: string;
+            covers_entire_document?: boolean;
             me: boolean;
             /** Format: int64 */
             signingOrder?: number;

--- a/tests/integration/features/file/validate.feature
+++ b/tests/integration/features/file/validate.feature
@@ -50,7 +50,7 @@ Feature: validate
       | (jq).ocs.data.signers[0].subject.ST           | State of Company                                                                         |
       | (jq).ocs.data.signers[0].subject.L            | City Name                                                                                |
       | (jq).ocs.data.signers[0].subject.O            | Organization                                                                             |
-      | (jq).ocs.data.signers[0].signature_validation | {"id":1,"label":"Signature is valid."}                                                   |
+      | (jq).ocs.data.signers[0].signature_validation | {"id":1,"label":"Signature is valid.","isValid":true}                                    |
       | (jq).ocs.data.signers[0].signatureTypeSN      | RSA-SHA256                                                                               |
       | (jq)(.ocs.data.signers[0].valid_from \| test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}$")) | true   |
       | (jq)(.ocs.data.signers[0].valid_to \| test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{2}:[0-9]{2}$"))   | true   |

--- a/tests/integration/features/sign/tsa.feature
+++ b/tests/integration/features/sign/tsa.feature
@@ -42,7 +42,7 @@ Feature: TSA Integration - End-to-End Workflow
     Then the response should have a status code 200
     And the response should be a JSON array with the following mandatory values
       | key                                           | value                                  |
-      | (jq).ocs.data.signers[0].signature_validation | {"id":1,"label":"Signature is valid."} |
+      | (jq).ocs.data.signers[0].signature_validation | {"id":1,"label":"Signature is valid.","isValid":true} |
     And the response should be a JSON array with the following mandatory values
       | key                                       | value     |
       | (jq).ocs.data.signers[0].timestamp.policy | 1.2.3.4.1 |

--- a/tests/php/Unit/Command/Developer/SignSetupTest.php
+++ b/tests/php/Unit/Command/Developer/SignSetupTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Command\Developer;
+
+use OCA\Libresign\Command\Developer\SignSetup;
+use OCA\Libresign\Service\Install\InstallService;
+use OCA\Libresign\Service\Install\SignSetupService;
+use OCA\Libresign\Tests\Unit\TestCase;
+use OCP\IConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SignSetupTest extends TestCase {
+	private SignSetupService&MockObject $signSetupService;
+	private InstallService&MockObject $installService;
+	private SignSetup $command;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->signSetupService = $this->createMock(SignSetupService::class);
+		$this->installService = $this->createMock(InstallService::class);
+		$this->command = new SignSetup(
+			$this->createMock(IConfig::class),
+			$this->signSetupService,
+			$this->installService,
+		);
+	}
+
+	#[DataProvider('malformedCertificateProvider')]
+	public function testRejectsMalformedCertificate(string $certificate): void {
+		$fixture = file_get_contents(__DIR__ . '/../../Handler/mock/cert.json');
+		$this->assertIsString($fixture);
+		$privateKey = json_decode($fixture, true, flags: JSON_THROW_ON_ERROR)['private_key'];
+		$this->assertIsString($privateKey);
+
+		$privateKeyPath = tempnam(sys_get_temp_dir(), 'libresign-private-key-');
+		$certificatePath = tempnam(sys_get_temp_dir(), 'libresign-certificate-');
+		$this->assertIsString($privateKeyPath);
+		$this->assertIsString($certificatePath);
+
+		file_put_contents($privateKeyPath, $privateKey);
+		file_put_contents($certificatePath, $certificate);
+
+		$this->signSetupService->expects($this->never())
+			->method('setCertificate');
+		$this->signSetupService->expects($this->never())
+			->method('setPrivateKey');
+		$this->installService->expects($this->never())
+			->method('getAvailableResources');
+
+		try {
+			$output = new BufferedOutput();
+			$status = $this->command->run(new ArrayInput([
+				'--privateKey' => $privateKeyPath,
+				'--certificate' => $certificatePath,
+			]), $output);
+
+			$this->assertSame(Command::FAILURE, $status);
+			$this->assertStringContainsString('Invalid certificate', $output->fetch());
+		} finally {
+			unlink($privateKeyPath);
+			unlink($certificatePath);
+		}
+	}
+
+	public static function malformedCertificateProvider(): array {
+		return [
+			'invalid PEM base64' => ['not a certificate'],
+			'truncated DER' => ["\x30\x82"],
+		];
+	}
+}

--- a/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/Pkcs12HandlerTest.php
@@ -44,6 +44,8 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private CrlService&MockObject $crlService;
 	private PdfSignatureValidationService&MockObject $pdfSignatureValidationService;
 	private PdfSignatureExtractor $pdfSignatureExtractor;
+	private array $nativeValidation = [];
+	private int $nativeValidationCalls = 0;
 
 	#[\Override]
 	public function setUp(): void {
@@ -74,7 +76,11 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->docMdpHandler = $this->createMock(DocMdpHandler::class);
 		$this->crlService = $this->createMock(CrlService::class);
 		$this->pdfSignatureValidationService = $this->createMock(PdfSignatureValidationService::class);
-		$this->pdfSignatureValidationService->method('validateFromResource')->willReturn([]);
+		$this->pdfSignatureValidationService->method('validateFromResource')
+			->willReturnCallback(function (): array {
+				$this->nativeValidationCalls++;
+				return $this->nativeValidation;
+			});
 		$this->pdfSignatureExtractor = new PdfSignatureExtractor();
 	}
 
@@ -447,13 +453,12 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetCertificateChainProvidesNativePackageShape(): void {
-		$this->pdfSignatureValidationService->method('validateFromResource')
-			->willReturn([
-				[
-					'signatureValidation' => ['id' => 1, 'label' => 'Signature is valid.'],
-					'certificateValidation' => ['id' => 3, 'label' => 'Certificate issuer is unknown.'],
-				],
-			]);
+		$this->nativeValidation = [
+			[
+				'signatureValidation' => ['id' => 1, 'label' => 'Signature is valid.'],
+				'certificateValidation' => ['id' => 3, 'label' => 'Certificate issuer is unknown.'],
+			],
+		];
 
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
@@ -492,9 +497,6 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	public function testGetCertificateChainUsesNativeValidationServiceForEachSignature(): void {
-		$this->pdfSignatureValidationService->expects($this->once())
-			->method('validateFromResource');
-
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
 		$this->assertIsResource($resource);
@@ -502,22 +504,22 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$result = $handler->getCertificateChain($resource);
 		fclose($resource);
 
+		$this->assertSame(1, $this->nativeValidationCalls);
 		$this->assertNotEmpty($result);
 		$this->assertSame(1, $result[0]['chain'][0]['signature_validation']['id']);
 		$this->assertSame(3, $result[0]['chain'][0]['certificate_validation']['id']);
 	}
 
-	public function testGetCertificateChainDoesNotOverrideLegacySignatureValidationOnDigestMismatch(): void {
-		$this->pdfSignatureValidationService->method('validateFromResource')
-			->willReturn([
-				[
-					'signatureValidation' => [
-						'id' => 3,
-						'label' => 'Digest mismatch.',
-						'reason' => 'PDF content hash does not match signed digest',
-					],
+	public function testGetCertificateChainUsesNativeDigestMismatchValidation(): void {
+		$this->nativeValidation = [
+			[
+				'signatureValidation' => [
+					'id' => 3,
+					'label' => 'Digest mismatch.',
+					'reason' => 'PDF content hash does not match signed digest',
 				],
-			]);
+			],
+		];
 
 		$handler = $this->getHandler();
 		$resource = fopen(__DIR__ . '/../../../fixtures/pdfs/small_valid-signed.pdf', 'r');
@@ -527,8 +529,8 @@ final class Pkcs12HandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		fclose($resource);
 
 		$this->assertNotEmpty($result);
-		$this->assertSame(1, $result[0]['chain'][0]['signature_validation']['id']);
-		$this->assertSame('Signature is valid.', $result[0]['chain'][0]['signature_validation']['label']);
+		$this->assertSame(3, $result[0]['chain'][0]['signature_validation']['id']);
+		$this->assertSame('Digest mismatch.', $result[0]['chain'][0]['signature_validation']['label']);
 	}
 
 	public function testGetCertificateChainPropagatesUnexpectedNativeMetadataExtractionFailureAndResetsPolicyValidationContext(): void {

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -84,16 +84,18 @@ class TSATest extends TestCase {
 			'genTime' => '2026-09-03 20:00:00',
 		], $this->getTstInfoMap());
 
-		$result = $this->tsa->extract([
-			[
-				'type' => ASN1::TYPE_OBJECT_IDENTIFIER,
-				'content' => 'tstInfo',
-			],
-			[
-				'type' => ASN1::TYPE_OCTET_STRING,
-				'content' => $tstInfo,
+		$timestampToken = ASN1::encodeDER([
+			'contentType' => 'id-ct-TSTInfo',
+			'content' => $tstInfo,
+		], [
+			'type' => ASN1::TYPE_SEQUENCE,
+			'children' => [
+				'contentType' => ['type' => ASN1::TYPE_OBJECT_IDENTIFIER],
+				'content' => ['type' => ASN1::TYPE_OCTET_STRING],
 			],
 		]);
+
+		$result = $this->tsa->extract([ASN1::decodeBER($timestampToken)]);
 
 		$this->assertSame('1.2.3.4.1', $result['policy']);
 	}

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -95,9 +95,10 @@ class TSATest extends TestCase {
 			],
 		]);
 
-		$result = $this->tsa->extract([ASN1::decodeBER($timestampToken)]);
+		$result = $this->tsa->extract(ASN1::decodeBER($timestampToken));
 
 		$this->assertSame('1.2.3.4.1', $result['policy']);
+		$this->assertSame('1', $result['serialNumber']);
 	}
 
 	public function testExtractWithMalformedData(): void {
@@ -122,6 +123,7 @@ class TSATest extends TestCase {
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('displayName', $result);
 		$this->assertIsString($result['displayName']);
+		$this->assertSame('Test CA', $result['cnHints']['commonName']);
 	}
 
 	private function createMockTstInfo(): array {
@@ -178,7 +180,7 @@ class TSATest extends TestCase {
 				'content' => [
 					[
 						'type' => ASN1::TYPE_OBJECT_IDENTIFIER,
-						'content' => '2.5.4.3' // commonName OID
+						'content' => 'id-at-commonName',
 					],
 					[
 						'type' => ASN1::TYPE_UTF8_STRING,
@@ -239,5 +241,7 @@ class TSATest extends TestCase {
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('cnHints', $result);
 		$this->assertIsArray($result['cnHints']);
+		$this->assertSame('US', $result['cnHints']['countryName']);
+		$this->assertSame('Test Organization', $result['cnHints']['organizationName']);
 	}
 }

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Libresign\Tests\Unit\Handler\SignEngine;
 
 use OCA\Libresign\Handler\SignEngine\TSA;
-use OCA\Libresign\Vendor\phpseclib3\File\ASN1;
+use OCA\Libresign\Vendor\phpseclib4\File\ASN1;
 use PHPUnit\Framework\TestCase;
 
 class TSATest extends TestCase {
@@ -22,8 +22,8 @@ class TSATest extends TestCase {
 	public function testConstructorLoadsOIDs(): void {
 		$tsa = new TSA();
 
-		$this->assertEquals('2.16.840.1.101.3.4.2.1', ASN1::getOID('id-sha256'));
-		$this->assertEquals('1.3.14.3.2.26', ASN1::getOID('id-sha1'));
+		$this->assertEquals('2.16.840.1.101.3.4.2.1', ASN1::getOIDFromName('id-sha256'));
+		$this->assertEquals('1.3.14.3.2.26', ASN1::getOIDFromName('id-sha1'));
 	}
 
 	public function testExtractWithEmptyArray(): void {

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -71,6 +71,33 @@ class TSATest extends TestCase {
 		$this->assertArrayHasKey('displayName', $result);
 	}
 
+	public function testExtractNormalizesNamedTsaPolicyToNumericOid(): void {
+		ASN1::loadOIDs(['testTsaPolicy' => '1.2.3.4.1']);
+		$tstInfo = ASN1::encodeDER([
+			'version' => 1,
+			'policy' => '1.2.3.4.1',
+			'messageImprint' => [
+				'hashAlgorithm' => ['algorithm' => 'id-sha256'],
+				'hashedMessage' => str_repeat("\x00", 32),
+			],
+			'serialNumber' => 1,
+			'genTime' => '2026-09-03 20:00:00',
+		], $this->getTstInfoMap());
+
+		$result = $this->tsa->extract([
+			[
+				'type' => ASN1::TYPE_OBJECT_IDENTIFIER,
+				'content' => '1.2.840.113549.1.9.16.1.4',
+			],
+			[
+				'type' => ASN1::TYPE_OCTET_STRING,
+				'content' => $tstInfo,
+			],
+		]);
+
+		$this->assertSame('1.2.3.4.1', $result['policy']);
+	}
+
 	public function testExtractWithMalformedData(): void {
 		$malformedData = [
 			[
@@ -115,6 +142,30 @@ class TSATest extends TestCase {
 					]
 				]
 			]
+		];
+	}
+
+	private function getTstInfoMap(): array {
+		return [
+			'type' => ASN1::TYPE_SEQUENCE,
+			'children' => [
+				'version' => ['type' => ASN1::TYPE_INTEGER],
+				'policy' => ['type' => ASN1::TYPE_OBJECT_IDENTIFIER],
+				'messageImprint' => [
+					'type' => ASN1::TYPE_SEQUENCE,
+					'children' => [
+						'hashAlgorithm' => [
+							'type' => ASN1::TYPE_SEQUENCE,
+							'children' => [
+								'algorithm' => ['type' => ASN1::TYPE_OBJECT_IDENTIFIER],
+							],
+						],
+						'hashedMessage' => ['type' => ASN1::TYPE_OCTET_STRING],
+					],
+				],
+				'serialNumber' => ['type' => ASN1::TYPE_INTEGER],
+				'genTime' => ['type' => ASN1::TYPE_GENERALIZED_TIME],
+			],
 		];
 	}
 

--- a/tests/php/Unit/Handler/SignEngine/TSATest.php
+++ b/tests/php/Unit/Handler/SignEngine/TSATest.php
@@ -87,7 +87,7 @@ class TSATest extends TestCase {
 		$result = $this->tsa->extract([
 			[
 				'type' => ASN1::TYPE_OBJECT_IDENTIFIER,
-				'content' => '1.2.840.113549.1.9.16.1.4',
+				'content' => 'tstInfo',
 			],
 			[
 				'type' => ASN1::TYPE_OCTET_STRING,

--- a/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
+++ b/tests/php/Unit/Service/File/CertificateSignersMergeServiceTest.php
@@ -162,6 +162,7 @@ final class CertificateSignersMergeServiceTest extends TestCase {
 			'uid' => 'email:signer@example.com',
 			'chain' => [[
 				'subject' => ['CN' => 'Signer User'],
+				'covers_entire_document' => false,
 				'validFrom_time_t' => 1769644731,
 				'validTo_time_t' => 1769731131,
 			]],
@@ -183,6 +184,7 @@ final class CertificateSignersMergeServiceTest extends TestCase {
 		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->valid_to);
 		$this->assertSame('2026-01-28T23:58:51+00:00', $signer->chain[0]['valid_from']);
 		$this->assertSame('2026-01-29T23:58:51+00:00', $signer->chain[0]['valid_to']);
+		$this->assertFalse($signer->covers_entire_document);
 	}
 
 	public function testMergeDoesNotExportTopLevelTsaWithTimestampData(): void {

--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -158,6 +158,38 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		self::assertArrayNotHasKey('file', $result['files'][0]);
 	}
 
+	public function testValidateExternalSignedPdfFromUploadLoadsCertificateSigners(): void {
+		$temporaryFile = tempnam(sys_get_temp_dir(), 'libresign-validation-');
+		self::assertNotFalse($temporaryFile);
+		file_put_contents($temporaryFile, file_get_contents(__DIR__ . '/../../fixtures/pdfs/small_valid-signed.pdf'));
+		$certData = [['chain' => [['subject' => ['CN' => 'External signer']]]]];
+
+		$this->mimeService->method('getMimeType')->willReturn('application/pdf');
+		$this->pkcs12Handler->method('getCertificateChain')->willReturn($certData);
+		$this->fileMapper->method('getBySignedHash')
+			->willThrowException(new DoesNotExistException('Not a LibreSign file'));
+		$this->signersLoader->expects($this->once())
+			->method('loadSignersFromCertData')
+			->with($this->isInstanceOf(\stdClass::class), $certData, '');
+
+		try {
+			$result = $this->createFileService()
+				->setFileFromRequest([
+					'tmp_name' => $temporaryFile,
+					'name' => 'external-signed.pdf',
+					'size' => filesize($temporaryFile),
+				])
+				->showSigners()
+				->toArray();
+		} finally {
+			if (file_exists($temporaryFile)) {
+				unlink($temporaryFile);
+			}
+		}
+
+		self::assertSame(FileStatus::NOT_LIBRESIGN_FILE->value, $result['status']);
+	}
+
 	public function testValidateFileContentSkipsNonPdfFiles(): void {
 		$service = $this->createFileService();
 


### PR DESCRIPTION
## 📝 Summary

- Update the scoped signature-validation dependencies to `3rdparty` main commit `cddfc39`, including phpseclib 4 and pdf-signature-validator v0.3.0.
- Validate uploaded external PDFs safely, including detected signers, cryptographic integrity, and incomplete ByteRange coverage.
- Migrate CRL generation, CMS timestamp parsing, and setup signing flows to phpseclib 4 APIs.

## 🧪 How to test

1. Upload an unsigned external PDF to document validation and confirm it is reported as external without a LibreSign file URL.
2. Upload a signed external PDF and confirm signer, integrity, certificate, and whole-document-coverage information are shown.
3. Generate a CRL with revoked certificates and verify its DER output with OpenSSL and the issuing CA.
4. Run the focused backend and frontend checks listed below.

## 🎨 UI / Front-end changes

- [x] Display external PDF signer integrity and warn when a signature does not cover the entire document.
- [x] Component and service unit tests added.
- [ ] Screenshots not added; the UI behavior is covered by component tests.

## ⚙️ API / Back-end changes

- [x] Handle external validation payloads without LibreSign database records.
- [x] Generate and sign CRLs with phpseclib 4's dedicated `CRL` API.
- [x] Regenerated OpenAPI specifications and TypeScript API types.
- [x] Backend unit tests added.

## ✅ Checklist

- [x] Ran `composer psalm`.
- [x] Ran `composer cs:check`.
- [x] Ran focused PHPUnit tests: 286 tests, 855 assertions.
- [x] Ran `npm run ts:check`.
- [x] Ran focused Vitest tests: 99 tests.
- [x] Ran Infection over changed PHP production files: 100% mutation coverage and 90% covered MSI.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI.