### PR TITLE
fix: encode native signature stamps as WinAnsi

### DIFF
--- a/lib/Service/SignatureStampPreview/SignatureStampAppearanceBuilder.php
+++ b/lib/Service/SignatureStampPreview/SignatureStampAppearanceBuilder.php
@@ -65,7 +65,7 @@ class SignatureStampAppearanceBuilder {
 				$nameY = $nameStartY;
 				$estimatedCharWidth = $nameFontSize * 0.52;
 				foreach ($nameLines as $nameLine) {
-					$lineWidth = strlen($nameLine) * $estimatedCharWidth;
+					$lineWidth = mb_strlen($nameLine) * $estimatedCharWidth;
 					$nameX = max($leftPadding, ($leftHalfW - $lineWidth) / 2.0);
 					$escaped = $this->escapePdfText($nameLine);
 					$stream .= "BT\n";
@@ -105,6 +105,7 @@ class SignatureStampAppearanceBuilder {
 						'Type' => '/Font',
 						'Subtype' => '/Type1',
 						'BaseFont' => '/Helvetica',
+						'Encoding' => '/WinAnsiEncoding',
 					],
 				],
 			],
@@ -122,7 +123,7 @@ class SignatureStampAppearanceBuilder {
 
 		$estimatedCharWidth = max(1.0, $fontSize * 0.52);
 		$maxChars = max(1, (int)floor($availableWidth / $estimatedCharWidth));
-		if (strlen($trimmed) <= $maxChars) {
+		if (mb_strlen($trimmed) <= $maxChars) {
 			return [$trimmed];
 		}
 
@@ -134,7 +135,7 @@ class SignatureStampAppearanceBuilder {
 			}
 
 			$candidate = $current === '' ? $word : $current . ' ' . $word;
-			if (strlen($candidate) <= $maxChars) {
+			if (mb_strlen($candidate) <= $maxChars) {
 				$current = $candidate;
 				continue;
 			}
@@ -144,9 +145,9 @@ class SignatureStampAppearanceBuilder {
 				$current = '';
 			}
 
-			while (strlen($word) > $maxChars) {
-				$result[] = substr($word, 0, $maxChars);
-				$word = substr($word, $maxChars);
+			while (mb_strlen($word) > $maxChars) {
+				$result[] = mb_substr($word, 0, $maxChars);
+				$word = mb_substr($word, $maxChars);
 			}
 
 			$current = $word;
@@ -160,10 +161,17 @@ class SignatureStampAppearanceBuilder {
 	}
 
 	public function escapePdfText(string $value): string {
-		$value = str_replace('\\', '\\\\', $value);
-		$value = str_replace('(', '\\(', $value);
-		$value = str_replace(')', '\\)', $value);
+		$encoded = mb_convert_encoding($value, 'Windows-1252', 'UTF-8');
+		if (mb_convert_encoding($encoded, 'UTF-8', 'Windows-1252') !== $value) {
+			throw new \InvalidArgumentException(
+				'signature stamp contains characters that cannot be represented by WinAnsiEncoding',
+			);
+		}
 
-		return $value;
+		$encoded = str_replace('\\', '\\\\', $encoded);
+		$encoded = str_replace('(', '\\(', $encoded);
+		$encoded = str_replace(')', '\\)', $encoded);
+
+		return $encoded;
 	}
 }

--- a/tests/php/Unit/Service/SignatureStampPreview/SignatureStampAppearanceBuilderTest.php
+++ b/tests/php/Unit/Service/SignatureStampPreview/SignatureStampAppearanceBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service\SignatureStampPreview;
+
+use OCA\Libresign\Service\SignatureStampPreview\SignatureStampAppearanceBuilder;
+use OCA\Libresign\Service\SignatureTextService;
+use OCA\Libresign\Service\SignerElementsService;
+
+final class SignatureStampAppearanceBuilderTest extends \OCA\Libresign\Tests\Unit\TestCase {
+	public function testBuildXObjectEncodesTextAsWinAnsi(): void {
+		$signatureTextService = $this->createMock(SignatureTextService::class);
+		$signatureTextService->method('parse')->willReturn([
+			'parsed' => 'Signé par Renée',
+			'templateFontSize' => 10.0,
+		]);
+		$builder = new SignatureStampAppearanceBuilder($signatureTextService);
+
+		$xObject = $builder->buildXObject(
+			100,
+			50,
+			SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY,
+		);
+
+		$this->assertSame('/WinAnsiEncoding', $xObject->resources['Font']['F1']['Encoding']);
+		$this->assertStringContainsString("(Sign\xE9 par Ren\xE9e) Tj", $xObject->stream);
+		$this->assertStringNotContainsString('Signé par Renée', $xObject->stream);
+	}
+
+	public function testWrapTextForPdfDoesNotSplitMultibyteCharacters(): void {
+		$signatureTextService = $this->createMock(SignatureTextService::class);
+		$builder = new SignatureStampAppearanceBuilder($signatureTextService);
+
+		$this->assertSame(
+			['éé', 'éé'],
+			$builder->wrapTextForPdf('éééé', 15.0, 10.0),
+		);
+	}
+
+	public function testEscapePdfTextRejectsCharactersOutsideWinAnsi(): void {
+		$signatureTextService = $this->createMock(SignatureTextService::class);
+		$builder = new SignatureStampAppearanceBuilder($signatureTextService);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('signature stamp contains characters that cannot be represented by WinAnsiEncoding');
+
+		$builder->escapePdfText('Signed by 😀');
+	}
+}


### PR DESCRIPTION
Fixes #8155

## Summary

- I convert UTF-8 signature stamp text to Windows-1252 before writing PDF literal strings and declare `/WinAnsiEncoding` for Helvetica.
- I use multibyte-aware length and substring operations so wrapping and centering do not split UTF-8 characters.
- I reject characters outside WinAnsi explicitly instead of writing corrupted bytes into a signed document.
- I added focused regression tests for accented text, multibyte wrapping, and unsupported characters.

## How to test

1. Configure the `PhpNative` signature engine.
2. Set a signature text template containing accented characters, for example `Signé par Renée`.
3. Sign a document and confirm the visible stamp preserves the accents.
4. Try a character outside WinAnsi and confirm signing fails explicitly rather than producing mojibake.

## Validation

- Focused `SignatureStampAppearanceBuilderTest`: 3 tests, 6 assertions passed on PHP 8.4.24.
- PHP CS Fixer dry run passed for both changed files.
- PHP syntax checks and `git diff --check` passed.
- The full Nextcloud-backed PHPUnit matrix was deferred to CI because this local checkout does not include a Nextcloud server bootstrap.

## API / back-end changes

- [x] Native PDF stamp text now uses WinAnsi bytes with a matching font encoding.
- [x] Unit tests cover the changed behavior.
- [x] No API or OpenAPI changes.

## Checklist

- [x] I have read and followed the contribution guide.
- [x] The commit uses Conventional Commits and includes a DCO sign-off.
