### PR TITLE
fix(jsignpdf): improve the diagnosis of TSA failures

### DIFF
--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -680,10 +680,13 @@ class JSignPdfHandler extends Pkcs12Handler {
 		} catch (\Throwable $th) {
 			$errorMessage = $th->getMessage();
 
+			// Log before the checks below: they throw, and the original message
+			// from JSignPdf is the only place where the real cause is described.
+			$this->logger->error('Error at JSignPdf side. LibreSign can not do nothing. Follow the error message: ' . $errorMessage);
+
 			$this->checkTsaError($errorMessage);
 			$this->checkHashAlgorithmError($errorMessage);
 
-			$this->logger->error('Error at JSignPdf side. LibreSign can not do nothing. Follow the error message: ' . $errorMessage);
 			throw new \Exception($errorMessage);
 		}
 	}

--- a/lib/Handler/SignEngine/JSignPdfHandler.php
+++ b/lib/Handler/SignEngine/JSignPdfHandler.php
@@ -702,6 +702,11 @@ class JSignPdfHandler extends Pkcs12Handler {
 		}
 
 		if ($isTsaError) {
+			$rejectionMessage = $this->getTsaRejectionMessage($errorMessage);
+			if ($rejectionMessage !== null) {
+				throw new LibresignException($rejectionMessage);
+			}
+
 			if (str_contains($errorMessage, 'Invalid TSA') && preg_match("/Invalid TSA '([^']+)'/", $errorMessage, $matches)) {
 				$friendlyMessage = 'Timestamp Authority (TSA) service is unavailable. Check DNS/network/firewall connectivity from this server: ' . $matches[1];
 			} else {
@@ -710,6 +715,22 @@ class JSignPdfHandler extends Pkcs12Handler {
 			}
 			throw new LibresignException($friendlyMessage);
 		}
+	}
+
+	/**
+	 * An HTTP status in the JSignPdf output means that the TSA was reached and
+	 * answered: the request was rejected. Reporting DNS/network/firewall in this
+	 * case sends whoever is debugging to the wrong place.
+	 */
+	private function getTsaRejectionMessage(string $errorMessage): ?string {
+		if (!preg_match('/HTTP response code: (?<status>\d{3})(?: for URL: (?<url>[^\s"\',]+))?/', $errorMessage, $matches)) {
+			return null;
+		}
+
+		$endpoint = isset($matches['url']) && $matches['url'] !== '' ? ': ' . $matches['url'] : '.';
+		return 'Timestamp Authority (TSA) rejected the request with HTTP status ' . $matches['status'] . $endpoint . "\n"
+			. 'The server was reached, so this is not a DNS/network/firewall problem.' . "\n"
+			. 'Check what the authority expects: hash algorithm, policy OID and authentication.';
 	}
 
 	private function checkHashAlgorithmError(string $errorMessage): void {

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -986,6 +986,35 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		];
 	}
 
+	#[DataProvider('providerErrorsLoggedBeforeBeingTranslated')]
+	public function testSignWrapperLogsTheOriginalErrorBeforeThrowing(string $errorMessage): void {
+		$jSignPdfHandler = $this->getInstance();
+
+		$jSignPdf = $this->createMock(JSignPDF::class);
+		$jSignPdf->method('sign')
+			->willThrowException(new \Exception($errorMessage));
+
+		$this->loggerInterface->expects($this->once())
+			->method('error')
+			->with($this->stringContains($errorMessage));
+
+		$this->expectException(LibresignException::class);
+
+		self::invokePrivate($jSignPdfHandler, 'signWrapper', [$jSignPdf]);
+	}
+
+	public static function providerErrorsLoggedBeforeBeingTranslated(): array {
+		return [
+			'TSA error' => [
+				'ExceptionConverter: java.io.IOException: Server returned HTTP response code: 400 for URL: http://time.certum.pl' . "\n"
+					. "\tat com.lowagie.text.pdf.TSAClientBouncyCastle.getTSAResponse(TSAClientBouncyCastle.java:288)",
+			],
+			'hash algorithm error' => [
+				'INFO The chosen hash algorithm (SHA-256) requires a newer PDF version.',
+			],
+		];
+	}
+
 	public function testCheckTsaErrorInvalidTsaMentionsDnsNetworkFirewall(): void {
 		$jSignPdfHandler = $this->getInstance();
 

--- a/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
+++ b/tests/php/Unit/Handler/SignEngine/JSignPdfHandlerTest.php
@@ -986,6 +986,51 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		];
 	}
 
