### PR TITLE
chore(deps-dev): bump vite config and fix e2e regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@nextcloud/browserslist-config": "^3.1.2",
         "@nextcloud/eslint-config": "^9.0.1",
         "@nextcloud/stylelint-config": "^3.2.1",
-        "@nextcloud/vite-config": "^3.0.0-beta.0",
+        "@nextcloud/vite-config": "^3.0.0-beta.1",
         "@pinia/testing": "^2.0.1",
         "@playwright/test": "^1.62.1",
         "@testing-library/dom": "^10.4.1",
@@ -3472,29 +3472,39 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-3.0.0-beta.0.tgz",
-      "integrity": "sha512-MoDKn4ZQnpVZDLHbD65+n+l3p4ccl0WEyjBfkGqp/n8G19QDC/RXUpfsw5dBvObGW7djY0e8gao+Zd52ft/5Bw==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-3.0.0-beta.1.tgz",
+      "integrity": "sha512-v2NzeCk4UmTA3GaWu+yDM2VEQhu9G1fcAYyKG1q5yEvxrfDGlrkRxSxifORA6zFJzO0xzme6Gib4bTjAbdzrVg==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "browserslist-to-esbuild": "^2.1.1",
-        "magic-string": "^0.30.21",
-        "rolldown-plugin-dts": "^0.26.0",
+        "magic-string": "^1.2.0",
+        "rolldown-plugin-dts": "^0.28.2",
         "rollup-plugin-corejs": "^1.0.2",
         "rollup-plugin-node-externals": "^9.0.1",
-        "spdx-expression-parse": "^4.0.0",
-        "vite-plugin-css-injected-by-js": "^5.0.1",
+        "spdx-expression-parse": "^5.0.0",
+        "vite-plugin-css-injected-by-js": "^5.0.2",
         "vite-plugin-node-polyfills": "^0.28.0"
       },
       "engines": {
-        "node": "^22.12 || ^24 || >=26.0.0"
+        "node": "^22.18 || ^24 || >=26.0.0"
       },
       "peerDependencies": {
         "@vitejs/plugin-vue": "^2.0 || >=6.0",
         "browserslist": ">=4.20",
         "sass": ">=1.80",
-        "vite": ">=8.1"
+        "vite": ">=8.2"
+      }
+    },
+    "node_modules/@nextcloud/vite-config/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@nextcloud/vue": {
@@ -4943,13 +4953,6 @@
         "@types/sizzle": "*"
       }
     },
-    "node_modules/@types/jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5991,6 +5994,385 @@
       "peerDependencies": {
         "vue": "^3.5.0"
       }
