### PR TITLE
feat: update JSignPdf to 3.1.0 with jsignpdf-php 3.0.0

### DIFF
--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -15,7 +15,6 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Helper\JavaHelper;
 use OCA\Libresign\Service\DocMdp\ConfigService as DocMdpConfigService;
-use OCA\Libresign\Service\Install\InstallService;
 use OCA\Libresign\Service\Policy\PolicyService;
 use OCA\Libresign\Service\Policy\Provider\SignatureHashAlgorithm\SignatureHashAlgorithmPolicy;
 use OCA\Libresign\Service\Policy\Provider\SignatureText\SignatureTextPolicyValue;
@@ -82,32 +81,27 @@ class JSignPdfHandler extends Pkcs12Handler {
 			if (!is_writable($tempPath)) {
 				throw new \Exception('The path ' . $tempPath . ' is not writtable. Fix this or change the LibreSign app setting jsignpdf_temp_path to a writtable path');
 			}
-			$jSignPdfJarPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path', '/opt/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar');
-			if (!file_exists($jSignPdfJarPath)) {
-				throw new \Exception('Invalid JSignPdf jar path. Run occ libresign:install --jsignpdf');
+			$jSignPdfPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_path');
+			if (!is_dir($jSignPdfPath)) {
+				throw new \Exception('Invalid JSignPdf path. Run occ libresign:install --jsignpdf');
 			}
+			$home = $this->getHome();
 			$this->jSignParam = (new JSignParam())
 				->setTempPath($tempPath)
 				->setIsUseJavaInstalled(empty($javaPath))
 				->setJavaDownloadUrl('')
 				->setJSignPdfDownloadUrl('')
-				->setjSignPdfJarPath($jSignPdfJarPath);
+				->setJSignPdfPath($jSignPdfPath)
+				->setJavaOptions(['-Duser.home=' . $home])
+				->setEnvironmentVariables(['JSIGNPDF_HOME' => $home]);
 			if (!empty($javaPath)) {
 				if (!file_exists($javaPath)) {
 					throw new \Exception('Invalid Java binary. Run occ libresign:install --java');
 				}
-				$this->jSignParam->setJavaPath(
-					$this->getEnvironments()
-					. $javaPath
-					. ' -Duser.home=' . escapeshellarg($this->getHome()) . ' '
-				);
+				$this->jSignParam->setJavaPath($javaPath);
 			}
 		}
 		return $this->jSignParam;
-	}
-
-	private function getEnvironments(): string {
-		return 'JSIGNPDF_HOME=' . escapeshellarg($this->getHome()) . ' ';
 	}
 
 	/**
@@ -264,36 +258,28 @@ class JSignPdfHandler extends Pkcs12Handler {
 		$normalizedPdf = $this->normalizePdfVersion($this->getInputFile()->getContent());
 		$hashAlgorithm = $this->getHashAlgorithm($normalizedPdf);
 		$param = $this->getJSignParam();
-
-		$tsaParams = $this->listParamsToString($this->getTsaParameters());
-
-		$visibleElements = $this->getVisibleElements();
-		$certParams = '';
-		$certificationLevel = $this->getCertificationLevel();
-		if ($certificationLevel !== null && !$visibleElements && !$this->hasExistingSignatures($normalizedPdf)) {
-			$certParams = ' -cl ' . $certificationLevel;
-		}
-
-		$param->setJSignParameters(
-			$param->getJSignParameters()
-			. $certParams
-			. $tsaParams
-		);
 		$param->setCertificate($this->getCertificate())
 			->setPdf($normalizedPdf)
 			->setPassword($this->getPassword());
+
+		$parameters = [];
+		$certificationLevel = $this->getCertificationLevel();
+		if ($certificationLevel !== null && !$this->getVisibleElements() && !$this->hasExistingSignatures($normalizedPdf)) {
+			$parameters['-cl'] = $certificationLevel;
+		}
+		$parameters += $this->getTsaParameters();
+		$param->addJSignParameters($parameters);
+		$tsaPassword = $this->getTsaPassword();
+		if ($tsaPassword !== '') {
+			$param->setTsaPassword($tsaPassword);
+		}
 
 		$signed = $this->signUsingVisibleElements($normalizedPdf, $hashAlgorithm);
 		if ($signed) {
 			return $signed;
 		}
 
-		$param->setJSignParameters(
-			$param->getJSignParameters()
-			. $this->listParamsToString([
-				'--hash-algorithm' => $hashAlgorithm,
-			])
-		);
+		$param->addJSignParameters(['--hash-algorithm' => $hashAlgorithm]);
 		$jSignPdf = $this->getJSignPdf();
 		$jSignPdf->setParam($param);
 		return $this->signWrapper($jSignPdf);
@@ -313,7 +299,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 			];
 
 			// When l2-text is empty, add hash-algorithm at the beginning
-			if ($params['--l2-text'] === '""') {
+			if ($params['--l2-text'] === '') {
 				$params = [
 					'--hash-algorithm' => $hashAlgorithm,
 					'--l2-text' => $params['--l2-text'],
@@ -322,7 +308,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 			}
 
 			$fontSize = $this->parseSignatureText()['templateFontSize'];
-			if ($fontSize === SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE || !$fontSize || $params['--l2-text'] === '""') {
+			if ($fontSize === SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE || !$fontSize || $params['--l2-text'] === '') {
 				$fontSize = 0;
 			}
 
@@ -335,11 +321,9 @@ class JSignPdfHandler extends Pkcs12Handler {
 
 			$certificationLevel = $this->getCertificationLevel();
 			$applyCertification = $certificationLevel !== null && !$this->hasExistingSignatures($normalizedPdf);
-			$certParams = $applyCertification ? ' -cl ' . $certificationLevel : '';
 			$elementIndex = 0;
 
-			$param = $this->getJSignParam();
-			$originalParam = clone $param;
+			$originalParam = $this->getJSignParam();
 
 			foreach ($visibleElements as $element) {
 				$elementIndex++;
@@ -374,7 +358,7 @@ class JSignPdfHandler extends Pkcs12Handler {
 					} elseif ($signatureImagePath) {
 						$params['--bg-path'] = $signatureImagePath;
 					}
-				} elseif ($params['--l2-text'] === '""') {
+				} elseif ($params['--l2-text'] === '') {
 					if ($backgroundPathForElement && $signatureImagePath) {
 						$params['--bg-path'] = $this->mergeBackgroundWithSignature(
 							$backgroundPathForElement,
@@ -409,16 +393,15 @@ class JSignPdfHandler extends Pkcs12Handler {
 				}
 
 				// Only add hash-algorithm at the end if l2-text is not empty
-				if ($params['--l2-text'] !== '""') {
+				if ($params['--l2-text'] !== '') {
 					$params['--hash-algorithm'] = $hashAlgorithm;
 				}
 
-				$elementCertParams = ($applyCertification && $elementIndex === 1) ? $certParams : '';
-				$param->setJSignParameters(
-					$originalParam->getJSignParameters()
-					. $elementCertParams
-					. $this->listParamsToString($params)
-				);
+				$param = clone $originalParam;
+				if ($applyCertification && $elementIndex === 1) {
+					$param->addJSignParameters(['-cl' => $certificationLevel]);
+				}
+				$param->addJSignParameters($this->toJSignParameters($params));
 				$param->setPdf($normalizedPdf);
 				$jSignPdf->setParam($param);
 				$signed = $this->signWrapper($jSignPdf);
@@ -625,59 +608,61 @@ class JSignPdfHandler extends Pkcs12Handler {
 	public function getSignatureText(): string {
 		$renderMode = $this->signatureTextService->getRenderMode();
 		if ($renderMode !== SignerElementsService::RENDER_MODE_GRAPHIC_ONLY) {
-			$data = $this->parseSignatureText();
-			$signatureText = '"' . str_replace(
-				['"', '$'],
-				['\"', '\$'],
-				$data['parsed']
-			) . '"';
-		} else {
-			$signatureText = '""';
+			return $this->parseSignatureText()['parsed'];
 		}
-
-		return $signatureText;
+		return '';
 	}
 
-	private function listParamsToString(array $params): string {
-		$paramString = '';
-		foreach ($params as $flag => $value) {
-			$paramString .= ' ' . $flag;
-			if ($value !== null && $value !== '') {
-				$paramString .= ' ' . $value;
+	/**
+	 * Options with a null value are flags. Every other value reaches the
+	 * wrapper as a string; the wrapper escapes it for the shell.
+	 *
+	 * @param array<string, string|int|float|null> $params
+	 * @return array<array-key, string>
+	 */
+	private function toJSignParameters(array $params): array {
+		$parameters = [];
+		foreach ($params as $option => $value) {
+			if ($value === null) {
+				$parameters[] = $option;
+				continue;
 			}
+			$parameters[$option] = (string)$value;
 		}
-		return $paramString;
+		return $parameters;
 	}
 
