### PR TITLE
fix: detect that the signer search has more results

### DIFF
--- a/lib/Collaboration/Collaborators/SignerPlugin.php
+++ b/lib/Collaboration/Collaborators/SignerPlugin.php
@@ -69,10 +69,6 @@ class SignerPlugin implements ISearchPlugin {
 		return $hasMore;
 	}
 
-	private function canValidateMethod(string $method): bool {
-		return in_array($method, ['email', 'account'], true);
-	}
-
 	private function rowToSearchResultItem(array $row): array {
 		$item = [
 			'label' => $row['display_name'],

--- a/lib/Collaboration/Collaborators/SignerPlugin.php
+++ b/lib/Collaboration/Collaborators/SignerPlugin.php
@@ -37,20 +37,18 @@ class SignerPlugin implements ISearchPlugin {
 		$user = $this->userSession->getUser()->getUID();
 		$method = $this->getMethod();
 
-		$limit++;
 		$identifiers = $this->identifyMethodMapper->searchByIdentifierValue(
 			$search,
 			$user,
 			$method,
-			$limit,
+			$limit + 1,
 			$offset,
 		);
 
 		$result = ['wide' => [], 'exact' => []];
 
-		$hasMore = false;
-		if (count($identifiers) > $limit) {
-			$hasMore = true;
+		$hasMore = count($identifiers) > $limit;
+		if ($hasMore) {
 			array_pop($identifiers);
 		}
 

--- a/tests/php/Unit/Collaboration/Collaborators/SignerPluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/SignerPluginTest.php
@@ -159,9 +159,15 @@ class SignerPluginTest extends TestCase {
 		$this->assertCount(1, $exactResults, 'Should match case-insensitively');
 	}
 
-	public function testSearchHandlesPagination(): void {
+	#[DataProvider('providerPaginationScenarios')]
+	public function testSearchTrimsTheRowUsedToDetectMoreResults(
+		int $limit,
+		int $rowsFound,
+		bool $expectedHasMore,
+		int $expectedCount,
+	): void {
 		$identifiers = [];
-		for ($i = 0; $i < 31; $i++) {
+		for ($i = 0; $i < $rowsFound; $i++) {
 			$identifiers[] = [
 				'identifier_value' => 'user' . $i . '@example.com',
 				'identifier_key' => 'email',
@@ -170,8 +176,9 @@ class SignerPluginTest extends TestCase {
 		}
 
 		$mapper = $this->createMock(IdentifyMethodMapper::class);
-		$mapper->method('searchByIdentifierValue')
-			->with('user', 'current', 'email', 26, 0)
+		$mapper->expects($this->once())
+			->method('searchByIdentifierValue')
+			->with('user', 'current', 'email', $limit + 1, 0)
 			->willReturn($identifiers);
 
 		$user = $this->createMock(IUser::class);
@@ -190,13 +197,13 @@ class SignerPluginTest extends TestCase {
 		);
 
 		$searchResult = new SearchResult();
-		$hasMore = $plugin->search('user', 25, 0, $searchResult);
+		$hasMore = $plugin->search('user', $limit, 0, $searchResult);
 
 		$results = $searchResult->asArray();
 		$allResults = array_merge($results['signer'] ?? [], $results['exact']['signer'] ?? []);
 
-		$this->assertTrue($hasMore, 'Should indicate more results available');
-		$this->assertCount(30, $allResults, 'Should return all results after trimming one');
+		$this->assertSame($expectedHasMore, $hasMore);
+		$this->assertCount($expectedCount, $allResults);
 	}
 
 	public function testSearchRespectOffset(): void {
@@ -404,6 +411,28 @@ class SignerPluginTest extends TestCase {
 				'expectedWideCount' => 0,
 				'expectedExactCount' => 1,
 				'expectedHasMore' => false,
+			],
+		];
+	}
+	public static function providerPaginationScenarios(): array {
+		return [
+			'one row more than the page can show' => [
+				'limit' => 25,
+				'rowsFound' => 26,
+				'expectedHasMore' => true,
+				'expectedCount' => 25,
+			],
+			'exactly one page' => [
+				'limit' => 25,
+				'rowsFound' => 25,
+				'expectedHasMore' => false,
+				'expectedCount' => 25,
+			],
+			'less than one page' => [
+				'limit' => 25,
+				'rowsFound' => 10,
+				'expectedHasMore' => false,
+				'expectedCount' => 10,
 			],
 		];
 	}

--- a/tests/php/Unit/Collaboration/Collaborators/SignerPluginTest.php
+++ b/tests/php/Unit/Collaboration/Collaborators/SignerPluginTest.php
@@ -126,14 +126,11 @@ class SignerPluginTest extends TestCase {
 		$this->assertCount(2, $exactResults, 'Should have 2 exact results (matched by value and display name)');
 	}
 
-	public function testSearchIsCaseInsensitive(): void {
-		$identifiers = [
-			['identifier_value' => 'Test@Example.COM', 'identifier_key' => 'email', 'display_name' => 'Test User'],
-		];
-
+	#[DataProvider('providerCaseInsensitiveMatches')]
+	public function testSearchIsCaseInsensitive(string $search, array $row): void {
 		$mapper = $this->createMock(IdentifyMethodMapper::class);
 		$mapper->method('searchByIdentifierValue')
-			->willReturn($identifiers);
+			->willReturn([$row]);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('current');
@@ -142,7 +139,7 @@ class SignerPluginTest extends TestCase {
 		$userSession->method('getUser')->willReturn($user);
 
 		$context = new SignerSearchContext();
-		$context->set('email', 'test@example.com');
+		$context->set('email', $search);
 
 		$plugin = new SignerPlugin(
 			$mapper,
@@ -151,7 +148,7 @@ class SignerPluginTest extends TestCase {
 		);
 
 		$searchResult = new SearchResult();
-		$plugin->search('test@example.com', 25, 0, $searchResult);
+		$plugin->search($search, 25, 0, $searchResult);
 
 		$results = $searchResult->asArray();
 		$exactResults = $results['exact']['signer'] ?? [];
@@ -278,7 +275,7 @@ class SignerPluginTest extends TestCase {
 		$this->assertSame('sms', $items[0]['method']);
 	}
 
-	public function testSearchReturnsCorrectShareType(): void {
+	public function testSearchDescribesTheSignerFoundInTheIdentifyMethods(): void {
 		$identifiers = [
 			['identifier_value' => 'test@example.com', 'identifier_key' => 'email', 'display_name' => 'Test User'],
 		];
@@ -309,6 +306,10 @@ class SignerPluginTest extends TestCase {
 		$items = array_merge($results['signer'] ?? [], $results['exact']['signer'] ?? []);
 
 		$this->assertCount(1, $items);
+		$this->assertSame('Test User', $items[0]['label']);
+		$this->assertSame('test@example.com', $items[0]['shareWithDisplayNameUnique']);
+		$this->assertSame('email', $items[0]['method']);
+		$this->assertSame('test@example.com', $items[0]['value']['shareWith']);
 		$this->assertSame(SignerPlugin::TYPE_SIGNER, $items[0]['value']['shareType']);
 	}
 
@@ -414,6 +415,24 @@ class SignerPluginTest extends TestCase {
 			],
 		];
 	}
+
+	public static function providerCaseInsensitiveMatches(): array {
+		return [
+			'stored identifier written in another case' => [
+				'search' => 'test@example.com',
+				'row' => ['identifier_value' => 'Test@Example.COM', 'identifier_key' => 'email', 'display_name' => 'Test User'],
+			],
+			'search typed in another case' => [
+				'search' => 'TEST@Example.com',
+				'row' => ['identifier_value' => 'test@example.com', 'identifier_key' => 'email', 'display_name' => 'Test User'],
+			],
+			'display name and search written in different cases' => [
+				'search' => 'MARIA SILVA',
+				'row' => ['identifier_value' => 'someone@example.com', 'identifier_key' => 'email', 'display_name' => 'Maria Silva'],
+			],
+		];
+	}
+
 	public static function providerPaginationScenarios(): array {
 		return [
 			'one row more than the page can show' => [


### PR DESCRIPTION
Related to: #8053

## 📝 Summary

Infection on `lib/Collaboration/Collaborators/SignerPlugin.php` reported 21 mutants, 6 escaped and a Covered MSI of 71%. One of them, `>` into `>=` on line 52, pointed at a real problem rather than a missing assertion.

`$limit` was incremented before the mapper call and the extra row was then looked for beyond that same incremented limit. As `IdentifyMethodMapper::searchByIdentifierValue()` applies `setMaxResults()`, it can never return more rows than it was asked for, so `count($identifiers) > $limit` was never true: the plugin never reported more results and never removed the extra row it had asked for.

What a user sees: a search with more signers than the page can show returns one item too many, and that item appears again at the top of the next page, because the offset is applied in SQL. The flag itself does not reach the API today — `IdentifyController::search()` destructures `[$result]` and drops the second element returned by the collaborators search — so the visible part is the extra item and its repetition.

The mapper is still asked for one row beyond the page, and that row is now what tells the plugin there is more to show, in the same way `AccountPhonePlugin` and `ContactPhonePlugin` already do it.

The old pagination test could not catch this: it returned 31 rows from a mapper call made with a limit of 26. The scenarios now stay within what the mapper can answer and cover the boundary, where the number of rows found is exactly the size of the page.

This PR also removes `canValidateMethod()`. It was private and had no caller anywhere in the project, so it never ran and no mutant could reach it.

The remaining escaped mutants were assertions missing from the tests: nothing checked the label and the value offered for a signer, and the search term was never written in a different case than the stored data, so lowercasing it was not covered on either side of the comparison.

| | before | after |
| --- | ---: | ---: |
| Generated mutants | 21 | 22 |
| Killed | 15 | 22 |
| Escaped | 6 | 0 |
| Covered Code MSI | 71% | 100% |

The three commits are meant to be read in order: the fix with its regression test, the removal of the unused method, then the remaining test improvements.

## 🧪 How to test

```bash
composer test:unit -- --filter SignerPluginTest
```

Expected result:

```
OK (18 tests, 44 assertions)
```

To see the bug, check out the first commit and revert only `lib/Collaboration/Collaborators/SignerPlugin.php`. The `one row more than the page can show` scenario then fails with:

```
Failed asserting that false is identical to true.
```

Infection, scoped to this source file:

```bash
composer mutation:test -- \
  lib/Collaboration/Collaborators/SignerPlugin.php \
  --show-mutations \
  --with-uncovered \
  --threads=1
```

Expected result:

```
22 mutations were generated:
      22 mutants were killed by Test Framework

Metrics:
         Mutation Score Indicator (MSI): 100%
         Mutation Code Coverage: 100%
         Covered Code MSI: 100%
```

The classes around this one were run as well: `IdentifyControllerTest`, `ResultFormatterTest`, `ShareTypeResolverTest` and the four collaborator plugins — 82 tests, 215 assertions, all passing. Psalm reports no error on the changed file.

## ⚙️ API / Back‑end changes

- [x] The signer search now reports when there are more results than the page can show, and returns the page size instead of one item more.
- [x] The unused private method `SignerPlugin::canValidateMethod()` was removed.
- [x] Unit tests added, including a regression test for the pagination boundary.
- [x] No API, capabilities or OpenAPI change.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] `php-cs-fixer`, `php -l` and psalm pass on the changed files.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