+    },
+    "node_modules/@yuku-codegen/binding-android-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-android-arm64/-/binding-android-arm64-0.9.3.tgz",
+      "integrity": "sha512-viote6xAyL5cKLquV2X2wRfopSckH+msDYbaI8Hh8JAaogYs8MJZVRUbSrbsY29TaPrIFZwNRwQ8+YSxs0dkGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-darwin-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.9.3.tgz",
+      "integrity": "sha512-y2PGOLyxc724EJ+Et/5PxGfutQuV1Z2J9cxHo6W1I5CR3nk0i03J4yPrnw6rNJOfrtlISzcc7q0RrSyfPndpIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-darwin-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-x64/-/binding-darwin-x64-0.9.3.tgz",
+      "integrity": "sha512-xZ9UpXUOLmsrKVUp7MRXxWU3drNiilRC42OLpjWEhnOehIGVF1bZgzHcqRYJxVyU53RMrkRMsaxplkGd6Qo/ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-freebsd-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-freebsd-x64/-/binding-freebsd-x64-0.9.3.tgz",
+      "integrity": "sha512-RGCYSZw3VonreVTpur9iOfnbMngR2/f7UOE7gwcDx5WoHjIhtmTK9EIq9qs78ARdMFAPzKp5OzHljl5QMaGJ7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-arm-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.9.3.tgz",
+      "integrity": "sha512-kjIJIw39GSPTF0hnq+jnM0tR+J5WlariAAWetxMtawNskITDT1ZigaK3YF5hMhDz2mAofaM1t+63qtx+7aXjeg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-arm-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-musl/-/binding-linux-arm-musl-0.9.3.tgz",
+      "integrity": "sha512-TVHeVdzaS4ub86URrQufiy4t01ZtdyKDZ5sTPqWFKAUbQJ7rQ0o5vIT+/jCeHQbP+Yf9p5peRdmPbcZewoDNiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-arm64-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.9.3.tgz",
+      "integrity": "sha512-9aQeeLh1qaCa2GcyzHnwLKGfFrsI+KOyhnh4+fICSq5kyhzCWQfXVCCK4RTEZPLcyuVwfN5Id0JEYavRN4oNTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-arm64-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.9.3.tgz",
+      "integrity": "sha512-TLXA5Hd1nr8VSP2MtxcFddsBIHj+DPpyG5eberEGMATndgG7STlKQmle51MV0MZ8UgsdYM6CybIVpzlCPQwP9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-x64-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.9.3.tgz",
+      "integrity": "sha512-tk0BFbF3Clb9k9biPH3qmr+Qwk24rRM26+HY91hYXmZlzlepZG0scQ6OffZFWtzwKE5JjlZpMdcWj1lTiHbEjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-linux-x64-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-musl/-/binding-linux-x64-musl-0.9.3.tgz",
+      "integrity": "sha512-xo+pXshsCXruEEkDMbwHqkeTyC4XHb6A6oXr6x2YK3jOMcS5kZz0e26BmTCr40J0nY/K3ysmwG9R1xHygtiuwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-win32-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-arm64/-/binding-win32-arm64-0.9.3.tgz",
+      "integrity": "sha512-70gAQo6HZzMgIJTjeMZOEO2XaRj4GcNGP/n81R9tXQv0x8d4ZHnZDv+ygeWfHo+xchAUPwpnrVZA4p6RhJa3GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@yuku-codegen/binding-win32-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-x64/-/binding-win32-x64-0.9.3.tgz",
+      "integrity": "sha512-7Hz3NGlq6qBBR8zMEk6GMZivofNjnYZpMXSoUwUgz9Ur2LaivuP23HQh0ern+T6HVkTJEvilw4VJrg1rX1Ugcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-android-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-android-arm64/-/binding-android-arm64-0.9.3.tgz",
+      "integrity": "sha512-z3tDGTaUXD5Q4IuebFOY/QHxhR/SqujMhkMv9C5bh25upyFEXdafp0MsXQIIheWhVZzn5VMOniyxFni/7s9LgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-darwin-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.9.3.tgz",
+      "integrity": "sha512-hzKvKSKS7z3ufnu1VkQYEoxmS6A5uNnkwukKnc2atxpWdq648nLVOqut4h1jUXjbM2WcoTfuZLF6AHAGFf8cmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-darwin-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-x64/-/binding-darwin-x64-0.9.3.tgz",
+      "integrity": "sha512-OM2PiVlPATvzlj/KGHNlu+t8FC3YzM5joVNjhsz/EaigQ8x2UUQ1Q0agQLiv5GZ2L8TSzrLUwBCZ7YOvP8q+tw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-freebsd-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.9.3.tgz",
+      "integrity": "sha512-WMn9M4LHNVysGNwsAJ9gpRPqQIW2lcPrDNGcyk0agx3IYqCJq1MQugh6Be8Otc5U08eGdE39o8Kx9YWJmXz7GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-arm-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.9.3.tgz",
+      "integrity": "sha512-vqKjwiyW1FWvbykYMEQIcAJwA17WxK3rxxqDuyCvQwcNVaLEUxI4BXiUdlF3kHucc7MnoFQhoRPkySgOzlLM+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-arm-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-musl/-/binding-linux-arm-musl-0.9.3.tgz",
+      "integrity": "sha512-qohilhYOT+zkt2gYzym4F1T6BzRdvPqS9/sFB03pmnVV8LrvjOXVsGwEBAa3CEvzJKhAZjdTmVz7zsVdjyHWLg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-arm64-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.9.3.tgz",
+      "integrity": "sha512-tvTIyUvTGkeee68i4JIo9o27As+Ug6LXOZvElGgFbTs6+KBdb5LGhvugaIQljdfIsm2XnIbOLG6OnQSXHMLB9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-arm64-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.9.3.tgz",
+      "integrity": "sha512-OWZBHW1wuChBpFlrF+On1yiBcFPMRrj2g0VKsM/PCBGffu1OM0ORkS+vLS3Snu6wYwndM5Dd9Ctvux6eUlrQjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-x64-gnu": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.9.3.tgz",
+      "integrity": "sha512-/tbk1h0dlADOCngbiQO9V3SHwBIJkoGBq8BDEraSw2CC3nGxPEPTCCYUDp5738Ij2FxVwy1FWVuhFkHvpMrPbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-linux-x64-musl": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.9.3.tgz",
+      "integrity": "sha512-u3+0sCso/mcjDvtc3866D2giV7l34PDyDVBkMesAWa3DWbIWPlybehi2SSnmScgArV22ctqSSgUzdBBVJ6zYAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-win32-arm64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-arm64/-/binding-win32-arm64-0.9.3.tgz",
+      "integrity": "sha512-xnGEvdhyjRkXozHtpXVpEEkyGZWAxJ3RoILv7XRV5SvTEztaTCk5GQyfcOzI9An/EJtcL4ERCI8QmS0TpDPJiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@yuku-parser/binding-win32-x64": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-x64/-/binding-win32-x64-0.9.3.tgz",
+      "integrity": "sha512-N5eShGcuwnrXEprePFmEjtng6acZmtnC4zgazK9xxkavcx1q1uX8Nz8lU5RS973EMlNr902cIc6Cd2D4tqZDBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@yuku-toolchain/types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@yuku-toolchain/types/-/types-0.9.3.tgz",
+      "integrity": "sha512-rFE+5P4g2wxko5C85MugJOlVjBHEQq87dIkhLkniLXLp63PEtgaFjD954i5HXlfnyzLxPcZHsSOVDVgmo1HToA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "5.0.0",
@@ -8109,17 +8491,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
-      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/eslint-plugin-perfectionist": {
       "version": "5.10.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.1.tgz",