+	/**
+	 * @return array<string, string>
+	 */
 	private function getTsaParameters(): array {
 		$tsaSettings = $this->getTsaSettings();
-		$tsaUrl = $tsaSettings['url'];
-		if (empty($tsaUrl)) {
+		if (empty($tsaSettings['url'])) {
 			return [];
 		}
 
-		$params = [
-			'--tsa-server-url' => $tsaUrl,
-			'--tsa-policy-oid' => $tsaSettings['policy_oid'],
-		];
-
-		if (!$params['--tsa-policy-oid']) {
-			unset($params['--tsa-policy-oid']);
+		$params = ['--tsa-server-url' => $tsaSettings['url']];
+		if ($tsaSettings['policy_oid']) {
+			$params['--tsa-policy-oid'] = $tsaSettings['policy_oid'];
 		}
-
-		$tsaAuthType = $tsaSettings['auth_type'];
-		if ($tsaAuthType === 'basic') {
-			$tsaUsername = $tsaSettings['username'];
-			$tsaPassword = $this->appConfig->getValueString(Application::APP_ID, TsaPolicy::PASSWORD_APP_CONFIG_KEY, '');
-
-			if (!empty($tsaUsername) && !empty($tsaPassword)) {
-				$params['--tsa-authentication'] = 'PASSWORD';
-				$params['--tsa-user'] = $tsaUsername;
-				$params['--tsa-password'] = $tsaPassword;
-			}
+		if ($this->getTsaPassword() !== '') {
+			$params['--tsa-authentication'] = 'PASSWORD';
+			$params['--tsa-user'] = $tsaSettings['username'];
 		}
 
 		return $params;
+	}
+
+	/**
+	 * The TSA password never goes to the command line: the wrapper writes it
+	 * to the stdin of JSignPdf.
+	 */
+	private function getTsaPassword(): string {
+		$tsaSettings = $this->getTsaSettings();
+		if (empty($tsaSettings['url']) || $tsaSettings['auth_type'] !== 'basic' || empty($tsaSettings['username'])) {
+			return '';
+		}
+		return $this->appConfig->getValueString(Application::APP_ID, TsaPolicy::PASSWORD_APP_CONFIG_KEY, '');
 	}
 
 	/**

--- a/lib/Service/Install/InstallService.php
+++ b/lib/Service/Install/InstallService.php
@@ -50,8 +50,7 @@ class InstallService {
 	private const string JAVA_URL_PATH_NAME = '21.0.8+9';
 	public const PDFTK_VERSION = '3.3.3'; /** @todo When update, verify the hash **/
 	private const string PDFTK_HASH = '59a28bed53b428595d165d52988bf4cf';
-	public const JSIGNPDF_VERSION = '2.3.0'; /** @todo When update, verify the hash **/
-	private const string JSIGNPDF_HASH = 'd239658ea50a39eb35169d8392feaffb';
+	public const JSIGNPDF_VERSION = JSignPdfRelease::VERSION;
 	public const CFSSL_VERSION = '1.6.5';
 	private const string PROCESS_SOURCE = 'install';
 
@@ -477,36 +476,34 @@ class InstallService {
 
 		if ($this->isDownloadedFilesOk()) {
 			// The binaries files could exists but not saved at database
-			$fullPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path');
+			$fullPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_path');
 			if (!$fullPath) {
 				$folder = $this->getFolder($this->resource);
-				$extractDir = $this->getInternalPathOfFolder($folder);
-				$fullPath = $extractDir . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar';
-				$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_jar_path', $fullPath);
+				$fullPath = JSignPdfRelease::installPath($this->getInternalPathOfFolder($folder));
+				$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_path', $fullPath);
 			}
 			$this->saveJsignPdfHome();
-			if (str_contains($fullPath, InstallService::JSIGNPDF_VERSION)) {
+			if (str_contains($fullPath, InstallService::JSIGNPDF_VERSION) && is_dir($fullPath)) {
 				return;
 			}
 		}
 		$folder = $this->getFolder($this->resource);
-		$compressedFileName = 'jsignpdf-' . InstallService::JSIGNPDF_VERSION . '.zip';
+		$compressedFileName = JSignPdfRelease::archiveName();
 		try {
 			$compressedFile = $folder->getFile($compressedFileName);
 		} catch (\Throwable) {
 			$compressedFile = $folder->newFile($compressedFileName);
 		}
 		$compressedInternalFileName = $this->getInternalPathOfFile($compressedFile);
-		$url = 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_' . str_replace('.', '_', InstallService::JSIGNPDF_VERSION) . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '.zip';
-
-		$this->download($url, 'JSignPdf', $compressedInternalFileName, self::JSIGNPDF_HASH);
+		$hash = $this->getHash($compressedFileName, JSignPdfRelease::checksumUrl());
+		$this->download(JSignPdfRelease::downloadUrl(), 'JSignPdf', $compressedInternalFileName, $hash, 'sha256');
 
 		$extractDir = $this->getInternalPathOfFolder($folder);
 		$zip = new ZIP($extractDir . '/' . $compressedFileName);
 		$zip->extract($extractDir);
 		unlink($extractDir . '/' . $compressedFileName);
-		$fullPath = $extractDir . '/jsignpdf-' . InstallService::JSIGNPDF_VERSION . '/JSignPdf.jar';
-		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_jar_path', $fullPath);
+		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_path', JSignPdfRelease::installPath($extractDir));
+		$this->appConfig->deleteKey(Application::APP_ID, 'jsignpdf_jar_path');
 		$this->saveJsignPdfHome();
 		$this->writeAppSignature();
 
@@ -536,8 +533,9 @@ class InstallService {
 	}
 
 	public function uninstallJSignPdf(): void {
-		$jsignpdJarPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path');
-		if (!$jsignpdJarPath) {
+		$jsignpdfPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_path')
+			?: $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path');
+		if (!$jsignpdfPath) {
 			return;
 		}
 		$this->setResource('jsignpdf');
@@ -546,6 +544,7 @@ class InstallService {
 			$folder->delete();
 		} catch (NotFoundException) {
 		}
+		$this->appConfig->deleteKey(Application::APP_ID, 'jsignpdf_path');
 		$this->appConfig->deleteKey(Application::APP_ID, 'jsignpdf_jar_path');
 		$this->appConfig->deleteKey(Application::APP_ID, 'jsignpdf_home');
 	}

--- a/lib/Service/Install/JSignPdfRelease.php
+++ b/lib/Service/Install/JSignPdfRelease.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Service\Install;
+
+/**
+ * Where LibreSign downloads JSignPdf from and where the archive ends up once
+ * extracted.
+ *
+ * JSignPdf 3.1 dropped the single JSignPdf.jar. The "minimal" package, meant
+ * for headless and command line use, ships a lib/ directory that the PHP
+ * wrapper starts through the classpath, so the configured path is the
+ * extracted directory instead of a jar file.
+ */
+final class JSignPdfRelease {
+	public const VERSION = '3.1.0';
+	private const RELEASES_URL = 'https://github.com/intoolswetrust/jsignpdf/releases/download/';
+
+	public static function archiveName(): string {
+		return 'jsignpdf-' . self::VERSION . '-minimal.zip';
+	}
+
+	public static function downloadUrl(): string {
+		return self::releaseUrl() . self::archiveName();
+	}
+
+	/**
+	 * One line per asset of the release, in the "hash  file name" format.
+	 */
+	public static function checksumUrl(): string {
+		return self::releaseUrl() . 'jsignpdf-' . self::VERSION . '-SHA256SUMS.txt';
+	}
+
+	/**
+	 * The archive extracts to a directory named after the version.
+	 */
+	public static function installPath(string $extractDir): string {
+		return $extractDir . '/jsignpdf-' . self::VERSION;
+	}
+
+	private static function releaseUrl(): string {
+		return self::RELEASES_URL . 'JSignPdf_' . str_replace('.', '_', self::VERSION) . '/';
+	}
+}

--- a/lib/Service/Install/SignSetupService.php
+++ b/lib/Service/Install/SignSetupService.php
@@ -196,7 +196,7 @@ class SignSetupService {
 				}
 				break;
 			case 'jsignpdf':
-				$path = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path');
+				$path = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_path');
 				if (!$path) {
 					// fallback
 					try {
@@ -212,7 +212,7 @@ class SignSetupService {
 						throw new InvalidSignatureException('JSignPdf path not found at app config.');
 					}
 				}
-				$installPath = substr($path, 0, strrpos($path, '/', -strlen('_/JSignPdf.jar')));
+				$installPath = dirname($path);
 				break;
 			case 'pdftk':
 				$path = $this->appConfig->getValueString(Application::APP_ID, 'pdftk_path');

--- a/lib/Service/Signature/PdfSignatureValidationService.php
+++ b/lib/Service/Signature/PdfSignatureValidationService.php
@@ -10,6 +10,8 @@ namespace OCA\Libresign\Service\Signature;
 
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Exception\UnsignedPdfException;
+use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ExtractedSignature;
+use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\TimestampToken;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationResult;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Model\ValidationState;
 use OCA\Libresign\Vendor\LibreSign\PdfSignatureValidator\Parser\PdfSignatureValidator;
@@ -103,14 +105,14 @@ class PdfSignatureValidationService {
 
 	/**
 	 * @param resource $resource
-	 * @return list<array{signature: mixed, signatureValidation: ValidationResult, certificates: list<string>, certificateValidation: ValidationResult}>
+	 * @return list<array{signature: ExtractedSignature, signatureValidation: ValidationResult, certificates: list<string>, certificateValidation: ValidationResult, timestamp: TimestampToken|null}>
 	 */
 	protected function validateNativeFromResource($resource): array {
 		return $this->validator->validateFromResource($resource);
 	}
 
 	/**
-	 * @return list<array{signature: mixed, signatureValidation: ValidationResult, certificates: list<string>, certificateValidation: ValidationResult}>
+	 * @return list<array{signature: ExtractedSignature, signatureValidation: ValidationResult, certificates: list<string>, certificateValidation: ValidationResult, timestamp: TimestampToken|null}>
 	 */
 	protected function validateNativeFromString(string $pdfContent): array {
 		return $this->validator->validateFromString($pdfContent);

--- a/lib/SetupCheck/JSignPdfSetupCheck.php
+++ b/lib/SetupCheck/JSignPdfSetupCheck.php
@@ -71,9 +71,9 @@ class JSignPdfSetupCheck implements ISetupCheck {
 	#[\Override]
 	public function run(): SetupResult {
 		$debugEnabled = $this->systemConfig->getSystemValueBool('debug', false);
-		$jsignpdfJarPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_jar_path');
+		$jsignpdfPath = $this->appConfig->getValueString(Application::APP_ID, 'jsignpdf_path');
 
-		if (!$jsignpdfJarPath) {
+		if (!$jsignpdfPath) {
 			return SetupResult::error(
 				// TRANSLATORS Warning shown in Nextcloud administration overview when the optional JSignPdf signing backend is not found.
 				$this->l10n->t('JSignPdf not found'),
@@ -88,12 +88,12 @@ class JSignPdfSetupCheck implements ISetupCheck {
 			return SetupResult::error($errorMsg, $tip);
 		}
 
-		if (!file_exists($jsignpdfJarPath)) {
+		if (!is_dir($jsignpdfPath)) {
 			return SetupResult::error(
 				// TRANSLATORS JSignPdf is an optional external signing backend used by LibreSign.
 				// LibreSign also supports other signing methods, including its native PHP signer.
 				// %s is the configured JSignPdf path that could not be found.
-				$this->l10n->t('JSignPdf file not found: %s', [$jsignpdfJarPath]),
+				$this->l10n->t('JSignPdf path not found: %s', [$jsignpdfPath]),
 				// TRANSLATORS Command to run into terminal using Nextcloud occ to configure LibreSign using CLI when the sysadmin want to do this by CLI.
 				$this->l10n->t('Run %s', ['occ libresign:install --jsignpdf'])
 			);
@@ -149,8 +149,8 @@ class JSignPdfSetupCheck implements ISetupCheck {
 			// TRANSLATORS JSignPdf is an optional external signing backend. %s is the detected JSignPdf version.
 			$this->l10n->t('JSignPdf version: %s', [$currentVersion]),
 
-			// TRANSLATORS JSignPdf is an optional external signing backend. %s is the configured or detected path to the JSignPdf executable/JAR file.
-			$this->l10n->t('JSignPdf path: %s', [$jsignpdfJarPath]),
+			// TRANSLATORS JSignPdf is an optional external signing backend. %s is the configured or detected directory where JSignPdf is installed.
+			$this->l10n->t('JSignPdf path: %s', [$jsignpdfPath]),
 		];
 
 		return SetupResult::success(implode("\n", $messages));

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -24,6 +24,7 @@ use OCA\Libresign\Service\Policy\Provider\SignatureHashAlgorithm\SignatureHashAl
 use OCA\Libresign\Service\Policy\Provider\SignatureText\SignatureTextPolicy;
 use OCA\Libresign\Service\Policy\Provider\SignatureText\SignatureTextPolicyValue;
 use OCA\Libresign\Service\Policy\Provider\Tsa\TsaPolicy;
+use OCA\Libresign\Service\Policy\Provider\Tsa\TsaPolicyValue;
 use OCA\Libresign\Service\SignatureBackgroundService;
 use OCA\Libresign\Service\SignatureTextService;
 use OCA\Libresign\Service\SignerElementsService;
@@ -319,7 +320,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		float $templateFontSize,
 		string $pdfContent,
 		?string $hashAlgorithm,
-		string $params,
+		array $params,
 	):void {
 		if (self::$certificateEngineFactory === null || empty(self::$certificateContent)) {
 			$this->markTestSkipped('Certificate initialization failed');
@@ -328,7 +329,12 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$inputFile = $this->createMock(\OC\Files\Node\File::class);
 		$inputFile->method('getContent')
 			->willReturn($pdfContent);
+		$paramsSeen = [];
 		$mock = $this->createMock(JSignPDF::class);
+		$mock->method('setParam')
+			->willReturnCallback(function (JSignParam $param) use (&$paramsSeen): void {
+				$paramsSeen[] = $param->getJSignParameters();
+			});
 		$mock->method('sign')->willReturn('content');
 
 		$this->signatureBackgroundService->method('getSignatureBackgroundType')->willReturn(
@@ -351,7 +357,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->persistHashAlgorithmPolicy($hashAlgorithm ?? '');
 		$this->appConfig->setValueString('libresign', 'java_path', __FILE__);
 		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', sys_get_temp_dir());
-		$this->appConfig->setValueString('libresign', 'jsignpdf_jar_path', __FILE__);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', __DIR__);
 
 		$jSignPdfHandler = $this->getInstance();
 		$jSignPdfHandler->setVisibleElements($visibleElements);
@@ -362,15 +368,28 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler->setPassword('password');
 		$actual = $jSignPdfHandler->getSignedContent();
 		$this->assertEquals('content', $actual);
-		$jSignParam = $jSignPdfHandler->getJSignParam();
-		$this->assertEquals('password', $jSignParam->getPassword());
-		$paramsAsOptions = $jSignParam->getJSignParameters();
-		$paramsAsOptions = preg_replace('/\\/\S+_merged.png/', 'merged.png', $paramsAsOptions);
+		$this->assertEquals('password', $jSignPdfHandler->getJSignParam()->getPassword());
+		$this->assertCount(1, $paramsSeen);
+		$paramsAsOptions = preg_replace('/\\/\S+_merged.png/', 'merged.png', $paramsSeen[0]);
 		$paramsAsOptions = preg_replace('/\\/\S+_text_image.png/', 'text_image.png', (string)$paramsAsOptions);
 		$paramsAsOptions = preg_replace('/\\/\S+_background.png/', 'background.png', (string)$paramsAsOptions);
 		$paramsAsOptions = preg_replace('/\\/\S+app-dark.png/', 'signature.png', (string)$paramsAsOptions);
-		$paramsAsOptions = preg_replace('/ --tsa-server-url\s+\S+/', '', (string)$paramsAsOptions);
-		$this->assertEquals($params, $paramsAsOptions);
+		$this->assertSame(self::expectedJSignParameters($params), $paramsAsOptions);
+	}
+
+	/**
+	 * What JSignParam::getJSignParameters() renders: the wrapper defaults
+	 * followed by the given options, each option and value escaped for the
+	 * shell, flags as bare escaped tokens.
+	 */
+	private static function expectedJSignParameters(array $params): string {
+		$tokens = [];
+		foreach (array_merge(['-a', '-kst' => 'PKCS12'], $params) as $option => $value) {
+			$tokens[] = is_string($option)
+				? escapeshellarg($option) . ' ' . escapeshellarg($value)
+				: escapeshellarg($value);
+		}
+		return implode(' ', $tokens);
 	}
 
 	public static function providerSignAffectedParams(): array {
@@ -385,7 +404,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => 0,
 				'pdfContent' => '%PDF-1',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --hash-algorithm SHA1',
+				'params' => ['--hash-algorithm' => 'SHA1'],
 			],
 			'page = 1 is default, do not will set the page' => [
 				'visibleElements' => [self::getElement([
@@ -403,7 +422,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --hash-algorithm SHA256 --l2-text "" -V -llx 0 -lly 0 -urx 0 -ury 0 --bg-path merged.png'
+				'params' => ['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-llx' => '0', '-lly' => '0', '-urx' => '0', '-ury' => '0', '--bg-path' => 'merged.png']
 			],
 			'page != 1: will have pg; without template: l2-text empty' => [
 				'visibleElements' => [self::getElement([
@@ -421,7 +440,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --hash-algorithm SHA256 --l2-text "" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path merged.png'
+				'params' => ['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'merged.png']
 			],
 			'with template we have the l2-text' => [
 				'visibleElements' => [self::getElement([
@@ -439,7 +458,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path background.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'background.png', '--hash-algorithm' => 'SHA256']
 			],
 			'font size != default font size: emits --font-size' => [
 				'visibleElements' => [self::getElement([
@@ -457,7 +476,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => 11,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --font-size 11 --bg-path background.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--font-size' => '11', '--bg-path' => 'background.png', '--hash-algorithm' => 'SHA256']
 			],
 			'background = deleted: bg-path = signature' => [
 				'visibleElements' => [self::getElement([
@@ -475,7 +494,43 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path signature.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'signature.png', '--hash-algorithm' => 'SHA256']
+			],
+			'template with shell special characters reaches the wrapper unescaped' => [
+				'visibleElements' => [self::getElement([
+					'page' => 2,
+					'llx' => 10,
+					'lly' => 20,
+					'urx' => 30,
+					'ury' => 40,
+				], realpath(__DIR__ . '/../../../../../img/app-dark.png'))],
+				'signatureWidth' => 20,
+				'signatureHeight' => 20,
+				'template' => 'a"b $c \'d e',
+				'signatureBackgroundType' => 'deleted',
+				'renderMode' => SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY,
+				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
+				'pdfContent' => '%PDF-1.6',
+				'hashAlgorithm' => '',
+				'params' => ['--l2-text' => 'a"b $c \'d e', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'signature.png', '--hash-algorithm' => 'SHA256'],
+			],
+			'font size != default but no template: no --font-size' => [
+				'visibleElements' => [self::getElement([
+					'page' => 2,
+					'llx' => 10,
+					'lly' => 20,
+					'urx' => 30,
+					'ury' => 40,
+				], realpath(__DIR__ . '/../../../../../img/app-dark.png'))],
+				'signatureWidth' => 20,
+				'signatureHeight' => 20,
+				'template' => '',
+				'signatureBackgroundType' => 'default',
+				'renderMode' => SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY,
+				'templateFontSize' => 11,
+				'pdfContent' => '%PDF-1.6',
+				'hashAlgorithm' => '',
+				'params' => ['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'merged.png'],
 			],
 			'background and template, bg-path = background, img-path = signature' => [
 				'visibleElements' => [self::getElement([
@@ -493,7 +548,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --render-mode GRAPHIC_AND_DESCRIPTION --bg-path background.png --img-path signature.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--render-mode' => 'GRAPHIC_AND_DESCRIPTION', '--bg-path' => 'background.png', '--img-path' => 'signature.png', '--hash-algorithm' => 'SHA256']
 			],
 			'background and template, render mode equals to SIGNAME_AND_DESCRIPTION: bg-path = background, img-path = text_image' => [
 				'visibleElements' => [self::getElement([
@@ -511,7 +566,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 1 -lly 100 -urx 351 -ury 200 --render-mode GRAPHIC_AND_DESCRIPTION --bg-path background.png --img-path text_image.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '1', '-lly' => '100', '-urx' => '351', '-ury' => '200', '--render-mode' => 'GRAPHIC_AND_DESCRIPTION', '--bg-path' => 'background.png', '--img-path' => 'text_image.png', '--hash-algorithm' => 'SHA256']
 			],
 			'template without background; with signature image; render-mode: SIGNAME_AND_DESCRIPTION' => [
 				'visibleElements' => [self::getElement([
@@ -529,7 +584,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --render-mode GRAPHIC_AND_DESCRIPTION --img-path text_image.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--render-mode' => 'GRAPHIC_AND_DESCRIPTION', '--img-path' => 'text_image.png', '--hash-algorithm' => 'SHA256']
 			],
 			'template without background; without signature image; render-mode: SIGNAME_AND_DESCRIPTION' => [
 				'visibleElements' => [self::getElement([
@@ -547,7 +602,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --render-mode GRAPHIC_AND_DESCRIPTION --img-path text_image.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--render-mode' => 'GRAPHIC_AND_DESCRIPTION', '--img-path' => 'text_image.png', '--hash-algorithm' => 'SHA256']
 			],
 			// Regression: background with GRAPHIC_AND_DESCRIPTION but NO user signature image.
 			// Before the fix, mergeBackgroundWithSignature('...', '') crashed with new Imagick('').
@@ -568,7 +623,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --l2-text "aaaaa" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --render-mode GRAPHIC_AND_DESCRIPTION --bg-path background.png --hash-algorithm SHA256'
+				'params' => ['--l2-text' => 'aaaaa', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--render-mode' => 'GRAPHIC_AND_DESCRIPTION', '--bg-path' => 'background.png', '--hash-algorithm' => 'SHA256']
 			],
 			'background without template: bg-path = merged with signature, without img-path' => [
 				'visibleElements' => [self::getElement([
@@ -586,7 +641,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --hash-algorithm SHA256 --l2-text "" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path merged.png'
+				'params' => ['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'merged.png']
 			],
 			'regression: invalid stored dimensions should fallback to defaults and keep signing flow' => [
 				'visibleElements' => [self::getElement([
@@ -604,7 +659,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'templateFontSize' => SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE,
 				'pdfContent' => '%PDF-1.6',
 				'hashAlgorithm' => '',
-				'params' => '-a -kst PKCS12 --hash-algorithm SHA256 --l2-text "" -V -pg 2 -llx 10 -lly 20 -urx 30 -ury 40 --bg-path merged.png'
+				'params' => ['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-pg' => '2', '-llx' => '10', '-lly' => '20', '-urx' => '30', '-ury' => '40', '--bg-path' => 'merged.png']
 			],
 		];
 	}
@@ -626,7 +681,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->persistHashAlgorithmPolicy('');
 		$this->appConfig->setValueString('libresign', 'java_path', __FILE__);
 		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', sys_get_temp_dir());
-		$this->appConfig->setValueString('libresign', 'jsignpdf_jar_path', __FILE__);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', __DIR__);
 
 		$paramsSeen = [];
 		$mock = $this->createMock(JSignPDF::class);
@@ -668,8 +723,8 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler->getSignedContent();
 
 		$this->assertCount(2, $paramsSeen);
-		$this->assertStringContainsString(' -cl ' . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name, $paramsSeen[0]);
-		$this->assertStringNotContainsString(' -cl ' . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name, $paramsSeen[1]);
+		$this->assertStringContainsString("'-cl' '" . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name . "'", $paramsSeen[0]);
+		$this->assertStringNotContainsString("'-cl' '" . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name . "'", $paramsSeen[1]);
 	}
 
 	public function testDocMdpSkippedWhenSignatureExists(): void {
@@ -689,7 +744,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->persistHashAlgorithmPolicy('');
 		$this->appConfig->setValueString('libresign', 'java_path', __FILE__);
 		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', sys_get_temp_dir());
-		$this->appConfig->setValueString('libresign', 'jsignpdf_jar_path', __FILE__);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', __DIR__);
 
 		$paramsSeen = [];
 		$mock = $this->createMock(JSignPDF::class);
@@ -724,7 +779,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler->getSignedContent();
 
 		$this->assertCount(1, $paramsSeen);
-		$this->assertStringNotContainsString(' -cl ' . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name, $paramsSeen[0]);
+		$this->assertStringNotContainsString("'-cl' '" . DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name . "'", $paramsSeen[0]);
 	}
 
 	#[DataProvider('providerSignatureDimensions')]
@@ -823,44 +878,43 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	#[DataProvider('providerGetJSignParam')]
-	public function testGetJSignParam(string $temp_path, string $java_path, string $jar_path, bool $throwException): void {
+	public function testGetJSignParam(string $temp_path, string $java_path, string $jsignpdf_path, bool $throwException): void {
 		$this->appConfig->setValueString('libresign', 'jsignpdf_home', '/');
 		$this->appConfig->setValueString('libresign', 'java_path', $java_path);
 		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', $temp_path);
-		$this->appConfig->setValueString('libresign', 'jsignpdf_jar_path', $jar_path);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', $jsignpdf_path);
 		$this->javaHelper->method('getJavaPath')->willReturn($java_path);
-
-		$expected = new JSignParam();
-		if ($java_path) {
-			$expected->setJavaPath("JSIGNPDF_HOME='/' $java_path -Duser.home='/' ");
-		}
-		$expected->setTempPath($temp_path);
-		$expected->setjSignPdfJarPath($jar_path);
 
 		$jSignPdfHandler = $this->getInstance();
 		if ($throwException) {
 			$this->expectException(\Exception::class);
-			$jSignParam = $jSignPdfHandler->getJSignParam();
-		} else {
-			$jSignParam = $jSignPdfHandler->getJSignParam();
-			$this->assertEquals($expected->getPdf(), $jSignParam->getPdf());
-			$this->assertEquals($expected->getJavaPath(), $jSignParam->getJavaPath());
-			$this->assertEquals($expected->getTempPath(), $jSignParam->getTempPath());
-			$this->assertEquals($expected->getjSignPdfJarPath(), $jSignParam->getjSignPdfJarPath());
-			$this->assertEquals('-a -kst PKCS12', $jSignParam->getJSignParameters());
+			$jSignPdfHandler->getJSignParam();
+			return;
 		}
+		$jSignParam = $jSignPdfHandler->getJSignParam();
+		$this->assertSame('', $jSignParam->getPdf());
+		if ($java_path === '') {
+			$this->assertTrue($jSignParam->isUseJavaInstalled());
+		} else {
+			$this->assertFalse($jSignParam->isUseJavaInstalled());
+			$this->assertSame($java_path, $jSignParam->getJavaPath());
+		}
+		$this->assertSame($temp_path, $jSignParam->getTempPath());
+		$this->assertSame($jsignpdf_path, $jSignParam->getJSignPdfPath());
+		$this->assertSame(['-Duser.home=/'], $jSignParam->getJavaOptions());
+		$this->assertSame(['JSIGNPDF_HOME' => '/'], $jSignParam->getEnvironmentVariables());
+		$this->assertSame("'-a' '-kst' 'PKCS12'", $jSignParam->getJSignParameters());
 	}
 
 	public static function providerGetJSignParam(): array {
 		return [
-			['',                 '',       __FILE__, true],
-			['invalid',          '',       __FILE__, true],
-			[sys_get_temp_dir(), '',       __FILE__, false],
-			[sys_get_temp_dir(), 'b',      __FILE__, true],
-			[sys_get_temp_dir(), __FILE__, __FILE__, false],
-			[sys_get_temp_dir(), 'b',      __FILE__, true],
-			[sys_get_temp_dir(), __FILE__, __FILE__, false],
-			[sys_get_temp_dir(), __FILE__, '',       true],
+			'temp path empty' => ['', '', __DIR__, true],
+			'temp path not writable' => ['invalid', '', __DIR__, true],
+			'system java' => [sys_get_temp_dir(), '', __DIR__, false],
+			'java binary missing' => [sys_get_temp_dir(), 'b', __DIR__, true],
+			'downloaded java' => [sys_get_temp_dir(), __FILE__, __DIR__, false],
+			'jsignpdf path not configured' => [sys_get_temp_dir(), __FILE__, '', true],
+			'jsignpdf path is a file, not the extracted directory' => [sys_get_temp_dir(), __FILE__, __FILE__, true],
 		];
 	}
 
@@ -881,7 +935,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler = $this->getInstance();
 		$actual = $jSignPdfHandler->getSignatureText();
 
-		$this->assertMatchesRegularExpression('/^"\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2} [A-Z]{3,4}"$/', $actual);
+		$this->assertMatchesRegularExpression('/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2} [A-Z]{3,4}$/', $actual);
 	}
 
 	public function testGetSignatureTextWithTwigDateFilterWithoutTimezone(): void {
@@ -893,7 +947,7 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler = $this->getInstance();
 		$actual = $jSignPdfHandler->getSignatureText();
 
-		$this->assertMatchesRegularExpression('/^"\d{2}\/\d{2}\/\d{4}"$/', $actual);
+		$this->assertMatchesRegularExpression('/^\d{2}\/\d{2}\/\d{4}$/', $actual);
 	}
 
 	public function testGetSignatureTextGraphicOnlyWithTwigDateFilterAlwaysReturnsEmpty(): void {
@@ -905,25 +959,27 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$jSignPdfHandler = $this->getInstance();
 		$actual = $jSignPdfHandler->getSignatureText();
 
-		$this->assertSame('""', $actual);
+		$this->assertSame('', $actual);
 	}
 
 	public static function providerGetSignatureText(): array {
 		return [
-			[SignerElementsService::RENDER_MODE_DEFAULT, '',     '""'],
-			[SignerElementsService::RENDER_MODE_DEFAULT, 'a',    '"a"'],
-			[SignerElementsService::RENDER_MODE_DEFAULT, "a\na", "\"a\na\""],
-			[SignerElementsService::RENDER_MODE_DEFAULT, 'a"a',  '"a\"a"'],
-			[SignerElementsService::RENDER_MODE_DEFAULT, 'a$a',  '"a\$a"'],
+			// The text reaches the wrapper as is: the wrapper escapes it for the shell.
+			[SignerElementsService::RENDER_MODE_DEFAULT, '',     ''],
+			[SignerElementsService::RENDER_MODE_DEFAULT, 'a',    'a'],
+			[SignerElementsService::RENDER_MODE_DEFAULT, "a\na", "a\na"],
+			[SignerElementsService::RENDER_MODE_DEFAULT, 'a"a',  'a"a'],
+			[SignerElementsService::RENDER_MODE_DEFAULT, "a'a",  "a'a"],
+			[SignerElementsService::RENDER_MODE_DEFAULT, 'a$a',  'a$a'],
 			// Plain {{ServerSignatureDate}} (no spaces) preserves JSign placeholder
-			[SignerElementsService::RENDER_MODE_DEFAULT, '{{ServerSignatureDate}}', '"\${timestamp}"'],
+			[SignerElementsService::RENDER_MODE_DEFAULT, '{{ServerSignatureDate}}', '${timestamp}'],
 			// Plain {{ ServerSignatureDate }} (with spaces) also preserves JSign placeholder
-			[SignerElementsService::RENDER_MODE_DEFAULT, '{{ ServerSignatureDate }}', '"\${timestamp}"'],
-			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, '',     '""'],
-			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a',    '""'],
-			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, "a\na", '""'],
-			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a"a',  '""'],
-			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a$a',  '""'],
+			[SignerElementsService::RENDER_MODE_DEFAULT, '{{ ServerSignatureDate }}', '${timestamp}'],
+			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, '',     ''],
+			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a',    ''],
+			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, "a\na", ''],
+			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a"a',  ''],
+			[SignerElementsService::RENDER_MODE_GRAPHIC_ONLY, 'a$a',  ''],
 		];
 	}
 
@@ -947,5 +1003,210 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		self::invokePrivate($jSignPdfHandler, 'checkTsaError', [
 			'TSAClientBouncyCastle: java.net.UnknownHostException: invalid-tsa.example.com',
 		]);
+	}
+
+	#[DataProvider('providerTsaParameters')]
+	public function testTsaParametersAndPassword(array $tsaSettings, string $storedPassword, array $expectedParameters, array $expectedPasswords): void {
+		if (self::$certificateEngineFactory === null || empty(self::$certificateContent)) {
+			$this->markTestSkipped('Certificate initialization failed');
+		}
+		$this->resolvedPolicyValues[TsaPolicy::KEY] = TsaPolicyValue::encode($tsaSettings);
+		$this->appConfig->setValueString('libresign', TsaPolicy::PASSWORD_APP_CONFIG_KEY, $storedPassword);
+		$this->appConfig->setValueString('libresign', 'java_path', __FILE__);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', sys_get_temp_dir());
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', __DIR__);
+		$this->persistHashAlgorithmPolicy('SHA256');
+
+		$inputFile = $this->createMock(\OC\Files\Node\File::class);
+		$inputFile->method('getContent')->willReturn('%PDF-1.6');
+
+		$paramsSeen = [];
+		$mock = $this->createMock(JSignPDF::class);
+		$mock->method('setParam')
+			->willReturnCallback(function (JSignParam $param) use (&$paramsSeen): void {
+				$paramsSeen[] = $param;
+			});
+		$mock->method('sign')->willReturn('content');
+
+		$jSignPdfHandler = $this->getInstance();
+		$jSignPdfHandler->setJSignPdf($mock);
+		$jSignPdfHandler->setInputFile($inputFile);
+		$jSignPdfHandler->setCertificate(self::$certificateContent);
+		$jSignPdfHandler->setPassword('password');
+		$jSignPdfHandler->getSignedContent();
+
+		$this->assertCount(1, $paramsSeen);
+		$this->assertSame(
+			self::expectedJSignParameters($expectedParameters + ['--hash-algorithm' => 'SHA256']),
+			$paramsSeen[0]->getJSignParameters(),
+		);
+		$this->assertSame($expectedPasswords, $paramsSeen[0]->getPasswords());
+		if ($storedPassword !== '') {
+			$this->assertStringNotContainsString($storedPassword, $paramsSeen[0]->getJSignParameters());
+		}
+	}
+
+	public static function providerTsaParameters(): array {
+		$tsa = [
+			'url' => 'https://tsa.example.test/tsr',
+			'policy_oid' => '1.2.3.4',
+			'auth_type' => 'basic',
+			'username' => 'alice',
+		];
+		return [
+			'no TSA configured' => [
+				['url' => ''],
+				'tsa secret',
+				[],
+				[],
+			],
+			'url only' => [
+				['url' => 'https://tsa.example.test/tsr'],
+				'',
+				['--tsa-server-url' => 'https://tsa.example.test/tsr'],
+				[],
+			],
+			'url with policy OID and no authentication' => [
+				['url' => 'https://tsa.example.test/tsr', 'policy_oid' => '1.2.3.4', 'auth_type' => 'none'],
+				'tsa secret',
+				['--tsa-server-url' => 'https://tsa.example.test/tsr', '--tsa-policy-oid' => '1.2.3.4'],
+				[],
+			],
+			'basic authentication: user on the command line, password over stdin' => [
+				$tsa,
+				'tsa secret',
+				[
+					'--tsa-server-url' => 'https://tsa.example.test/tsr',
+					'--tsa-policy-oid' => '1.2.3.4',
+					'--tsa-authentication' => 'PASSWORD',
+					'--tsa-user' => 'alice',
+				],
+				['-tsp' => 'tsa secret'],
+			],
+			'basic authentication with shell characters in the password' => [
+				$tsa,
+				"p4\$s 'w\"ord",
+				[
+					'--tsa-server-url' => 'https://tsa.example.test/tsr',
+					'--tsa-policy-oid' => '1.2.3.4',
+					'--tsa-authentication' => 'PASSWORD',
+					'--tsa-user' => 'alice',
+				],
+				['-tsp' => "p4\$s 'w\"ord"],
+			],
+			'basic authentication without a stored password is skipped' => [
+				$tsa,
+				'',
+				['--tsa-server-url' => 'https://tsa.example.test/tsr', '--tsa-policy-oid' => '1.2.3.4'],
+				[],
+			],
+			'basic authentication without a URL sends nothing' => [
+				['url' => '', 'auth_type' => 'basic', 'username' => 'alice'],
+				'tsa secret',
+				[],
+				[],
+			],
+			'basic authentication without a username is skipped' => [
+				['url' => 'https://tsa.example.test/tsr', 'auth_type' => 'basic', 'username' => ''],
+				'tsa secret',
+				['--tsa-server-url' => 'https://tsa.example.test/tsr'],
+				[],
+			],
+		];
+	}
+
+	#[DataProvider('providerCertificationLevelWithoutVisibleElements')]
+	public function testCertificationLevelWithoutVisibleElements(bool $docMdpEnabled, array $visibleElements, string $pdfContent, array $tsaSettings, array $expectedParameters): void {
+		if (self::$certificateEngineFactory === null || empty(self::$certificateContent)) {
+			$this->markTestSkipped('Certificate initialization failed');
+		}
+		$this->resolvedPolicyValues[TsaPolicy::KEY] = TsaPolicyValue::encode($tsaSettings);
+		$this->appConfig->setValueString('libresign', 'java_path', __FILE__);
+		$this->appConfig->setValueString('libresign', 'jsignpdf_temp_path', sys_get_temp_dir());
+		$this->appConfig->setValueString('libresign', 'jsignpdf_path', __DIR__);
+		$this->persistSignatureStampPolicy('', SignerElementsService::RENDER_MODE_DESCRIPTION_ONLY, 10, SignatureTextPolicyValue::DEFAULT_SIGNATURE_FONT_SIZE, 100, 100, 'deleted');
+		$this->persistHashAlgorithmPolicy('SHA256');
+		$this->signatureBackgroundService->method('getSignatureBackgroundType')->willReturn('deleted');
+
+		$inputFile = $this->createMock(\OC\Files\Node\File::class);
+		$inputFile->method('getContent')->willReturn($pdfContent);
+
+		$paramsSeen = [];
+		$mock = $this->createMock(JSignPDF::class);
+		$mock->method('setParam')
+			->willReturnCallback(function (JSignParam $param) use (&$paramsSeen): void {
+				$paramsSeen[] = $param->getJSignParameters();
+			});
+		$mock->method('sign')->willReturn('content');
+
+		$docMdpConfigService = $this->createMock(DocMdpConfigService::class);
+		$docMdpConfigService->method('isEnabled')->willReturn($docMdpEnabled);
+		$docMdpConfigService->method('getLevel')->willReturn(DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS);
+
+		$jSignPdfHandler = $this->getInstance();
+		$this->setDocMdpConfigService($jSignPdfHandler, $docMdpConfigService);
+		$jSignPdfHandler->setVisibleElements($visibleElements);
+		$jSignPdfHandler->setJSignPdf($mock);
+		$jSignPdfHandler->setInputFile($inputFile);
+		$jSignPdfHandler->setSignatureParams(['SignerCommonName' => 'Test User']);
+		$jSignPdfHandler->setCertificate(self::$certificateContent);
+		$jSignPdfHandler->setPassword('password');
+		$jSignPdfHandler->getSignedContent();
+
+		$this->assertCount(1, $paramsSeen);
+		$paramsAsOptions = preg_replace('/\\/\S+app-dark.png/', 'signature.png', $paramsSeen[0]);
+		$this->assertSame(self::expectedJSignParameters($expectedParameters), $paramsAsOptions);
+	}
+
+	public static function providerCertificationLevelWithoutVisibleElements(): array {
+		$element = self::getElement([
+			'page' => 1,
+			'llx' => 10,
+			'lly' => 10,
+			'urx' => 110,
+			'ury' => 60,
+		], realpath(__DIR__ . '/../../../../../img/app-dark.png'));
+		$tsa = ['url' => 'https://tsa.example.test/tsr'];
+		return [
+			'certification before the TSA options when the PDF has no signature' => [
+				true,
+				[],
+				'%PDF-1.6',
+				$tsa,
+				['-cl' => DocMdpLevel::CERTIFIED_FORM_FILLING_AND_ANNOTATIONS->name, '--tsa-server-url' => 'https://tsa.example.test/tsr', '--hash-algorithm' => 'SHA256'],
+			],
+			'no certification when the PDF already has a signature' => [
+				true,
+				[],
+				"%PDF-1.6\n/ByteRange [0 0 0 0]",
+				$tsa,
+				['--tsa-server-url' => 'https://tsa.example.test/tsr', '--hash-algorithm' => 'SHA256'],
+			],
+			'no certification when DocMDP is disabled, even with a visible element on a signed PDF' => [
+				false,
+				[$element],
+				"%PDF-1.6\n/ByteRange [0 0 0 0]",
+				['url' => ''],
+				['--hash-algorithm' => 'SHA256', '--l2-text' => '', '-V', '-llx' => '10', '-lly' => '10', '-urx' => '110', '-ury' => '60', '--bg-path' => 'signature.png'],
+			],
+		];
+	}
+
+	#[DataProvider('providerToJSignParameters')]
+	public function testToJSignParameters(array $params, array $expected): void {
+		$jSignPdfHandler = $this->getInstance();
+
+		$this->assertSame($expected, self::invokePrivate($jSignPdfHandler, 'toJSignParameters', [$params]));
+	}
+
+	public static function providerToJSignParameters(): array {
+		return [
+			'null is a flag' => [['-V' => null], ['-V']],
+			'integers become strings' => [['-pg' => 2, '-llx' => 0], ['-pg' => '2', '-llx' => '0']],
+			'floats become strings' => [['--font-size' => 16.5, '--bg-scale' => 1.0], ['--font-size' => '16.5', '--bg-scale' => '1']],
+			'empty string is a value' => [['--l2-text' => ''], ['--l2-text' => '']],
+			'text is kept as is' => [['--l2-text' => 'a"b $c \'d'], ['--l2-text' => 'a"b $c \'d']],
+			'order is preserved' => [['-a' => null, '-kst' => 'PKCS12', '-cl' => 'CERTIFIED_NO_CHANGES_ALLOWED'], ['-a', '-kst' => 'PKCS12', '-cl' => 'CERTIFIED_NO_CHANGES_ALLOWED']],
+		];
 	}
 }

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -16,6 +16,7 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Handler\SignEngine\JSignPdfHandler;
 use OCA\Libresign\Helper\JavaHelper;
+use OCA\Libresign\Service\CaIdentifierService;
 use OCA\Libresign\Service\DocMdp\ConfigService as DocMdpConfigService;
 use OCA\Libresign\Service\Policy\Model\ResolvedPolicy;
 use OCA\Libresign\Service\Policy\PolicyService;
@@ -61,6 +62,8 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		try {
 			$appConfig = self::getMockAppConfig();
 			$appConfig->setValueString(Application::APP_ID, 'certificate_engine', 'openssl');
+			// The CRL distribution point of the root certificate needs a CA identifier.
+			\OCP\Server::get(CaIdentifierService::class)->generateCaId('openssl');
 			self::$certificateEngineFactory = \OCP\Server::get(CertificateEngineFactory::class);
 			$certificateEngine = self::$certificateEngineFactory->getEngine();
 			$certificateEngine

--- a/tests/php/Unit/Service/Install/JSignPdfReleaseTest.php
+++ b/tests/php/Unit/Service/Install/JSignPdfReleaseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Tests\Unit\Service\Install;
+
+use OCA\Libresign\Service\Install\JSignPdfRelease;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class JSignPdfReleaseTest extends TestCase {
+	private const RELEASE_URL = 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_3_1_0/';
+
+	public function testArchiveIsTheMinimalPackageOfTheVersion(): void {
+		$this->assertSame('3.1.0', JSignPdfRelease::VERSION);
+		$this->assertSame('jsignpdf-3.1.0-minimal.zip', JSignPdfRelease::archiveName());
+	}
+
+	public function testDownloadUrlPointsToTheArchiveOfTheReleaseTag(): void {
+		$this->assertSame(
+			self::RELEASE_URL . 'jsignpdf-3.1.0-minimal.zip',
+			JSignPdfRelease::downloadUrl(),
+		);
+	}
+
+	public function testChecksumUrlPointsToTheSha256SumsOfTheSameRelease(): void {
+		$this->assertSame(
+			self::RELEASE_URL . 'jsignpdf-3.1.0-SHA256SUMS.txt',
+			JSignPdfRelease::checksumUrl(),
+		);
+	}
+
+	#[DataProvider('providerInstallPath')]
+	public function testInstallPathIsTheVersionedDirectoryInsideTheExtractDir(string $extractDir, string $expected): void {
+		$this->assertSame($expected, JSignPdfRelease::installPath($extractDir));
+	}
+
+	public static function providerInstallPath(): array {
+		return [
+			'appdata folder' => [
+				'/var/www/html/data/appdata_abc/libresign/x86_64/jsignpdf',
+				'/var/www/html/data/appdata_abc/libresign/x86_64/jsignpdf/jsignpdf-3.1.0',
+			],
+			'path with spaces' => [
+				'/opt/libre sign/jsignpdf',
+				'/opt/libre sign/jsignpdf/jsignpdf-3.1.0',
+			],
+			'relative path' => [
+				'jsignpdf',
+				'jsignpdf/jsignpdf-3.1.0',
+			],
+		];
+	}
+}

--- a/tests/php/Unit/Service/Install/JSignPdfReleaseTest.php
+++ b/tests/php/Unit/Service/Install/JSignPdfReleaseTest.php
@@ -13,23 +13,26 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class JSignPdfReleaseTest extends TestCase {
-	private const RELEASE_URL = 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_3_1_0/';
+	private static function releaseUrl(): string {
+		return 'https://github.com/intoolswetrust/jsignpdf/releases/download/JSignPdf_'
+			. str_replace('.', '_', JSignPdfRelease::VERSION) . '/';
+	}
 
 	public function testArchiveIsTheMinimalPackageOfTheVersion(): void {
 		$this->assertSame('3.1.0', JSignPdfRelease::VERSION);
-		$this->assertSame('jsignpdf-3.1.0-minimal.zip', JSignPdfRelease::archiveName());
+		$this->assertSame('jsignpdf-' . JSignPdfRelease::VERSION . '-minimal.zip', JSignPdfRelease::archiveName());
 	}
 
 	public function testDownloadUrlPointsToTheArchiveOfTheReleaseTag(): void {
 		$this->assertSame(
-			self::RELEASE_URL . 'jsignpdf-3.1.0-minimal.zip',
+			self::releaseUrl() . 'jsignpdf-' . JSignPdfRelease::VERSION . '-minimal.zip',
 			JSignPdfRelease::downloadUrl(),
 		);
 	}
 
 	public function testChecksumUrlPointsToTheSha256SumsOfTheSameRelease(): void {
 		$this->assertSame(
-			self::RELEASE_URL . 'jsignpdf-3.1.0-SHA256SUMS.txt',
+			self::releaseUrl() . 'jsignpdf-' . JSignPdfRelease::VERSION . '-SHA256SUMS.txt',
 			JSignPdfRelease::checksumUrl(),
 		);
 	}
@@ -43,15 +46,15 @@ final class JSignPdfReleaseTest extends TestCase {
 		return [
 			'appdata folder' => [
 				'/var/www/html/data/appdata_abc/libresign/x86_64/jsignpdf',
-				'/var/www/html/data/appdata_abc/libresign/x86_64/jsignpdf/jsignpdf-3.1.0',
+				'/var/www/html/data/appdata_abc/libresign/x86_64/jsignpdf/jsignpdf-' . JSignPdfRelease::VERSION,
 			],
 			'path with spaces' => [
 				'/opt/libre sign/jsignpdf',
-				'/opt/libre sign/jsignpdf/jsignpdf-3.1.0',
+				'/opt/libre sign/jsignpdf/jsignpdf-' . JSignPdfRelease::VERSION,
 			],
 			'relative path' => [
 				'jsignpdf',
-				'jsignpdf/jsignpdf-3.1.0',
+				'jsignpdf/jsignpdf-' . JSignPdfRelease::VERSION,
 			],
 		];
 	}

--- a/tests/php/Unit/Service/Install/SignSetupServiceTest.php
+++ b/tests/php/Unit/Service/Install/SignSetupServiceTest.php
@@ -199,7 +199,7 @@ final class SignSetupServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	#[DataProvider('dataGetInstallPath')]
 	public function testGetInstallPath(string $architecture, string $resource, string $distro, string $expected): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'java_path', 'vfs://home/data/appdata_1/libresign/x86_64/linux/java/jdk-21.0.2+13-jre/bin/java');
-		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_jar_path', 'vfs://home/data/appdata_1/libresign/x86_64/jsignpdf/jsignpdf-2.2.2/JSignPdf.jar');
+		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_path', 'vfs://home/data/appdata_1/libresign/x86_64/jsignpdf/jsignpdf-3.1.0');
 		$this->appConfig->setValueString(Application::APP_ID, 'pdftk_path', 'vfs://home/data/appdata_1/libresign/x86_64/pdftk/pdftk.jar');
 		$this->appConfig->setValueString(Application::APP_ID, 'cfssl_bin', 'vfs://home/data/appdata_1/libresign/x86_64/cfssl/cfssl');
 		$actual = $this->getInstance()

--- a/tests/php/Unit/Service/Install/SignSetupServiceTest.php
+++ b/tests/php/Unit/Service/Install/SignSetupServiceTest.php
@@ -12,6 +12,7 @@ use bovigo\vfs\vfsStream;
 use OC\IntegrityCheck\Helpers\EnvironmentHelper;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OCA\Libresign\AppInfo\Application;
+use OCA\Libresign\Service\Install\JSignPdfRelease;
 use OCA\Libresign\Service\Install\SignSetupService;
 use OCP\App\IAppManager;
 use OCP\Files\AppData\IAppDataFactory;
@@ -199,7 +200,7 @@ final class SignSetupServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	#[DataProvider('dataGetInstallPath')]
 	public function testGetInstallPath(string $architecture, string $resource, string $distro, string $expected): void {
 		$this->appConfig->setValueString(Application::APP_ID, 'java_path', 'vfs://home/data/appdata_1/libresign/x86_64/linux/java/jdk-21.0.2+13-jre/bin/java');
-		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_path', 'vfs://home/data/appdata_1/libresign/x86_64/jsignpdf/jsignpdf-3.1.0');
+		$this->appConfig->setValueString(Application::APP_ID, 'jsignpdf_path', 'vfs://home/data/appdata_1/libresign/x86_64/jsignpdf/jsignpdf-' . JSignPdfRelease::VERSION);
 		$this->appConfig->setValueString(Application::APP_ID, 'pdftk_path', 'vfs://home/data/appdata_1/libresign/x86_64/pdftk/pdftk.jar');
 		$this->appConfig->setValueString(Application::APP_ID, 'cfssl_bin', 'vfs://home/data/appdata_1/libresign/x86_64/cfssl/cfssl');
 		$actual = $this->getInstance()

--- a/tests/php/Unit/SetupCheck/JSignPdfSetupCheckTest.php
+++ b/tests/php/Unit/SetupCheck/JSignPdfSetupCheckTest.php
@@ -14,6 +14,12 @@ if (!function_exists('OCA\Libresign\SetupCheck\file_exists')) {
 	}
 }
 
+if (!function_exists('OCA\Libresign\SetupCheck\is_dir')) {
+	function is_dir(string $filename): bool {
+		return \OCA\Libresign\Tests\Mock\FileSystemMock::fileExists($filename);
+	}
+}
+
 namespace OCA\Libresign\Tests\Unit\SetupCheck;
 
 use OCA\Libresign\Handler\SignEngine\JSignPdfHandler;
@@ -95,7 +101,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 	public function testRunNoPathConfigured(): void {
 		$this->mockTranslation();
 		$this->appConfig->method('getValueString')
-			->with('libresign', 'jsignpdf_jar_path')
+			->with('libresign', 'jsignpdf_path')
 			->willReturn('');
 
 		$result = $this->check->run();
@@ -134,9 +140,9 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunBinaryNotFound(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 
@@ -144,29 +150,52 @@ class JSignPdfSetupCheckTest extends TestCase {
 		$this->signSetupService->method('verify')
 			->willReturn([]);
 
-		FileSystemMock::$files[$jarPath] = false;
+		FileSystemMock::$files[$jsignPdfPath] = false;
 
 		$result = $this->check->run();
 
 		$this->assertInstanceOf(SetupResult::class, $result);
 		$this->assertSame('error', $result->getSeverity());
-		$this->assertStringContainsString('JSignPdf file not found', $result->getDescription());
+		$this->assertStringContainsString('JSignPdf path not found', $result->getDescription());
 	}
 
 	public function testRunJavaNotFound(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 		$this->signSetupService->method('verify')
 			->willReturn([]);
 
-		FileSystemMock::$files[$jarPath] = true;
+		FileSystemMock::$files[$jsignPdfPath] = true;
 
 		$this->javaHelper->method('getJavaPath')
 			->willReturn('');
+
+		$result = $this->check->run();
+
+		$this->assertInstanceOf(SetupResult::class, $result);
+		$this->assertSame('error', $result->getSeverity());
+		$this->assertStringContainsString('Necessary Java to run JSignPdf', $result->getDescription());
+	}
+
+	public function testRunJavaBinaryMissing(): void {
+		$this->mockTranslation();
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$this->appConfig->method('getValueString')
+			->willReturn($jsignPdfPath);
+		$this->systemConfig->method('getSystemValueBool')
+			->willReturn(false);
+		$this->signSetupService->method('verify')
+			->willReturn([]);
+
+		FileSystemMock::$files[$jsignPdfPath] = true;
+		FileSystemMock::$files['/opt/java/bin/java'] = false;
+
+		$this->javaHelper->method('getJavaPath')
+			->willReturn('/opt/java/bin/java');
 
 		$result = $this->check->run();
 
@@ -183,14 +212,14 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionEmpty(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 		$this->signSetupService->method('verify')->willReturn([]);
 		$this->javaHelper->method('getJavaPath')->willReturn('/usr/bin/java');
-		FileSystemMock::$files[$jarPath] = true;
+		FileSystemMock::$files[$jsignPdfPath] = true;
 		FileSystemMock::$files['/usr/bin/java'] = true;
 
 		$jsignPdfMock = $this->getMockBuilder(\OCA\Libresign\Vendor\Jeidison\JSignPDF\JSignPDF::class)
@@ -200,6 +229,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 		$jsignPdfMock->method('getVersion')->willReturn('');
 
 		$jsignParamMock = $this->createJSignParamMock();
+		$jsignPdfMock->expects($this->once())->method('setParam')->with($jsignParamMock);
 
 		$this->jSignPdfHandler->method('getJSignPdf')->willReturn($jsignPdfMock);
 		$this->jSignPdfHandler->method('getJSignParam')->willReturn($jsignParamMock);
@@ -213,14 +243,14 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionTooLow(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 		$this->signSetupService->method('verify')->willReturn([]);
 		$this->javaHelper->method('getJavaPath')->willReturn('/usr/bin/java');
-		FileSystemMock::$files[$jarPath] = true;
+		FileSystemMock::$files[$jsignPdfPath] = true;
 		FileSystemMock::$files['/usr/bin/java'] = true;
 
 		$jsignPdfMock = $this->getMockBuilder(\OCA\Libresign\Vendor\Jeidison\JSignPDF\JSignPDF::class)
@@ -243,14 +273,14 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionTooHigh(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 		$this->signSetupService->method('verify')->willReturn([]);
 		$this->javaHelper->method('getJavaPath')->willReturn('/usr/bin/java');
-		FileSystemMock::$files[$jarPath] = true;
+		FileSystemMock::$files[$jsignPdfPath] = true;
 		FileSystemMock::$files['/usr/bin/java'] = true;
 
 		$jsignPdfMock = $this->getMockBuilder(\OCA\Libresign\Vendor\Jeidison\JSignPDF\JSignPDF::class)
@@ -273,14 +303,14 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunSuccess(): void {
 		$this->mockTranslation();
-		$jarPath = '/fake/path/jsignpdf.jar';
+		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
 		$this->appConfig->method('getValueString')
-			->willReturn($jarPath);
+			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
 			->willReturn(false);
 		$this->signSetupService->method('verify')->willReturn([]);
 		$this->javaHelper->method('getJavaPath')->willReturn('/usr/bin/java');
-		FileSystemMock::$files[$jarPath] = true;
+		FileSystemMock::$files[$jsignPdfPath] = true;
 		FileSystemMock::$files['/usr/bin/java'] = true;
 
 		$jsignPdfMock = $this->getMockBuilder(\OCA\Libresign\Vendor\Jeidison\JSignPDF\JSignPDF::class)
@@ -299,6 +329,6 @@ class JSignPdfSetupCheckTest extends TestCase {
 		$this->assertInstanceOf(SetupResult::class, $result);
 		$this->assertSame('success', $result->getSeverity());
 		$this->assertStringContainsString('JSignPdf version: ' . InstallService::JSIGNPDF_VERSION, $result->getDescription());
-		$this->assertStringContainsString('JSignPdf path: ' . $jarPath, $result->getDescription());
+		$this->assertStringContainsString('JSignPdf path: ' . $jsignPdfPath, $result->getDescription());
 	}
 }

--- a/tests/php/Unit/SetupCheck/JSignPdfSetupCheckTest.php
+++ b/tests/php/Unit/SetupCheck/JSignPdfSetupCheckTest.php
@@ -25,6 +25,7 @@ namespace OCA\Libresign\Tests\Unit\SetupCheck;
 use OCA\Libresign\Handler\SignEngine\JSignPdfHandler;
 use OCA\Libresign\Helper\JavaHelper;
 use OCA\Libresign\Service\Install\InstallService;
+use OCA\Libresign\Service\Install\JSignPdfRelease;
 use OCA\Libresign\Service\Install\SignSetupService;
 use OCA\Libresign\SetupCheck\JSignPdfSetupCheck;
 use OCA\Libresign\Tests\Mock\FileSystemMock;
@@ -140,7 +141,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunBinaryNotFound(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -161,7 +162,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunJavaNotFound(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -183,7 +184,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunJavaBinaryMissing(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -212,7 +213,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionEmpty(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -243,7 +244,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionTooLow(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -273,7 +274,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunVersionTooHigh(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')
@@ -303,7 +304,7 @@ class JSignPdfSetupCheckTest extends TestCase {
 
 	public function testRunSuccess(): void {
 		$this->mockTranslation();
-		$jsignPdfPath = '/fake/path/jsignpdf-3.1.0';
+		$jsignPdfPath = '/fake/path/jsignpdf-' . JSignPdfRelease::VERSION;
 		$this->appConfig->method('getValueString')
 			->willReturn($jsignPdfPath);
 		$this->systemConfig->method('getSystemValueBool')


### PR DESCRIPTION
Resolves: #8068

## 📝 Summary

Updates the JSignPdf signing backend to **JSignPdf 3.1.0** through **jsignpdf-php 3.0.0** (LibreSign/3rdparty#96). JSignPdf 3.1.0 also uses SHA-256 as the default TSA hash, which is what #8145 is about.

**Install.** JSignPdf 3.1 dropped the single `JSignPdf.jar`: the `minimal` package, meant for headless and command line use, ships a `lib/` directory that the wrapper starts through the classpath. `InstallService` now downloads `jsignpdf-3.1.0-minimal.zip`, verifies it against the `SHA256SUMS` file published with the release (instead of a hard-coded md5), and stores the extracted directory in the new `jsignpdf_path` app config key. The legacy `jsignpdf_jar_path` key is deleted on install and on uninstall. The release metadata lives in the new `JSignPdfRelease` class so it can be unit tested. `SignSetupService` and the setup check read the new key.

**Handler.** jsignpdf-php 3 escapes every argument itself and takes the options as a list, so `JSignPdfHandler` stops building shell syntax: the parameters are arrays (`addJSignParameters()`, one cloned `JSignParam` per visible element), the signature text is passed as is (no more quoting of `"` and `$`), the JVM option `-Duser.home` and the `JSIGNPDF_HOME` variable go through `setJavaOptions()` / `setEnvironmentVariables()`, and the TSA password goes through `setTsaPassword()`, which the wrapper writes to the stdin of JSignPdf instead of the command line. The wrapper now reports failure through the exit code instead of the "Finished: Signature succesfully created." message; the error parsing in `checkTsaError()` / `checkHashAlgorithmError()` is unchanged.

**Tests.** `JSignPdfHandlerTest` asserts the parameters that reach the wrapper (captured from `setParam()`), with the sign cases as structured providers, a case with shell special characters in the signature text, and a TSA provider covering no TSA, URL only, policy OID, basic authentication with the password over stdin, shell characters in the password, and the two cases with incomplete credentials. `JSignPdfReleaseTest` covers the download URL, checksum URL and install path. `JSignPdfSetupCheckTest` and `SignSetupServiceTest` follow the new key; the setup check gained two cases for mutants that escaped.

While doing this I found that 68 tests of `JSignPdfHandlerTest` were being skipped as "Certificate initialization failed": `generateRootCert()` needs a CA identifier to resolve the CRL distribution point and the class never generated one. `setUpBeforeClass()` now calls `CaIdentifierService::generateCaId()`, like `OpenSslHandlerTest` does, and all 96 tests run.

**Existing installations.** JSignPdf 2.3.0 cannot read passwords from stdin, so it does not work with the new wrapper: after upgrading, `occ libresign:install --jsignpdf` (or the install button in the admin settings) has to run once. Until then the setup check reports "JSignPdf not found" with that command as the tip, because `jsignpdf_path` is empty. I kept this explicit instead of downloading 35 MB during `occ upgrade`; say so if you prefer a repair step. The `-a` (append) default of the wrapper is a no-op in 3.x, where appending is the default, and LibreSign already rewrites the PDF header before signing, so the 3.x limitation that append mode cannot raise the PDF version for SHA-256 does not apply.

## 🧪 How to test

1. `occ libresign:install --use-local-cert --java` and `occ libresign:install --use-local-cert --jsignpdf`: the jsignpdf appdata folder gets `jsignpdf-3.1.0/lib/*.jar`, `occ config:app:get libresign jsignpdf_path` points to it and `jsignpdf_jar_path` is gone.
2. `occ libresign:configure:check` (or the admin overview) reports JSignPdf version 3.1.0.
3. Request a signature and sign it (clickToSign is enough). With a TSA configured with basic authentication, the password no longer appears in the JSignPdf command line (`ps` while signing, or the `--enable-stdin-passwords -ksp - -tsp -` in the command).
4. `composer run test:unit -- tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php`: 96 tests, none skipped.

## ⚙️ API / Back‑end changes

- [x] `InstallService`, `SignSetupService`, `JSignPdfSetupCheck`, `JSignPdfHandler`, new `JSignPdfRelease`; new app config key `jsignpdf_path` (replaces `jsignpdf_jar_path`)
- [x] Unit and/or integration tests added
- [ ] Capabilities updated (not applicable)
- [ ] Documentation updated (not applicable)
- [ ] API documentation updated with `composer openapi` (no API change)

### 🚧 Tasks
- [ ] Merge LibreSign/3rdparty#96 and point the submodule to its merge commit (the branch pins the head of that pull request for now).
- [ ] #8255 first: the 3rdparty `main` also carries pdf-signature-validator 0.5.1.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Validation (PHP 8.3 devcontainer):
  - PHPUnit: `JSignPdfHandlerTest` 107/107 (68 of them used to be skipped), `JSignPdfReleaseTest` 6/6, `JSignPdfSetupCheckTest` 11/11, `SignSetupServiceTest` 23/23; whole unit suite 3600 tests, the only 4 failures are in `AEngineHandlerTest` and pass when the class runs alone (state leaking between classes, unrelated to this change).
  - Infection on the lines changed against `main` (`--git-diff-lines`): 68 mutants, 68 killed, 100% coverage and 100% MSI. Per class: `JSignPdfRelease` 32/32, `JSignPdfSetupCheck` 33/33. `InstallService` has no unit coverage, as before; the install path is exercised by the behat and Playwright jobs (`libresign:install --jsignpdf`) and by the manual run below.
  - Psalm and php-cs-fixer clean on the changed files.
  - End to end: `occ libresign:install --use-local-cert --jsignpdf` downloaded `jsignpdf-3.1.0-minimal.zip`, verified it and set `jsignpdf_path` to `.../x86_64/jsignpdf/jsignpdf-3.1.0` (76 jars in `lib/`, legacy key gone); `java -classpath 'lib/*' com.intoolswetrust.jsignpdf.Bootstrap --version` prints `JSignPdf version 3.1.0`; a signature request signed with clickToSign returned 200 and the validation endpoint reports the signature as `adbe.pkcs7.detached`, RSA-SHA256, valid.

## 🤖 AI

- [x] The content of this PR was partially or fully generated using AI

Assisted by Claude Code (claude-fable-5-1); I reviewed and tested every change.

## JSignPdf 3.x features worth a look (not implemented here)

- **Pluggable signing engines** (`--list-engines`, `-eng`): OpenPDF stays the default; the new **EU DSS engine** produces PAdES signatures at the ETSI baseline levels B, T, LT and LTA, which OpenPDF cannot create.
- **Passwords over stdin** (`--enable-stdin-passwords`): used by this pull request through the wrapper.
- **`--overwrite`** replaces existing signatures instead of appending. LibreSign relies on appending, so nothing to do, but it is the switch to stay away from.
- **SHA-256 as the default hash, TSA included**: `--tsa-hash-algorithm` defaults to `AppConfig.defaultTsaHashAlg()` = SHA-256, which fixes the SHA-1 failure of #8145; a configurable TSA hash in the TSA policy stays as the follow-up discussed there.
- **3.2 (beta)**: sign into an existing signature field (`--sig-field`, `--list-sig-fields`), the feature the issue points at for pre-placed signature boxes; a `debug` output logging the certificate chain and every AIA/CRL/OCSP request, useful for TSA diagnostics; `buffering.mode=temp` to sign very large PDFs without a bigger heap.
- **Checksums for every artifact** (`SHA256SUMS.txt`): used by the installer here.