+	#[DataProvider('providerTsaErrors')]
+	public function testCheckTsaError(string $errorMessage, string $expectedMessage): void {
+		$jSignPdfHandler = $this->getInstance();
+
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage($expectedMessage);
+
+		self::invokePrivate($jSignPdfHandler, 'checkTsaError', [$errorMessage]);
+	}
+
+	public static function providerTsaErrors(): array {
+		$rejected = 'The server was reached, so this is not a DNS/network/firewall problem.' . "\n"
+			. 'Check what the authority expects: hash algorithm, policy OID and authentication.';
+
+		return [
+			'invalid TSA blames DNS, network and firewall' => [
+				"Invalid TSA 'https://invalid-tsa.example.com/tsr'",
+				'Timestamp Authority (TSA) service is unavailable. Check DNS/network/firewall connectivity from this server: https://invalid-tsa.example.com/tsr',
+			],
+			'unknown host blames DNS, network and firewall' => [
+				'TSAClientBouncyCastle: java.net.UnknownHostException: invalid-tsa.example.com',
+				"Timestamp Authority (TSA) service error.\nCheck TSA endpoint and DNS/network/firewall connectivity from this server.",
+			],
+			'HTTP status reports a rejection and the endpoint that answered' => [
+				'ExceptionConverter: java.io.IOException: Server returned HTTP response code: 400 for URL: http://time.certum.pl' . "\n"
+					. "\tat com.lowagie.text.pdf.TSAClientBouncyCastle.getTSAResponse(TSAClientBouncyCastle.java:288)",
+				'Timestamp Authority (TSA) rejected the request with HTTP status 400: http://time.certum.pl' . "\n" . $rejected,
+			],
+			'HTTP status without an URL still reports a rejection' => [
+				'TSAClientBouncyCastle: java.io.IOException: Server returned HTTP response code: 503',
+				'Timestamp Authority (TSA) rejected the request with HTTP status 503.' . "\n" . $rejected,
+			],
+		];
+	}
+
+	public function testCheckTsaErrorIgnoresErrorsFromOtherSources(): void {
+		$jSignPdfHandler = $this->getInstance();
+
+		$this->expectNotToPerformAssertions();
+
+		self::invokePrivate($jSignPdfHandler, 'checkTsaError', [
+			'java.io.IOException: Server returned HTTP response code: 400 for URL: https://example.test/crl',
+		]);
+	}
+
 	#[DataProvider('providerErrorsLoggedBeforeBeingTranslated')]
 	public function testSignWrapperLogsTheOriginalErrorBeforeThrowing(string $errorMessage): void {
 		$jSignPdfHandler = $this->getInstance();
@@ -1013,28 +1058,6 @@ final class JSignPdfHandlerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'INFO The chosen hash algorithm (SHA-256) requires a newer PDF version.',
 			],
 		];
-	}
-
-	public function testCheckTsaErrorInvalidTsaMentionsDnsNetworkFirewall(): void {
-		$jSignPdfHandler = $this->getInstance();
-
-		$this->expectException(LibresignException::class);
-		$this->expectExceptionMessage('Timestamp Authority (TSA) service is unavailable. Check DNS/network/firewall connectivity from this server: https://invalid-tsa.example.com/tsr');
-
-		self::invokePrivate($jSignPdfHandler, 'checkTsaError', [
-			"Invalid TSA 'https://invalid-tsa.example.com/tsr'",
-		]);
-	}
-
-	public function testCheckTsaErrorUnknownHostMentionsDnsNetworkFirewall(): void {
-		$jSignPdfHandler = $this->getInstance();
-
-		$this->expectException(LibresignException::class);
-		$this->expectExceptionMessage("Timestamp Authority (TSA) service error.\nCheck TSA endpoint and DNS/network/firewall connectivity from this server.");
-
-		self::invokePrivate($jSignPdfHandler, 'checkTsaError', [
-			'TSAClientBouncyCastle: java.net.UnknownHostException: invalid-tsa.example.com',
-		]);
 	}
 
 	#[DataProvider('providerTsaParameters')]


### PR DESCRIPTION
Resolves: # <!-- part of #8145, does not close it -->

## 📝 Summary

Two diagnosis problems reported in #8145, both independent of the TSA hash algorithm option
discussed there:

1. **The original JSignPdf error was never logged.** `checkTsaError()` and
   `checkHashAlgorithmError()` throw before the `logger->error(...)` line in `signWrapper()`, so
   the Java message — the only place where the real cause is described — never reached
   `nextcloud.log`. The reporter found the actual cause only by running JSignPdf by hand.
   The log call now happens first, and the friendly message is still what the user sees.

2. **A rejected request was reported as a connectivity problem.** `checkTsaError()` triggers on
   `TSAClientBouncyCastle`, `UnknownHostException` and `Invalid TSA`, and always answered
   *"Check TSA endpoint and DNS/network/firewall connectivity from this server"*. When the TSA
   answers with an HTTP status (Certum replies `400` to a SHA-1 query, for example), the server
   was reached: it is not a DNS, network or firewall problem. Those cases now report the status
   and the endpoint that answered, and point at what the authority expects.

Before:

```
Timestamp Authority (TSA) service error.
Check TSA endpoint and DNS/network/firewall connectivity from this server.
```

After, for `Server returned HTTP response code: 400 for URL: http://time.certum.pl`:

```
Timestamp Authority (TSA) rejected the request with HTTP status 400: http://time.certum.pl
The server was reached, so this is not a DNS/network/firewall problem.
Check what the authority expects: hash algorithm, policy OID and authentication.
```

`UnknownHostException` and `Invalid TSA` keep the existing message: there the connectivity hint is
correct.

This is the first of the three parts of #8145. The remaining ones — moving the hash resolution out
of the handler into a dedicated class, and exposing the TSA hash algorithm in the TSA policy — come
in separate PRs.

## 🧪 How to test

Unit tests cover both behaviors:

```bash
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --filter JSignPdfHandlerTest
```

Reverting `lib/Handler/SignEngine/JSignPdfHandler.php` alone makes the four new data sets fail.

With a real TSA, configure one that rejects SHA-1 on a LibreSign older than 15.0 (JSignPdf 2.3.0)
and sign a document: the message now names the HTTP status, and `nextcloud.log` carries the full
Java error.

## ⚙️ API / Back‑end changes

- [x] `signWrapper()` logs the JSignPdf error before the checks that translate it into a friendly message
- [x] `checkTsaError()` reports an HTTP rejection as a rejection, not as a connectivity failure
- [x] Unit and/or integration tests added – *required for backend changes*

No API, capability or documentation change: the messages are internal error strings.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Infection on the changed lines: 29/31 mutants killed (93% covered MSI, 100% mutation code
  coverage). The two survivors rewrite the concatenation of the log message itself; the test
  asserts that the original JSignPdf message reaches the log, not the exact wording of the prefix.
- [x] Psalm and php-cs-fixer clean on the changed files

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