@@ -8891,6 +9262,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.6.tgz",
+      "integrity": "sha512-X6fBC0pmImC70gvX2zm56go9hx0MyoGVdG0tUCkg/D+Xnh5TJsOZ7iDbOdI3PvmtrDxnu1YdDufpK2QJX1Meqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/git-hooks-list": {
@@ -10152,6 +10539,7 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -11850,9 +12238,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -13061,39 +13449,37 @@
       }
     },
     "node_modules/rolldown-plugin-dts": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.26.0.tgz",
-      "integrity": "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==",
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.28.4.tgz",
+      "integrity": "sha512-yNg16bsWNk1MQ0Pkf3bAPFoZRqSWtxhiTHxKKHCoTZIwwyWerA5pX1MOogb1mjjwusVN2/kd4pK08iQ8M8hFIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "ast-kit": "^3.0.0",
-        "birpc": "^4.0.0",
         "dts-resolver": "^3.0.0",
-        "get-tsconfig": "5.0.0-beta.5",
-        "obug": "^2.1.3"
+        "get-tsconfig": "5.0.0-beta.6",
+        "obug": "^2.1.4",
+        "yuku-ast": "^0.9.3",
+        "yuku-codegen": "^0.9.3",
+        "yuku-parser": "^0.9.3"
       },
       "engines": {
-        "node": "^22.18.0 || >=24.11.0"
+        "node": "^22.18.0 || ^24.11.0 || >=26.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       },
       "peerDependencies": {
-        "@ts-macro/tsc": "^0.3.6",
-        "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
-        "rolldown": "^1.0.0",
-        "typescript": "^5.0.0 || ^6.0.0",
+        "@typescript/native-preview": "*",
+        "@volar/typescript": "~2.4.0",
+        "rolldown": "^1.2.0",
+        "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0",
         "vue-tsc": "~3.2.0 || ~3.3.0"
       },
       "peerDependenciesMeta": {
-        "@ts-macro/tsc": {
+        "@typescript/native-preview": {
           "optional": true
         },
-        "@typescript/native-preview": {
+        "@volar/typescript": {
           "optional": true
         },
         "typescript": {
@@ -13102,128 +13488,6 @@
         "vue-tsc": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/generator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
-      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^8.0.0",
-        "@babel/types": "^8.0.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "@types/jsesc": "^2.5.0",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/ast-kit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
-      "integrity": "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^8.0.0",
-        "estree-walker": "^3.0.3",
-        "pathe": "^2.0.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/birpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
-      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/get-tsconfig": {
-      "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
-      "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20.20.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -13717,9 +13981,9 @@
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15222,9 +15486,9 @@
       }
     },
     "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-5.0.1.tgz",
-      "integrity": "sha512-JSB0jjN4VCKqG7XTUdrwiIl5gA+z2yi/tAl9WHo0X4sdyJ1yrmbLOEjf95TDoDIIuKr4GJIc7lMJG0CT88eEUQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-5.0.2.tgz",
+      "integrity": "sha512-Hvg48QfYsCL53ju9T5zTC0Ofg90XLa8t5zhhKmPYbayoMQieNcQDkkRX8pv4TAcKPZwVisLFiwDy5uBjOn+3Ow==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -15876,6 +16140,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yuku-ast": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/yuku-ast/-/yuku-ast-0.9.3.tgz",
+      "integrity": "sha512-Kt0PXlPCXdKF1fWFTl7N3DaxsVk6DHF8VAXHJMkwPtJnWYgbx20pYgGSweuC/86mIM7k1NUITQ4JffgOLUWTCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yuku-toolchain/types": "^0.9.3"
+      }
+    },
+    "node_modules/yuku-codegen": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/yuku-codegen/-/yuku-codegen-0.9.3.tgz",
+      "integrity": "sha512-7oTWwetHiMSyrVPFb8089lBBqkU1gaeQZyumNBJ0t5hocMQRaWhnMeSXTz7J1xm/rcw9+ePsajORdZbub2C35w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yuku-toolchain/types": "^0.9.3"
+      },
+      "optionalDependencies": {
+        "@yuku-codegen/binding-android-arm64": "0.9.3",
+        "@yuku-codegen/binding-darwin-arm64": "0.9.3",
+        "@yuku-codegen/binding-darwin-x64": "0.9.3",
+        "@yuku-codegen/binding-freebsd-x64": "0.9.3",
+        "@yuku-codegen/binding-linux-arm-gnu": "0.9.3",
+        "@yuku-codegen/binding-linux-arm-musl": "0.9.3",
+        "@yuku-codegen/binding-linux-arm64-gnu": "0.9.3",
+        "@yuku-codegen/binding-linux-arm64-musl": "0.9.3",
+        "@yuku-codegen/binding-linux-x64-gnu": "0.9.3",
+        "@yuku-codegen/binding-linux-x64-musl": "0.9.3",
+        "@yuku-codegen/binding-win32-arm64": "0.9.3",
+        "@yuku-codegen/binding-win32-x64": "0.9.3"
+      }
+    },
+    "node_modules/yuku-parser": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/yuku-parser/-/yuku-parser-0.9.3.tgz",
+      "integrity": "sha512-96wPoHnwaXfkZv7UIOUkDb+s7ZH8lv8Qtg+MxdvHUV1LFa5jV9iKOaams1942YQt+krFQrWiD6lSg2ermv5kHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yuku-toolchain/types": "^0.9.3",
+        "yuku-ast": "^0.9.3"
+      },
+      "optionalDependencies": {
+        "@yuku-parser/binding-android-arm64": "0.9.3",
+        "@yuku-parser/binding-darwin-arm64": "0.9.3",
+        "@yuku-parser/binding-darwin-x64": "0.9.3",
+        "@yuku-parser/binding-freebsd-x64": "0.9.3",
+        "@yuku-parser/binding-linux-arm-gnu": "0.9.3",
+        "@yuku-parser/binding-linux-arm-musl": "0.9.3",
+        "@yuku-parser/binding-linux-arm64-gnu": "0.9.3",
+        "@yuku-parser/binding-linux-arm64-musl": "0.9.3",
+        "@yuku-parser/binding-linux-x64-gnu": "0.9.3",
+        "@yuku-parser/binding-linux-x64-musl": "0.9.3",
+        "@yuku-parser/binding-win32-arm64": "0.9.3",
+        "@yuku-parser/binding-win32-x64": "0.9.3"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@nextcloud/browserslist-config": "^3.1.2",
     "@nextcloud/eslint-config": "^9.0.1",
     "@nextcloud/stylelint-config": "^3.2.1",
-    "@nextcloud/vite-config": "^3.0.0-beta.0",
+    "@nextcloud/vite-config": "^3.0.0-beta.1",
     "@pinia/testing": "^2.0.1",
     "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.1",

--- a/playwright/e2e/visible-element-persistence.spec.ts
+++ b/playwright/e2e/visible-element-persistence.spec.ts
@@ -130,9 +130,13 @@ test('visible signature element persists and can be deleted', async ({ page }) =
 
 	// Save the now-empty element list
 	await page.getByLabel('Signature positions').getByRole('button', { name: 'Save' }).click()
+	await expect(page.getByLabel('Signature positions')).toBeHidden()
 
-	// Navigate away and back to force a fresh load from the server
-	await page.getByRole('link', { name: 'Request' }).click()
+	// Navigate away and back to force a fresh load from the server. Use direct
+	// navigation instead of the side-navigation link because the Nextcloud header
+	// can overlap the first navigation item in CI and intercept pointer events.
+	await page.goto('./apps/libresign/f/request')
+	await expect(page).toHaveURL(/\/apps\/libresign\/f\/request/)
 
 	// Re-open the document one last time and confirm the element is gone
 	await reopenFileFromUuid(requestUuid)

--- a/src/views/Settings/PolicyWorkbench/settings/signature-footer/SignatureFooterRuleEditor.vue
+++ b/src/views/Settings/PolicyWorkbench/settings/signature-footer/SignatureFooterRuleEditor.vue
@@ -477,9 +477,13 @@ function resetPreviewSize() {
 
 	&__preview-frame {
 		width: 100%;
+		overflow-x: auto;
+		overflow-y: hidden;
+		touch-action: pan-x pan-y;
 		border: 1px solid var(--color-border);
 		border-radius: var(--border-radius-element, 8px);
 		background: #f7fafc;
+		-webkit-overflow-scrolling: touch;
 	}
 }
 </style>


### PR DESCRIPTION
Refs #8048

## 📝 Summary

Bumps `@nextcloud/vite-config` from `3.0.0-beta.0` to `3.0.0-beta.1` and fixes the Playwright regressions exposed by the new app chunking behavior.

The Dependabot PR currently cannot be updated reliably with an extra fix commit, so this PR carries the same dependency update plus the focused fixes needed for CI.

## 🧪 How to test

- `npx eslint playwright/e2e/visible-element-persistence.spec.ts playwright/e2e/mobile-pdf-horizontal-scroll.spec.ts src/views/Settings/PolicyWorkbench/settings/signature-footer/SignatureFooterRuleEditor.vue`
- `npx stylelint src/views/Settings/PolicyWorkbench/settings/signature-footer/SignatureFooterRuleEditor.vue`
- `TESTING=true npm run build --if-present`
- `PLAYWRIGHT_BASE_URL=https://nginx PLAYWRIGHT_FAST_FAIL=1 npx playwright test playwright/e2e/visible-element-persistence.spec.ts playwright/e2e/mobile-pdf-horizontal-scroll.spec.ts --project=chromium --reporter=list`

## 🎨 UI / Front‑end changes

- [x] Updated footer preview CSS so the PDF preview remains horizontally scrollable on mobile and explicitly allows pan gestures.
- [x] Stabilized the visible signature persistence E2E flow by navigating directly instead of clicking a side-navigation item that can be overlapped by the Nextcloud header.
- [x] Components, Unit (with vitest) and/or e2e (with Playwright) tests added - *Required*
- [ ] Screenshots before/after (not applicable; no intentional visual change)
- [ ] Tested in multiple browsers (Chrome, Firefox, Safari) – *optional but appreciated*
- [ ] Accessibility verified (contrast, keyboard navigation, screen reader friendly) – *if applicable*
- [ ] Design review approved – *optional, link to feedback if available*
- [ ] Documentation updated (if applicable) – [docs repository](https://github.com/LibreSign/documentation/)

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Focused Playwright checks pass locally for the failing specs.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
