### PR TITLE
[stable34] ci(psalm): move composer install back into the install dependencies step

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
+          composer i
 
       - name: Check for vulnerable PHP dependencies
         run: composer require --dev roave/security-advisories:dev-latest
-        composer i
 
       - name: Install nextcloud/ocp
         run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies


### PR DESCRIPTION
Resolves: #8246

## 📝 Summary

The workflow template sync in #8075 moved `composer i` out of the `run: |` block of the "Install dependencies" step of `.github/workflows/psalm.yml` and left it after the single-line `run:` of "Check for vulnerable PHP dependencies", at key level. The file stopped being valid YAML, so every `Static analysis` run on `stable34` ends with "This run likely failed because of a workflow file issue" and zero jobs, and pull requests against `stable34` no longer get the `static-psalm-analysis` check.

This PR puts the line back in the block it belonged to. One-line move, nothing else changes.

## 🧪 How to test

1. The `static-psalm-analysis` check runs again on this PR. It is missing on every PR against `stable34` opened after 2026-08-27, e.g. #8199.
2. Locally, `node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/psalm.yml','utf8'))"` parses the file on this branch and fails on `stable34`.

Same fix for the other two branches, `stable32` and `stable33`: #8247 and #8248.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
