### PR TITLE
test: cover the manual phone entry rules

### DIFF
--- a/tests/php/Unit/Collaboration/Collaborators/ManualPhonePluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/ManualPhonePluginTest.php
@@ -17,14 +17,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ManualPhonePluginTest extends TestCase {
-	#[DataProvider('providerSearchScenarios')]
-	public function testSearchReturnsManualEntryOnlyWhenValid(
+	#[DataProvider('providerValidPhoneNumbers')]
+	public function testSearchAddsAnExactManualEntryForAValidPhoneNumber(
 		string $method,
+		string $search,
 		string $rawSearch,
-		?string $normalized,
+		string $expectedRawSearch,
 		string $defaultRegion,
-		?string $expectedRegionParam,
-		int $expectedCount,
+		?string $expectedRegion,
+		string $standardFormat,
+		string $expectedShareWith,
 	): void {
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValueString')
@@ -32,60 +34,150 @@ class ManualPhonePluginTest extends TestCase {
 			->willReturn($defaultRegion);
 
 		$phoneUtil = $this->createMock(IPhoneNumberUtil::class);
-		$phoneUtil->method('convertToStandardFormat')
-			->with($rawSearch, $expectedRegionParam)
-			->willReturn($normalized);
+		$phoneUtil->expects($this->once())
+			->method('convertToStandardFormat')
+			->with($expectedRawSearch, $expectedRegion)
+			->willReturn($standardFormat);
 
 		$context = new SignerSearchContext();
-		$context->set($method, $normalized ?? '', $rawSearch);
+		$context->set($method, $search, $rawSearch);
 
 		$plugin = new ManualPhonePlugin($config, $phoneUtil, $context);
 
 		$searchResult = new SearchResult();
-		$plugin->search($normalized ?? '', 10, 0, $searchResult);
+		$hasMore = $plugin->search($search, 10, 0, $searchResult);
 
 		$results = $searchResult->asArray();
-		$items = array_merge($results['manual-phone'] ?? [], $results['exact']['manual-phone'] ?? []);
-		$this->assertCount($expectedCount, $items);
-		if ($expectedCount > 0) {
-			$this->assertSame(ManualPhonePlugin::TYPE_SIGNER_MANUAL_PHONE, $items[0]['value']['shareType']);
-			$this->assertSame($normalized, $items[0]['value']['shareWith']);
-		}
+		$exact = $results['exact']['manual-phone'] ?? [];
+		$wide = $results['manual-phone'] ?? [];
+
+		$this->assertFalse($hasMore, 'The manual entry is the only result this plugin can offer');
+		$this->assertEmpty($wide, 'A manual entry is always an exact match');
+		$this->assertCount(1, $exact);
+		$this->assertSame($expectedShareWith, $exact[0]['label']);
+		$this->assertSame($expectedShareWith, $exact[0]['shareWithDisplayNameUnique']);
+		$this->assertSame($method, $exact[0]['method']);
+		$this->assertSame($expectedShareWith, $exact[0]['value']['shareWith']);
+		$this->assertSame(ManualPhonePlugin::TYPE_SIGNER_MANUAL_PHONE, $exact[0]['value']['shareType']);
 	}
 
-	public static function providerSearchScenarios(): array {
+	#[DataProvider('providerSearchesWithoutAPhoneNumberToValidate')]
+	public function testSearchDoesNotValidateWhenThereIsNoPhoneNumberToOffer(
+		string $method,
+		string $search,
+		string $contextSearch,
+		string $rawSearch,
+	): void {
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->never())
+			->method('getSystemValueString');
+
+		$phoneUtil = $this->createMock(IPhoneNumberUtil::class);
+		$phoneUtil->expects($this->never())
+			->method('convertToStandardFormat');
+
+		$context = new SignerSearchContext();
+		$context->set($method, $contextSearch, $rawSearch);
+
+		$plugin = new ManualPhonePlugin($config, $phoneUtil, $context);
+
+		$searchResult = new SearchResult();
+		$hasMore = $plugin->search($search, 10, 0, $searchResult);
+
+		$results = $searchResult->asArray();
+
+		$this->assertFalse($hasMore);
+		$this->assertEmpty($results['exact']['manual-phone'] ?? []);
+		$this->assertEmpty($results['manual-phone'] ?? []);
+	}
+
+	public function testSearchDoesNotOfferANumberRejectedByThePhoneNumberUtil(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueString')
+			->with('default_phone_region', '')
+			->willReturn('BR');
+
+		$phoneUtil = $this->createMock(IPhoneNumberUtil::class);
+		$phoneUtil->expects($this->once())
+			->method('convertToStandardFormat')
+			->with('123', 'BR')
+			->willReturn(null);
+
+		$context = new SignerSearchContext();
+		$context->set('sms', '123', '123');
+
+		$plugin = new ManualPhonePlugin($config, $phoneUtil, $context);
+
+		$searchResult = new SearchResult();
+		$hasMore = $plugin->search('123', 10, 0, $searchResult);
+
+		$results = $searchResult->asArray();
+
+		$this->assertFalse($hasMore);
+		$this->assertEmpty($results['exact']['manual-phone'] ?? []);
+		$this->assertEmpty($results['manual-phone'] ?? []);
+	}
+
+	public static function providerValidPhoneNumbers(): array {
 		return [
-			'non phone method' => [
-				'method' => 'email',
-				'rawSearch' => '21987654321',
-				'normalized' => '+5521987654321',
-				'defaultRegion' => 'BR',
-				'expectedRegionParam' => 'BR',
-				'expectedCount' => 0,
-			],
-			'invalid number' => [
-				'method' => 'sms',
-				'rawSearch' => '123',
-				'normalized' => null,
-				'defaultRegion' => 'BR',
-				'expectedRegionParam' => 'BR',
-				'expectedCount' => 0,
-			],
-			'valid number' => [
+			'national number with a default region' => [
 				'method' => 'whatsapp',
+				'search' => '+5521987654321',
 				'rawSearch' => '21987654321',
-				'normalized' => '+5521987654321',
+				'expectedRawSearch' => '21987654321',
 				'defaultRegion' => 'BR',
-				'expectedRegionParam' => 'BR',
-				'expectedCount' => 1,
+				'expectedRegion' => 'BR',
+				'standardFormat' => '+5521987654321',
+				'expectedShareWith' => '+5521987654321',
 			],
-			'valid e164 without default region' => [
+			'e164 number without a default region' => [
 				'method' => 'sms',
+				'search' => '+12025551234',
 				'rawSearch' => '+12025551234',
-				'normalized' => '+12025551234',
+				'expectedRawSearch' => '+12025551234',
 				'defaultRegion' => '',
-				'expectedRegionParam' => null,
-				'expectedCount' => 1,
+				'expectedRegion' => null,
+				'standardFormat' => '+12025551234',
+				'expectedShareWith' => '+12025551234',
+			],
+			'surrounding whitespace is discarded' => [
+				'method' => 'signal',
+				'search' => '  +5521987654321  ',
+				'rawSearch' => "\t21987654321 ",
+				'expectedRawSearch' => '21987654321',
+				'defaultRegion' => 'BR',
+				'expectedRegion' => 'BR',
+				'standardFormat' => '+55 21 98765-4321',
+				'expectedShareWith' => '+5521987654321',
+			],
+		];
+	}
+
+	public static function providerSearchesWithoutAPhoneNumberToValidate(): array {
+		return [
+			'method that does not use a phone number' => [
+				'method' => 'email',
+				'search' => '+5521987654321',
+				'contextSearch' => '+5521987654321',
+				'rawSearch' => '21987654321',
+			],
+			'empty search' => [
+				'method' => 'sms',
+				'search' => '',
+				'contextSearch' => '',
+				'rawSearch' => '21987654321',
+			],
+			'search made only of whitespace' => [
+				'method' => 'sms',
+				'search' => '   ',
+				'contextSearch' => '   ',
+				'rawSearch' => '21987654321',
+			],
+			'context without the raw search typed by the user' => [
+				'method' => 'sms',
+				'search' => '+5521987654321',
+				'contextSearch' => '',
+				'rawSearch' => '',
 			],
 		];
 	}


### PR DESCRIPTION
Related to: #8053

## 📝 Summary

Infection on `lib/Collaboration/Collaborators/ManualPhonePlugin.php` reported 18 mutants, 5 escaped and a Covered MSI of 72%. Running it with `--with-uncovered` shows 22 mutants and 81% mutation code coverage: 4 mutants on lines 43 and 52 were never reached, because no test executed the early return for a context without a raw search, or the one for a number the phone number util rejects.

The dataset written for the rejected number did not reach it. It passed the normalized value as the search term, so the plugin returned on the empty search before ever calling `convertToStandardFormat()`.

This PR changes tests only.

What the tests now protect:

* the return value of `search()`, which was never asserted;
* the exact and the wide result sets, kept apart instead of merged before counting;
* the whole payload of the offered entry — `label`, `shareWithDisplayNameUnique`, `method` and both values — instead of the share type alone;
* the two early returns that had no test at all;
* the trimming of the search and of the raw search, through a scenario with surrounding whitespace on both;
* that neither the configuration nor the phone number util is touched when there is no number to offer.

| | before | after |
| --- | ---: | ---: |
| Generated mutants | 18 | 22 |
| Killed | 13 | 22 |
| Escaped | 5 | 0 |
| Not covered | 4 | 0 |
| Covered Code MSI | 72% | 100% |

The single test method became three: the valid number, with a data provider for the national number with a default region, the E164 number without one and the whitespace case; the searches that must not be validated at all, with a data provider for the non-phone method, the empty search, the whitespace-only search and the context without a raw search; and the number rejected by the phone number util.

## 🧪 How to test

```bash
composer test:unit -- --filter ManualPhonePluginTest
```

Expected result:

```
OK (8 tests, 51 assertions)
```

Infection, scoped to this source file:

```bash
composer mutation:test -- \
  lib/Collaboration/Collaborators/ManualPhonePlugin.php \
  --show-mutations \
  --with-uncovered \
  --threads=1
```

Expected result:

```
22 mutations were generated:
      22 mutants were killed by Test Framework

Metrics:
         Mutation Score Indicator (MSI): 100%
         Mutation Code Coverage: 100%
         Covered Code MSI: 100%
```

One thread is needed here for the same reason described in #8230: with more threads the run reports errors instead of real results.

## ⚙️ API / Back‑end changes

- [x] Tests only. No production code, no API and no OpenAPI change.
- [x] Unit tests added — the whole PR is the test improvement.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] `php-cs-fixer` and `php -l` pass on the changed file.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
