### PR TITLE
refactor: centralize Nextcloud user folder access

### DIFF
--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -10,7 +10,6 @@ namespace OCA\Libresign\Helper;
 
 use InvalidArgumentException;
 use OC\AppFramework\Http;
-use OC\User\NoUserException;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileElement;
 use OCA\Libresign\Db\FileElementMapper;
@@ -39,6 +38,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\User\Exceptions\UserNotFoundException;
 
 class ValidateHelper {
 	/** @var \OCP\Files\File[] */
@@ -519,7 +519,7 @@ class ValidateHelper {
 		}
 		try {
 			$file = $this->root->getUserFolder($userId)->getFirstNodeById($nodeId);
-		} catch (NoUserException) {
+		} catch (UserNotFoundException) {
 			// TRANSLATORS Validation error when the Nextcloud user associated with a file or signature request cannot be found.
 			throw new LibresignException($this->l10n->t('User not found.'));
 		} catch (NotPermittedException) {

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -36,7 +36,6 @@ use OCP\Config\IUserConfig;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
@@ -58,7 +57,6 @@ class AccountService {
 		private SignRequestMapper $signRequestMapper,
 		private IUserManager $userManager,
 		private IAccountManager $accountManager,
-		private IRootFolder $root,
 		private IMimeTypeDetector $mimeTypeDetector,
 		private FileMapper $fileMapper,
 		private FileTypeMapper $fileTypeMapper,
@@ -132,8 +130,8 @@ class AccountService {
 
 			$nodeId = $this->fileData->getNodeId();
 
-			$fileToSign = $this->root->getUserFolder($this->fileData->getUserId())->getFirstNodeById($nodeId);
-			if ($fileToSign) {
+			$fileToSign = $this->folderService->getReadableNodeById($this->fileData->getUserId(), $nodeId);
+			if ($fileToSign instanceof File) {
 				$this->fileToSign = $fileToSign;
 			}
 		}

--- a/lib/Service/Envelope/EnvelopeFileRelocator.php
+++ b/lib/Service/Envelope/EnvelopeFileRelocator.php
@@ -20,9 +20,7 @@ class EnvelopeFileRelocator {
 	}
 
 	public function ensureFileInEnvelopeFolder(Node $sourceNode, int $envelopeFolderId, IUser $userManager): Node {
-		$this->folderService->setUserId($userManager->getUID());
-		$userRootFolder = $this->folderService->getUserRootFolder();
-		$envelopeFolder = $userRootFolder->getFirstNodeById($envelopeFolderId);
+		$envelopeFolder = $this->folderService->getCreatableFolderById($userManager->getUID(), $envelopeFolderId);
 
 		if (!$envelopeFolder instanceof \OCP\Files\Folder) {
 			throw new LibresignException('Envelope folder not found');

--- a/lib/Service/Envelope/EnvelopeService.php
+++ b/lib/Service/Envelope/EnvelopeService.php
@@ -131,10 +131,7 @@ class EnvelopeService {
 			throw new LibresignException('Envelope does not have a user');
 		}
 
-		$this->folderService->setUserId($userId);
-		$userRootFolder = $this->folderService->getUserRootFolder();
-
-		$envelopeFolderNode = $userRootFolder->getFirstNodeById($envelope->getNodeId());
+		$envelopeFolderNode = $this->folderService->getCreatableFolderById($userId, $envelope->getNodeId());
 		if (!$envelopeFolderNode instanceof \OCP\Files\Folder) {
 			throw new LibresignException('Envelope folder not found');
 		}

--- a/lib/Service/EnvelopeService.php
+++ b/lib/Service/EnvelopeService.php
@@ -130,10 +130,7 @@ class EnvelopeService {
 			throw new LibresignException('Envelope does not have a user');
 		}
 
-		$this->folderService->setUserId($userId);
-		$userRootFolder = $this->folderService->getUserRootFolder();
-
-		$envelopeFolderNode = $userRootFolder->getFirstNodeById($envelope->getNodeId());
+		$envelopeFolderNode = $this->folderService->getCreatableFolderById($userId, $envelope->getNodeId());
 		if (!$envelopeFolderNode instanceof \OCP\Files\Folder) {
 			throw new LibresignException('Envelope folder not found');
 		}

--- a/lib/Service/EnvelopeService.php
+++ b/lib/Service/EnvelopeService.php
@@ -130,7 +130,10 @@ class EnvelopeService {
 			throw new LibresignException('Envelope does not have a user');
 		}
 
-		$envelopeFolderNode = $this->folderService->getCreatableFolderById($userId, $envelope->getNodeId());
+		$this->folderService->setUserId($userId);
+		$userRootFolder = $this->folderService->getUserRootFolder();
+
+		$envelopeFolderNode = $userRootFolder->getFirstNodeById($envelope->getNodeId());
 		if (!$envelopeFolderNode instanceof \OCP\Files\Folder) {
 			throw new LibresignException('Envelope folder not found');
 		}

--- a/lib/Service/File/EnvelopeAssembler.php
+++ b/lib/Service/File/EnvelopeAssembler.php
@@ -14,8 +14,8 @@ use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Service\FileElementService;
+use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\IdentifyMethodService;
-use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -24,7 +24,7 @@ class EnvelopeAssembler {
 		private SignRequestMapper $signRequestMapper,
 		private IdentifyMethodService $identifyMethodService,
 		private FileMapper $fileMapper,
-		private IRootFolder $root,
+		private FolderService $folderService,
 		private IURLGenerator $urlGenerator,
 		private SignersLoader $signersLoader,
 		private ?CertificateChainService $certificateChainService,
@@ -51,7 +51,7 @@ class EnvelopeAssembler {
 		$fileData->metadata = $childMetadata;
 
 		$nodeId = $childFile->getSignedNodeId() ?: $childFile->getNodeId();
-		$fileNode = $this->root->getUserFolder($childFile->getUserId())->getFirstNodeById($nodeId);
+		$fileNode = $this->folderService->getReadableNodeById($childFile->getUserId(), $nodeId);
 		if ($fileNode instanceof \OCP\Files\File) {
 			if (method_exists($fileNode, 'getSize')) {
 				$fileData->size = $fileNode->getSize();
@@ -137,7 +137,7 @@ class EnvelopeAssembler {
 
 		if ($options->isValidateFile() && $childFile->getSignedNodeId()) {
 			try {
-				$fileNode = $this->root->getUserFolder($childFile->getUserId())->getFirstNodeById($childFile->getSignedNodeId());
+				$fileNode = $this->folderService->getReadableNodeById($childFile->getUserId(), $childFile->getSignedNodeId());
 				if ($fileNode instanceof \OCP\Files\File) {
 					if ($this->certificateChainService !== null) {
 						$certData = $this->certificateChainService->getCertificateChain($fileNode, $childFile, $options);

--- a/lib/Service/File/FileContentProvider.php
+++ b/lib/Service/File/FileContentProvider.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OCA\Libresign\Service\File;
 
 use OCA\Libresign\Exception\LibresignException;
-use OCP\Files\IRootFolder;
+use OCA\Libresign\Service\FolderService;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
@@ -19,7 +19,7 @@ class FileContentProvider {
 	public function __construct(
 		private IClientService $client,
 		private MimeService $mimeService,
-		private IRootFolder $root,
+		private FolderService $folderService,
 		private LoggerInterface $logger,
 		private IL10N $l10n,
 	) {
@@ -132,7 +132,7 @@ class FileContentProvider {
 				$nodeId = $file->getNodeId();
 			}
 
-			$fileNode = $this->root->getUserFolder($file->getUserId())->getFirstNodeById($nodeId);
+			$fileNode = $this->folderService->getReadableNodeById($file->getUserId(), $nodeId);
 
 			if (!$fileNode instanceof \OCP\Files\File) {
 				// TRANSLATORS Error shown when the requested document cannot be found.

--- a/lib/Service/File/FileListService.php
+++ b/lib/Service/File/FileListService.php
@@ -22,13 +22,13 @@ use OCA\Libresign\Enum\SignerGeolocationCollectionStatus;
 use OCA\Libresign\Enum\SignerGeolocationMode;
 use OCA\Libresign\ResponseDefinitions;
 use OCA\Libresign\Service\FileElementService;
+use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SignatureRejection\SignatureRejectionVisibilityService;
 use OCA\Libresign\Service\SignerGeolocation\SignerGeolocationMetadataValidator;
 use OCA\Libresign\Service\SignerGeolocation\SignerGeolocationPolicyService;
 use OCP\AppFramework\Db\Entity;
 use OCP\Files\File as NodeFile;
-use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -57,7 +57,7 @@ class FileListService {
 		private IAppConfig $appConfig,
 		private IL10N $l10n,
 		private IUserManager $userManager,
-		private IRootFolder $root,
+		private FolderService $folderService,
 		private SignatureRejectionVisibilityService $signatureRejectionVisibilityService,
 	) {
 	}
@@ -998,7 +998,7 @@ class FileListService {
 			return 0;
 		}
 		try {
-			$fileNode = $this->root->getUserFolder($file->getUserId())->getFirstNodeById($nodeId);
+			$fileNode = $this->folderService->getReadableNodeById($file->getUserId(), $nodeId);
 			if ($fileNode instanceof NodeFile && method_exists($fileNode, 'getSize')) {
 				return max(0, (int)$fileNode->getSize());
 			}

--- a/lib/Service/File/MetadataLoader.php
+++ b/lib/Service/File/MetadataLoader.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
 namespace OCA\Libresign\Service\File;
 
 use OCA\Libresign\Db\File;
+use OCA\Libresign\Service\FolderService;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 use stdClass;
 
 class MetadataLoader {
 	public function __construct(
-		private IRootFolder $root,
+		private FolderService $folderService,
 		private IMimeTypeDetector $mimeTypeDetector,
 		private IURLGenerator $urlGenerator,
 		private FileContentProvider $contentProvider,
@@ -79,7 +79,7 @@ class MetadataLoader {
 			$nodeId = $file->getNodeId();
 		}
 
-		$fileNode = $this->root->getUserFolder($file->getUserId())->getFirstNodeById($nodeId);
+		$fileNode = $this->folderService->getReadableNodeById($file->getUserId(), $nodeId);
 
 		if (!$fileNode instanceof \OCP\Files\File && !$fileNode instanceof \OCP\Files\Folder) {
 			throw new \OCA\Libresign\Exception\LibresignException('File not found', 404);

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -39,7 +39,6 @@ use OCA\Libresign\Service\File\SignersLoader;
 use OCA\Libresign\Service\File\UploadProcessor;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
@@ -80,7 +79,6 @@ class FileService {
 		protected Pkcs12Handler $pkcs12Handler,
 		protected DocMdpHandler $docMdpHandler,
 		protected PdfValidator $pdfValidator,
-		private IRootFolder $root,
 		protected LoggerInterface $logger,
 		protected IL10N $l10n,
 		private EnvelopeService $envelopeService,
@@ -366,7 +364,7 @@ class FileService {
 		if (!$nodeId) {
 			$nodeId = $this->file->getNodeId();
 		}
-		$fileToValidate = $this->root->getUserFolder($this->file->getUserId())->getFirstNodeById($nodeId);
+		$fileToValidate = $this->folderService->getReadableNodeById($this->file->getUserId(), $nodeId);
 		if (!$fileToValidate instanceof \OCP\Files\File) {
 			// TRANSLATORS Error shown when the requested document cannot be found.
 			throw new LibresignException($this->l10n->t('File not found'), 404);

--- a/lib/Service/FolderService.php
+++ b/lib/Service/FolderService.php
@@ -16,6 +16,7 @@ use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
 use OCP\Files\ISetupManager;
+use OCP\Files\IUserFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -27,7 +28,6 @@ use OCP\Lock\LockedException;
 
 class FolderService {
 	protected IAppData $appData;
-	private ?string $initializedFilesystemUser = null;
 	public function __construct(
 		private IRootFolder $root,
 		protected IAppDataFactory $appDataFactory,
@@ -43,9 +43,6 @@ class FolderService {
 	}
 
 	public function setUserId(?string $userId): void {
-		if ($this->userId !== $userId) {
-			$this->initializedFilesystemUser = null;
-		}
 		$this->userId = $userId;
 	}
 
@@ -53,18 +50,39 @@ class FolderService {
 		return $this->userId;
 	}
 
+	public function getUserFolder(string $userId): IUserFolder {
+		return $this->root->getUserFolder($userId);
+	}
+
+	public function getReadableNodeById(string $userId, int $nodeId): ?Node {
+		foreach ($this->getUserFolder($userId)->getById($nodeId) as $node) {
+			if ($node->isReadable()) {
+				return $node;
+			}
+		}
+		return null;
+	}
+
+	public function getCreatableFolderById(string $userId, int $nodeId): ?Folder {
+		foreach ($this->getUserFolder($userId)->getById($nodeId) as $node) {
+			if ($node instanceof Folder && $node->isCreatable()) {
+				return $node;
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * Get the user's root folder (full home), not the LibreSign container.
 	 *
 	 * @throws LibresignException
 	 */
-	public function getUserRootFolder(): Folder {
+	public function getUserRootFolder(): IUserFolder {
 		if (!$this->userId) {
 			throw new LibresignException('Invalid user to resolve folder');
 		}
 
-		$this->initializeUserFilesystem($this->userId);
-		return $this->root->getUserFolder($this->userId);
+		return $this->getUserFolder($this->userId);
 	}
 
 	/**
@@ -93,8 +111,7 @@ class FolderService {
 		// For guests, files are stored in appdata, not in user folder
 		// Skip getUserFolder search for guests to avoid false positives
 		if ($this->getUserId() && !$this->groupManager->isInGroup($this->getUserId(), 'guest_app')) {
-			$this->initializeUserFilesystem($this->getUserId());
-			$file = $this->root->getUserFolder($this->getUserId())->getFirstNodeById($nodeId);
+			$file = $this->getReadableNodeById($this->getUserId(), $nodeId);
 			if ($file instanceof File) {
 				return $file;
 			}
@@ -116,9 +133,9 @@ class FolderService {
 
 	protected function getContainerFolder(): Folder {
 		if ($this->getUserId() && !$this->groupManager->isInGroup($this->getUserId(), 'guest_app')) {
-			$this->initializeUserFilesystem($this->getUserId());
+			$this->prepareUserFilesystemForWrite($this->getUserId());
 			try {
-				$containerFolder = $this->root->getUserFolder($this->getUserId());
+				$containerFolder = $this->getUserFolder($this->getUserId());
 				if ($containerFolder->isUpdateable()) {
 					return $containerFolder;
 				}
@@ -242,8 +259,7 @@ class FolderService {
 	}
 
 	public function getFileByPath(string $path): Node {
-		$this->initializeUserFilesystem($this->getUserId());
-		$userFolder = $this->root->getUserFolder($this->getUserId());
+		$userFolder = $this->getUserRootFolder();
 		try {
 			return $userFolder->get($path);
 		} catch (NotFoundException) {
@@ -264,8 +280,8 @@ class FolderService {
 		}
 
 		$cleanPath = ltrim($path, '/');
-		$this->initializeUserFilesystem($this->userId);
-		$userFolder = $this->root->getUserFolder($this->userId);
+		$this->prepareUserFilesystemForWrite($this->userId);
+		$userFolder = $this->getUserFolder($this->userId);
 
 		if ($cleanPath === '') {
 			return $userFolder;
@@ -300,18 +316,14 @@ class FolderService {
 		return $folder;
 	}
 
-	protected function initializeUserFilesystem(string $userId): void {
-		if ($this->initializedFilesystemUser === $userId) {
-			return;
-		}
-
-		$this->setupManager->tearDown();
+	private function prepareUserFilesystemForWrite(string $userId): void {
 		$user = $this->userManager->get($userId);
 		if (!$user instanceof IUser) {
 			return;
 		}
 
+		$this->setupManager->tearDown();
 		$this->setupManager->setupForUser($user);
-		$this->initializedFilesystemUser = $userId;
 	}
+
 }

--- a/lib/Service/FolderService.php
+++ b/lib/Service/FolderService.php
@@ -73,7 +73,7 @@ class FolderService {
 	}
 
 	/**
-	 * Get the user's root folder (full home), not the LibreSign container.
+	 * Get the root of the user's visible files, not the LibreSign container.
 	 *
 	 * @throws LibresignException
 	 */
@@ -201,12 +201,14 @@ class FolderService {
 		$userFolder = $this->getFolder();
 
 		if (isset($data['settings']['envelopeFolderId'])) {
-			$envelopeFolder = $userFolder->getFirstNodeById($data['settings']['envelopeFolderId']);
-			if ($envelopeFolder === null || !$envelopeFolder instanceof Folder) {
-				// TRANSLATORS Error shown when the Nextcloud folder that stores envelope documents cannot be found.
-				throw new LibresignException($this->l10n->t('Envelope folder not found'));
+			foreach ($userFolder->getById($data['settings']['envelopeFolderId']) as $node) {
+				if ($node instanceof Folder && $node->isCreatable()) {
+					return $node;
+				}
 			}
-			return $envelopeFolder;
+
+			// TRANSLATORS Error shown when the Nextcloud folder that stores envelope documents cannot be found or is not writable.
+			throw new LibresignException($this->l10n->t('Envelope folder not found'));
 		}
 
 		$folderName = $this->getFolderName($data, $identifier);
@@ -318,7 +320,7 @@ class FolderService {
 
 	private function prepareUserFilesystemForWrite(string $userId): void {
 		$user = $this->userManager->get($userId);
-		if (!$user instanceof IUser) {
+		if (!$user instanceof IUser || $this->setupManager->isSetupComplete($user)) {
 			return;
 		}
 

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -13,7 +13,6 @@ use DateTimeInterface;
 use Exception;
 use InvalidArgumentException;
 use OC\AppFramework\Http as AppFrameworkHttp;
-use OC\User\NoUserException;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\BackgroundJob\SignSingleFileJob;
 use OCA\Libresign\DataObjects\VisibleElementAssoc;
@@ -55,7 +54,6 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
-use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
@@ -67,6 +65,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Security\ICredentialsManager;
 use OCP\Security\ISecureRandom;
+use OCP\User\Exceptions\UserNotFoundException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Sabre\DAV\UUIDUtil;
@@ -99,7 +98,6 @@ class SignFileService {
 		private IAppConfig $appConfig,
 		protected ValidateHelper $validateHelper,
 		private SignerElementsService $signerElementsService,
-		private IRootFolder $root,
 		private IUserSession $userSession,
 		private IDateTimeZone $dateTimeZone,
 		private FileElementMapper $fileElementMapper,
@@ -1515,21 +1513,17 @@ class SignFileService {
 
 	protected function getNodeByIdUsingUid(string $uid, int $nodeId): File {
 		try {
-			$userFolder = $this->root->getUserFolder($uid);
-		} catch (NoUserException $e) {
-			$this->logger->error('[file-access] NoUserException for uid={uid}', ['uid' => $uid]);
+			$fileToSign = $this->folderService->getReadableNodeById($uid, $nodeId);
+		} catch (UserNotFoundException) {
+			$this->logger->error('[file-access] UserNotFoundException for uid={uid}', ['uid' => $uid]);
 			// TRANSLATORS Error shown when the Nextcloud user linked to the signer cannot be found.
 			throw new LibresignException($this->l10n->t('User not found.'));
-		} catch (NotPermittedException $e) {
+		} catch (NotPermittedException) {
 			$this->logger->error('[file-access] NotPermittedException for uid={uid}', ['uid' => $uid]);
 			// TRANSLATORS Permission error shown when the current user cannot perform the requested signing action.
 			throw new LibresignException($this->l10n->t('You do not have permission for this action.'));
-		}
-
-		try {
-			$fileToSign = $userFolder->getFirstNodeById($nodeId);
 		} catch (\Throwable $e) {
-			$this->logger->error('[file-access] Failed getFirstNodeById - nodeId={nodeId} error={error}', [
+			$this->logger->error('[file-access] Failed to resolve node - nodeId={nodeId} error={error}', [
 				'nodeId' => $nodeId,
 				'error' => $e->getMessage(),
 			]);
@@ -1560,9 +1554,7 @@ class SignFileService {
 		}
 
 		try {
-			$userFolder = $this->root->getUserFolder($uid);
-			$node = $userFolder->getFirstNodeById($nodeId);
-			return $node instanceof File;
+			return $this->folderService->getReadableNodeById($uid, $nodeId) instanceof File;
 		} catch (\Throwable $e) {
 			$this->logger->warning('[verify-file] File not accessible - nodeId={nodeId} uid={uid} error={error}', [
 				'nodeId' => $nodeId,
@@ -1602,8 +1594,7 @@ class SignFileService {
 		$uniqueFilename = substr((string)$filename, 0, -strlen($extension) - 1) . '_' . $fileId . '.' . $extension;
 
 		try {
-			/** @var \OCP\Files\Folder */
-			$parentFolder = $this->root->getUserFolder($ownerUid)->getFirstNodeById($originalFile->getParentId());
+			$parentFolder = $originalFile->getParent();
 
 			$this->createdSignedFile = $this->runWithVolatileActiveUser(
 				$owner,
@@ -1661,7 +1652,7 @@ class SignFileService {
 						'errors' => [['message' => $this->l10n->t('File not found')]],
 					]), AppFrameworkHttp::STATUS_NOT_FOUND);
 				}
-				$file = $this->root->getUserFolder($child->getUserId())->getFirstNodeById($nodeId);
+				$file = $this->folderService->getReadableNodeById($child->getUserId(), $nodeId);
 				if ($file instanceof File) {
 					$files[] = $file;
 				}

--- a/tests/php/Unit/Helper/ValidateHelperTest.php
+++ b/tests/php/Unit/Helper/ValidateHelperTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Unit\Helper;
 
-use OC\User\NoUserException;
 use OCA\Libresign\Db\FileElementMapper;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Db\FileTypeMapper;
@@ -38,6 +37,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\User\Exceptions\UserNotFoundException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -585,7 +585,7 @@ final class ValidateHelperTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	public function testValidateIfNodeIdExistsWhenUserNotFound():void {
 		$this->expectExceptionMessage('User not found');
 		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->willThrowException(new NoUserException());
+		$userFolder->method('getFirstNodeById')->willThrowException(new UserNotFoundException());
 		$this->root->method('getUserFolder')->willReturn($userFolder);
 		$this->getValidateHelper()->validateIfNodeIdExists(171);
 	}

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -47,8 +47,6 @@ use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\Files\NotFoundException;
 use OCP\Group\ISubAdmin;
 use OCP\IAppConfig;
@@ -70,7 +68,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private SignRequestMapper&MockObject $signRequestMapper;
 	private IUserManager&MockObject $userManager;
 	private IAccountManager&MockObject $accountManager;
-	private IRootFolder&MockObject $root;
 	private IMimeTypeDetector&MockObject $mimeTypeDetector;
 	private FileMapper&MockObject $fileMapper;
 	private FileTypeMapper&MockObject $fileTypeMapper;
@@ -110,7 +107,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->accountManager = $this->createMock(IAccountManager::class);
-		$this->root = $this->createMock(IRootFolder::class);
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->fileTypeMapper = $this->createMock(FileTypeMapper::class);
@@ -149,7 +145,6 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->signRequestMapper,
 			$this->userManager,
 			$this->accountManager,
-			$this->root,
 			$this->mimeTypeDetector,
 			$this->fileMapper,
 			$this->fileTypeMapper,
@@ -356,56 +351,41 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->getService()->createToSign('uuid', 'username', 'passwordOfUser', 'passwordToSign');
 	}
 
-	public function testGetPdfByUuidWithSuccessAndSignedFile():void {
+	#[DataProvider('provideGetPdfByUuidNodeSelection')]
+	public function testGetPdfByUuidSelectsExpectedNode(
+		int $status,
+		?int $signedNodeId,
+		int $nodeId,
+		int $expectedNodeId,
+	): void {
 		$libresignFile = $this->createMock(\OCA\Libresign\Db\File::class);
 		$libresignFile->method('__call')
-			->willReturnCallback(fn ($method)
-				=> match ($method) {
-					'getSignedNodeId' => 1,
-					'getNodeId' => 1,
-					'getStatus' => \OCA\Libresign\Enum\FileStatus::SIGNED->value,
-				}
-			);
-		$this->fileMapper
-			->method('getByUuid')
-			->willReturn($libresignFile);
-		$node = $this->createMock(\OCP\Files\File::class);
-		$userFolder = $this->createMock(IUserFolder::class);
-		$this->root
-			->method('getUserFolder')
-			->willReturn($userFolder);
-		$userFolder
-			->method('getFirstNodeById')
+			->willReturnCallback(fn ($method) => match ($method) {
+				'getSignedNodeId' => $signedNodeId,
+				'getNodeId' => $nodeId,
+				'getStatus' => $status,
+			});
+
+		$this->fileMapper->method('getByUuid')->with('uuid')->willReturn($libresignFile);
+		$this->fileMapper->method('getStorageUserIdByUuid')->with('uuid')->willReturn('storage-user');
+		$this->folderService->expects($this->once())->method('setUserId')->with('storage-user');
+
+		$node = $this->createMock(File::class);
+		$this->folderService
+			->expects($this->once())
+			->method('getFileByNodeId')
+			->with($expectedNodeId)
 			->willReturn($node);
 
-		$actual = $this->getService()->getPdfByUuid('uuid');
-		$this->assertInstanceOf(\OCP\Files\File::class, $actual);
+		$this->assertSame($node, $this->getService()->getPdfByUuid('uuid'));
 	}
 
-	public function testGetPdfByUuidWithSuccessAndUnignedFile():void {
-		$libresignFile = $this->createMock(\OCA\Libresign\Db\File::class);
-		$libresignFile->method('__call')
-			->willReturnCallback(fn ($method)
-				=> match ($method) {
-					'getSignedNodeId' => 1,
-					'getNodeId' => 1,
-					'getStatus' => \OCA\Libresign\Enum\FileStatus::SIGNED->value,
-				}
-			);
-		$this->fileMapper
-			->method('getByUuid')
-			->willReturn($libresignFile);
-		$node = $this->createMock(\OCP\Files\File::class);
-		$userFolder = $this->createMock(IUserFolder::class);
-		$this->root
-			->method('getUserFolder')
-			->willReturn($userFolder);
-		$userFolder
-			->method('getFirstNodeById')
-			->willReturn($node);
-
-		$actual = $this->getService()->getPdfByUuid('uuid');
-		$this->assertInstanceOf(\OCP\Files\File::class, $actual);
+	public static function provideGetPdfByUuidNodeSelection(): array {
+		return [
+			'signed file uses signed node' => [FileStatus::SIGNED->value, 200, 100, 200],
+			'partially signed file uses signed node' => [FileStatus::PARTIAL_SIGNED->value, 201, 101, 201],
+			'draft file uses original node' => [FileStatus::DRAFT->value, null, 102, 102],
+		];
 	}
 
 	public function testGetPdfByUuidThrowsDoesNotExistWhenNodeNotFound(): void {
@@ -698,16 +678,10 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 						->method('getIdentifyMethodsFromSignRequestId')
 						->willReturn(['email' => [$identifyMethod]]);
 
-					$self->root
-						->method('getById')
-						->will($self->returnValue([]));
-					$folder = $self->createMock(IUserFolder::class);
-					$folder
-						->method('getById')
-						->willReturn([]);
-					$self->root
-						->method('getUserFolder')
-						->willReturn($folder);
+					$self->folderService
+						->method('getReadableNodeById')
+						->with('username', 999)
+						->willReturn(null);
 					return [
 						'uuid' => '12345678-1234-1234-1234-123456789012',
 						'user' => [

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -19,6 +19,7 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Db\UserElement;
 use OCA\Libresign\Db\UserElementMapper;
 use OCA\Libresign\Enum\CRLReason;
+use OCA\Libresign\Enum\FileStatus;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Helper\FileUploadHelper;
@@ -358,13 +359,10 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		int $nodeId,
 		int $expectedNodeId,
 	): void {
-		$libresignFile = $this->createMock(\OCA\Libresign\Db\File::class);
-		$libresignFile->method('__call')
-			->willReturnCallback(fn ($method) => match ($method) {
-				'getSignedNodeId' => $signedNodeId,
-				'getNodeId' => $nodeId,
-				'getStatus' => $status,
-			});
+		$libresignFile = new \OCA\Libresign\Db\File();
+		$libresignFile->setSignedNodeId($signedNodeId);
+		$libresignFile->setNodeId($nodeId);
+		$libresignFile->setStatus($status);
 
 		$this->fileMapper->method('getByUuid')->with('uuid')->willReturn($libresignFile);
 		$this->fileMapper->method('getStorageUserIdByUuid')->with('uuid')->willReturn('storage-user');
@@ -658,15 +656,9 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 								'getUserId' => 'username',
 							}
 						);
-					$file = $self->createMock(\OCA\Libresign\Db\File::class);
-					$file
-						->method('__call')
-						->willReturnCallback(fn (string $method)
-							=> match ($method) {
-								'getNodeId' => 999,
-								'getUserId' => 'username',
-							}
-						);
+					$file = new \OCA\Libresign\Db\File();
+					$file->setNodeId(999);
+					$file->setUserId('username');
 					$self->fileMapper
 						->method('getById')
 						->will($self->returnValue($file));

--- a/tests/php/Unit/Service/EnvelopeFileRelocatorTest.php
+++ b/tests/php/Unit/Service/EnvelopeFileRelocatorTest.php
@@ -33,11 +33,7 @@ class EnvelopeFileRelocatorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$envelopeFolder = $this->createMock(Folder::class);
 		$envelopeFolder->method('getPath')->willReturn('/user/files/Envelope');
 
-		$rootFolder = $this->createMock(Folder::class);
-		$rootFolder->method('getFirstNodeById')->with(10)->willReturn($envelopeFolder);
-
-		$this->folderService->expects($this->once())->method('setUserId')->with('u1');
-		$this->folderService->method('getUserRootFolder')->willReturn($rootFolder);
+		$this->folderService->method('getCreatableFolderById')->with('u1', 10)->willReturn($envelopeFolder);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('u1');
@@ -61,11 +57,7 @@ class EnvelopeFileRelocatorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->with('doc.pdf', 'content')
 			->willReturn($copiedFile);
 
-		$rootFolder = $this->createMock(Folder::class);
-		$rootFolder->method('getFirstNodeById')->with(10)->willReturn($envelopeFolder);
-
-		$this->folderService->expects($this->once())->method('setUserId')->with('u1');
-		$this->folderService->method('getUserRootFolder')->willReturn($rootFolder);
+		$this->folderService->method('getCreatableFolderById')->with('u1', 10)->willReturn($envelopeFolder);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('u1');
@@ -78,11 +70,7 @@ class EnvelopeFileRelocatorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$sourceFile = $this->createMock(\OCP\Files\File::class);
 		$sourceFile->method('getPath')->willReturn('/user/files/doc.pdf');
 
-		$rootFolder = $this->createMock(Folder::class);
-		$rootFolder->method('getFirstNodeById')->with(10)->willReturn($this->createMock(Node::class));
-
-		$this->folderService->method('setUserId');
-		$this->folderService->method('getUserRootFolder')->willReturn($rootFolder);
+		$this->folderService->method('getCreatableFolderById')->with('u1', 10)->willReturn(null);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('u1');
@@ -99,11 +87,7 @@ class EnvelopeFileRelocatorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$envelopeFolder = $this->createMock(Folder::class);
 		$envelopeFolder->method('getPath')->willReturn('/user/files/Envelope');
 
-		$rootFolder = $this->createMock(Folder::class);
-		$rootFolder->method('getFirstNodeById')->with(10)->willReturn($envelopeFolder);
-
-		$this->folderService->method('setUserId');
-		$this->folderService->method('getUserRootFolder')->willReturn($rootFolder);
+		$this->folderService->method('getCreatableFolderById')->with('u1', 10)->willReturn($envelopeFolder);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('u1');

--- a/tests/php/Unit/Service/EnvelopeServiceTest.php
+++ b/tests/php/Unit/Service/EnvelopeServiceTest.php
@@ -312,6 +312,33 @@ final class EnvelopeServiceTest extends TestCase {
 		$this->service->createEnvelope('Test', 'user', 1, '/Documents/Existing');
 	}
 
+	public function testGetEnvelopeFolderReturnsCreatableFolderForStorageUser(): void {
+		$envelope = new FileEntity();
+		$envelope->setUserId('storage-user');
+		$envelope->setNodeId(321);
+		$folder = $this->createMock(Folder::class);
+
+		$this->folderService
+			->expects($this->once())
+			->method('getCreatableFolderById')
+			->with('storage-user', 321)
+			->willReturn($folder);
+
+		$this->assertSame($folder, $this->service->getEnvelopeFolder($envelope));
+	}
+
+	public function testGetEnvelopeFolderRejectsFolderWithoutCreatePermission(): void {
+		$envelope = new FileEntity();
+		$envelope->setUserId('storage-user');
+		$envelope->setNodeId(321);
+		$this->folderService->method('getCreatableFolderById')->with('storage-user', 321)->willReturn(null);
+
+		$this->expectException(LibresignException::class);
+		$this->expectExceptionMessage('Envelope folder not found');
+
+		$this->service->getEnvelopeFolder($envelope);
+	}
+
 	#[DataProvider('envelopeConstraintsProvider')]
 	public function testValidateEnvelopeConstraints(
 		int $fileCount,

--- a/tests/php/Unit/Service/File/EnvelopeAssemblerTest.php
+++ b/tests/php/Unit/Service/File/EnvelopeAssemblerTest.php
@@ -18,11 +18,10 @@ use OCA\Libresign\Service\File\EnvelopeAssembler;
 use OCA\Libresign\Service\File\FileResponseOptions;
 use OCA\Libresign\Service\File\SignersLoader;
 use OCA\Libresign\Service\FileElementService;
+use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCP\Files\File;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -32,7 +31,7 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private SignRequestMapper&MockObject $signRequestMapper;
 	private IdentifyMethodService&MockObject $identifyMethodService;
 	private FileMapper&MockObject $fileMapper;
-	private IRootFolder&MockObject $root;
+	private FolderService&MockObject $folderService;
 	private IURLGenerator&MockObject $urlGenerator;
 	private SignersLoader&MockObject $signersLoader;
 	private Pkcs12Handler&MockObject $pkcs12Handler;
@@ -43,7 +42,7 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
-		$this->root = $this->createMock(IRootFolder::class);
+		$this->folderService = $this->createMock(FolderService::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->signersLoader = $this->createMock(SignersLoader::class);
 		$this->pkcs12Handler = $this->createMock(Pkcs12Handler::class);
@@ -55,7 +54,7 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->signRequestMapper,
 			$this->identifyMethodService,
 			$this->fileMapper,
-			$this->root,
+			$this->folderService,
 			$this->urlGenerator,
 			$this->signersLoader,
 			null,
@@ -66,10 +65,8 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	private function mockFileNode(): void {
-		$folder = $this->createMock(IUserFolder::class);
 		$fileNode = $this->createMock(File::class);
-		$folder->method('getFirstNodeById')->willReturn($fileNode);
-		$this->root->method('getUserFolder')->willReturn($folder);
+		$this->folderService->method('getReadableNodeById')->willReturn($fileNode);
 		$this->urlGenerator->method('linkToRoute')->willReturn('http://example.com/page.pdf');
 	}
 

--- a/tests/php/Unit/Service/File/FileContentProviderTest.php
+++ b/tests/php/Unit/Service/File/FileContentProviderTest.php
@@ -13,9 +13,8 @@ use OCA\Libresign\Db\File;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Service\File\FileContentProvider;
 use OCA\Libresign\Service\File\MimeService;
+use OCA\Libresign\Service\FolderService;
 use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -26,7 +25,7 @@ use Psr\Log\LoggerInterface;
 final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IClientService|MockObject $client;
 	private MimeService|MockObject $mimeService;
-	private IRootFolder|MockObject $root;
+	private FolderService|MockObject $folderService;
 	private LoggerInterface|MockObject $logger;
 	private IL10N|MockObject $l10n;
 
@@ -34,7 +33,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		parent::setUp();
 		$this->client = $this->createMock(IClientService::class);
 		$this->mimeService = $this->createMock(MimeService::class);
-		$this->root = $this->createMock(IRootFolder::class);
+		$this->folderService = $this->createMock(FolderService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->method('t')->willReturnCallback(fn ($text) => $text);
@@ -44,7 +43,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		return new FileContentProvider(
 			$this->client,
 			$this->mimeService,
-			$this->root,
+			$this->folderService,
 			$this->logger,
 			$this->l10n,
 		);
@@ -278,10 +277,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode = $this->createMock(\OCP\Files\File::class);
 		$fileNode->method('getContent')->willReturn('PDF content');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($fileNode);
 
 		$service = $this->getService();
 		$result = $service->getContentFromLibresignFile($file);
@@ -299,10 +295,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode = $this->createMock(\OCP\Files\File::class);
 		$fileNode->method('getContent')->willReturn('PDF content');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(456)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 456)->willReturn($fileNode);
 
 		$service = $this->getService();
 		$result = $service->getContentFromLibresignFile($file);
@@ -317,10 +310,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$file->setSignedNodeId(null);
 		$file->setNodeId(456);
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->willReturn(null);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 456)->willReturn(null);
 
 		$this->expectException(LibresignException::class);
 
@@ -336,10 +326,7 @@ final class FileContentProviderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 		$folderNode = $this->createMock(Folder::class);
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($folderNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($folderNode);
 
 		$this->expectException(LibresignException::class);
 

--- a/tests/php/Unit/Service/File/FileListServiceTest.php
+++ b/tests/php/Unit/Service/File/FileListServiceTest.php
@@ -15,12 +15,11 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Enum\SignatureFlow;
 use OCA\Libresign\Service\File\FileListService;
 use OCA\Libresign\Service\FileElementService;
+use OCA\Libresign\Service\FolderService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\SignatureRejection\SignatureRejectionVisibilityService;
 use OCA\Libresign\Tests\Unit\TestCase;
 use OCP\Files\File as NodeFile;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -38,8 +37,7 @@ final class FileListServiceTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 	private IL10N&MockObject $l10n;
 	private IUserManager&MockObject $userManager;
-	private IRootFolder&MockObject $rootFolder;
-	private IUserFolder&MockObject $userFolder;
+	private FolderService&MockObject $folderService;
 	private SignatureRejectionVisibilityService&MockObject $signatureRejectionVisibilityService;
 	private IUser&MockObject $user;
 
@@ -54,12 +52,10 @@ final class FileListServiceTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->userManager = $this->createMock(IUserManager::class);
-		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$this->userFolder = $this->createMock(IUserFolder::class);
+		$this->folderService = $this->createMock(FolderService::class);
 		$this->signatureRejectionVisibilityService = $this->createMock(SignatureRejectionVisibilityService::class);
 
 		$this->user = $this->createMock(IUser::class);
-		$this->rootFolder->method('getUserFolder')->willReturn($this->userFolder);
 	}
 
 	private function getService(): FileListService {
@@ -72,7 +68,7 @@ final class FileListServiceTest extends TestCase {
 			$this->appConfig,
 			$this->l10n,
 			$this->userManager,
-			$this->rootFolder,
+			$this->folderService,
 			$this->signatureRejectionVisibilityService,
 		);
 	}
@@ -638,7 +634,7 @@ final class FileListServiceTest extends TestCase {
 
 		$fileNode = $this->createMock(NodeFile::class);
 		$fileNode->method('getSize')->willReturn(4096);
-		$this->userFolder->method('getFirstNodeById')->with(100)->willReturn($fileNode);
+		$this->folderService->method('getReadableNodeById')->with('creator123', 100)->willReturn($fileNode);
 
 		$service = $this->getService();
 		$result = $service->formatSingleFile($this->user, $file);
@@ -742,9 +738,9 @@ final class FileListServiceTest extends TestCase {
 		$fileNodeA->method('getSize')->willReturn(1024);
 		$fileNodeB = $this->createMock(NodeFile::class);
 		$fileNodeB->method('getSize')->willReturn(2048);
-		$this->userFolder->method('getFirstNodeById')->willReturnMap([
-			[200, $fileNodeA],
-			[300, $fileNodeB],
+		$this->folderService->method('getReadableNodeById')->willReturnMap([
+			['creator123', 200, $fileNodeA],
+			['creator123', 300, $fileNodeB],
 		]);
 
 		$mockUser = $this->createMock(IUser::class);

--- a/tests/php/Unit/Service/File/MetadataLoaderTest.php
+++ b/tests/php/Unit/Service/File/MetadataLoaderTest.php
@@ -12,9 +12,8 @@ namespace OCA\Libresign\Tests\Unit\Service\File;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Service\File\FileContentProvider;
 use OCA\Libresign\Service\File\MetadataLoader;
+use OCA\Libresign\Service\FolderService;
 use OCP\Files\IMimeTypeDetector;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -22,7 +21,7 @@ use Psr\Log\LoggerInterface;
 use stdClass;
 
 final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
-	private IRootFolder|MockObject $root;
+	private FolderService|MockObject $folderService;
 	private IMimeTypeDetector|MockObject $mimeTypeDetector;
 	private IURLGenerator|MockObject $urlGenerator;
 	private FileContentProvider|MockObject $contentProvider;
@@ -30,7 +29,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->root = $this->createMock(IRootFolder::class);
+		$this->folderService = $this->createMock(FolderService::class);
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->contentProvider = $this->createMock(FileContentProvider::class);
@@ -39,7 +38,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	private function getService(): MetadataLoader {
 		return new MetadataLoader(
-			$this->root,
+			$this->folderService,
 			$this->mimeTypeDetector,
 			$this->urlGenerator,
 			$this->contentProvider,
@@ -69,10 +68,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode->method('getSize')->willReturn(5000);
 		$fileNode->method('getMimeType')->willReturn('application/pdf');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($fileNode);
 
 		$this->urlGenerator->method('linkToRoute')->willReturn('http://example.com/page.pdf');
 
@@ -97,10 +93,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode->method('getSize')->willReturn(5000);
 		$fileNode->method('getMimeType')->willReturn('application/pdf');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($fileNode);
 
 		$this->urlGenerator->method('linkToRoute')->willReturnCallback(
 			fn ($route, $params) => "http://example.com/page/{$params['page']}"
@@ -125,10 +118,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$file->setUserId('user123');
 		$file->setSignedNodeId(123);
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->willThrowException(new \Exception('File not found'));
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willThrowException(new \Exception('File not found'));
 
 		$this->logger
 			->expects($this->once())
@@ -158,14 +148,11 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode->method('getSize')->willReturn(5000);
 		$fileNode->method('getMimeType')->willReturn('application/pdf');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder
+		$this->folderService
 			->expects($this->once())
-			->method('getFirstNodeById')
-			->with($expectedNodeId)
+			->method('getReadableNodeById')
+			->with('user123', $expectedNodeId)
 			->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
 
 		$this->urlGenerator->method('linkToRoute')->willReturn('http://example.com/page.pdf');
 
@@ -201,10 +188,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode->method('getSize')->willReturn(5000);
 		$fileNode->method('getMimeType')->willReturn('application/pdf');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($fileNode);
 
 		$this->urlGenerator->method('linkToRoute')->willReturn('http://example.com/page.pdf');
 
@@ -244,10 +228,7 @@ final class MetadataLoaderTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$fileNode->method('getSize')->willReturn(5000);
 		$fileNode->method('getMimeType')->willReturn('application/pdf');
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->with(123)->willReturn($fileNode);
-
-		$this->root->method('getUserFolder')->with('user123')->willReturn($userFolder);
+		$this->folderService->method('getReadableNodeById')->with('user123', 123)->willReturn($fileNode);
 		$this->urlGenerator->method('linkToRoute')->willReturn('http://example.com/page.pdf');
 
 		$fileData = new stdClass();

--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -28,7 +28,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private $pkcs12Handler;
 	private $docMdpHandler;
 	private $pdfValidator;
-	private $rootFolder;
 	private $logger;
 	private $l10n;
 	private $envelopeService;
@@ -61,7 +60,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->pkcs12Handler = $this->createMock(\OCA\Libresign\Handler\SignEngine\Pkcs12Handler::class);
 		$this->docMdpHandler = $this->createMock(\OCA\Libresign\Handler\DocMdpHandler::class);
 		$this->pdfValidator = $this->createMock(\OCA\Libresign\Service\File\Pdf\PdfValidator::class);
-		$this->rootFolder = $this->createMock(\OCP\Files\IRootFolder::class);
 		$this->logger = $this->createMock(\Psr\Log\LoggerInterface::class);
 		$this->l10n = $this->createMock(\OCP\IL10N::class);
 		$this->envelopeService = $this->createMock(\OCA\Libresign\Service\Envelope\EnvelopeService::class);
@@ -94,7 +92,6 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->pkcs12Handler,
 			$this->docMdpHandler,
 			$this->pdfValidator,
-			$this->rootFolder,
 			$this->logger,
 			$this->l10n,
 			$this->envelopeService,

--- a/tests/php/Unit/Service/FolderServiceTest.php
+++ b/tests/php/Unit/Service/FolderServiceTest.php
@@ -81,6 +81,7 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
 		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 	}

--- a/tests/php/Unit/Service/FolderServiceTest.php
+++ b/tests/php/Unit/Service/FolderServiceTest.php
@@ -169,6 +169,36 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->getInstance()->getReadableNodeById('alice', 42);
 	}
 
+	public function testWriteDoesNotReinitializePreparedUserFilesystem(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with('alice')->willReturn($user);
+		$this->setupManager->expects($this->once())->method('isSetupComplete')->with($user)->willReturn(true);
+		$this->setupManager->expects($this->never())->method('tearDown');
+		$this->setupManager->expects($this->never())->method('setupForUser');
+
+		$userFolder = $this->createMock(IUserFolder::class);
+		$userFolder->method('isUpdateable')->willReturn(true);
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$this->groupManager->method('isInGroup')->willReturn(false);
+
+		$this->invokePrivate($this->getInstance('alice'), 'getContainerFolder');
+	}
+
+	public function testWritePreparesUserFilesystemWhenSetupIsIncomplete(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with('alice')->willReturn($user);
+		$this->setupManager->expects($this->once())->method('isSetupComplete')->with($user)->willReturn(false);
+		$this->setupManager->expects($this->once())->method('tearDown');
+		$this->setupManager->expects($this->once())->method('setupForUser')->with($user);
+
+		$userFolder = $this->createMock(IUserFolder::class);
+		$userFolder->method('isUpdateable')->willReturn(true);
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$this->groupManager->method('isInGroup')->willReturn(false);
+
+		$this->invokePrivate($this->getInstance('alice'), 'getContainerFolder');
+	}
+
 	public function testGetContainerFolderAsUnauthenticatedWhenUserIdIsInvalid():void {
 		$folder = $this->createMock(\OCP\Files\Folder::class);
 		$fakeFolder = new FakeFolder();
@@ -488,10 +518,13 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$mockUserFolder = $this->createMock(Folder::class);
 		$mockEnvelopeFolder = $this->createMock(Folder::class);
 
+		$readOnlyFolder = $this->createMock(Folder::class);
+		$readOnlyFolder->method('isCreatable')->willReturn(false);
+		$mockEnvelopeFolder->method('isCreatable')->willReturn(true);
 		$mockUserFolder->expects($this->once())
-			->method('getFirstNodeById')
+			->method('getById')
 			->with($envelopeFolderId)
-			->willReturn($mockEnvelopeFolder);
+			->willReturn([$readOnlyFolder, $mockEnvelopeFolder]);
 
 		$this->appConfig->method('getUserValue')->willReturn('/LibreSign');
 		$this->groupManager->method('isInGroup')->willReturn(false);
@@ -505,6 +538,32 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$result = $service->getFolderForFile($data, 'testuser');
 
 		$this->assertInstanceOf(Folder::class, $result);
+	}
+
+	public function testGetFolderForFileRejectsEnvelopeFolderWithoutCreatePermission(): void {
+		$envelopeFolderId = 456;
+		$data = ['settings' => ['envelopeFolderId' => $envelopeFolderId]];
+
+		$mockUserFolder = $this->createMock(Folder::class);
+		$readOnlyFolder = $this->createMock(Folder::class);
+		$readOnlyFolder->method('isCreatable')->willReturn(false);
+		$mockUserFolder->method('getById')->with($envelopeFolderId)->willReturn([$readOnlyFolder]);
+
+		$this->appConfig->method('getUserValue')->willReturn('/LibreSign');
+		$this->groupManager->method('isInGroup')->willReturn(false);
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->willReturn($user);
+		$this->setupManager->method('isSetupComplete')->willReturn(true);
+
+		$userFolder = $this->createMock(IUserFolder::class);
+		$userFolder->method('isUpdateable')->willReturn(true);
+		$userFolder->method('getOrCreateFolder')->willReturn($mockUserFolder);
+		$this->root->method('getUserFolder')->willReturn($userFolder);
+
+		$this->expectException(\OCA\Libresign\Exception\LibresignException::class);
+		$this->expectExceptionMessage('Envelope folder not found');
+
+		$this->getInstance('testuser')->getFolderForFile($data, 'testuser');
 	}
 
 	public function testGetFolderForFileCreatesNewFolderWhenNoEnvelopeId(): void {

--- a/tests/php/Unit/Service/FolderServiceTest.php
+++ b/tests/php/Unit/Service/FolderServiceTest.php
@@ -86,21 +86,87 @@ final class FolderServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	}
 
 	private function getInstance(?string $userId = '171'): FolderService {
-		$service = $this->getMockBuilder(FolderService::class)
-			->setConstructorArgs([
-				$this->root,
-				$this->appDataFactory,
-				$this->groupManager,
-				$this->appConfig,
-				$this->l10n,
-				$this->setupManager,
-				$this->userManager,
-				$userId,
-			])
-			->onlyMethods(['initializeUserFilesystem'])
-			->getMock();
-		$service->method('initializeUserFilesystem');
-		return $service;
+		return new FolderService(
+			$this->root,
+			$this->appDataFactory,
+			$this->groupManager,
+			$this->appConfig,
+			$this->l10n,
+			$this->setupManager,
+			$this->userManager,
+			$userId,
+		);
+	}
+
+	public function testGetUserFolderReturnsNextcloudUserFolder(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$this->root
+			->expects($this->once())
+			->method('getUserFolder')
+			->with('alice')
+			->willReturn($userFolder);
+
+		$this->assertSame($userFolder, $this->getInstance()->getUserFolder('alice'));
+	}
+
+	public function testGetReadableNodeByIdSkipsUnreadableMount(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$unreadableNode = $this->createMock(\OCP\Files\Node::class);
+		$readableNode = $this->createMock(\OCP\Files\Node::class);
+		$unreadableNode->method('isReadable')->willReturn(false);
+		$readableNode->method('isReadable')->willReturn(true);
+
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$unreadableNode, $readableNode]);
+
+		$this->assertSame($readableNode, $this->getInstance()->getReadableNodeById('alice', 42));
+	}
+
+	public function testGetReadableNodeByIdReturnsNullWhenNoReadableMountExists(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$unreadableNode = $this->createMock(\OCP\Files\Node::class);
+		$unreadableNode->method('isReadable')->willReturn(false);
+
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$userFolder->method('getById')->with(42)->willReturn([$unreadableNode]);
+
+		$this->assertNull($this->getInstance()->getReadableNodeById('alice', 42));
+	}
+
+	public function testGetCreatableFolderByIdSkipsNonCreatableMounts(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$readOnlyFolder = $this->createMock(Folder::class);
+		$creatableFolder = $this->createMock(Folder::class);
+		$readOnlyFolder->method('isCreatable')->willReturn(false);
+		$creatableFolder->method('isCreatable')->willReturn(true);
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$userFolder->method('getById')->with(42)->willReturn([$readOnlyFolder, $creatableFolder]);
+
+		$this->assertSame($creatableFolder, $this->getInstance()->getCreatableFolderById('alice', 42));
+	}
+
+	public function testGetCreatableFolderByIdReturnsNullWithoutCreatableFolder(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$file = $this->createMock(\OCP\Files\File::class);
+		$folder = $this->createMock(Folder::class);
+		$folder->method('isCreatable')->willReturn(false);
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$userFolder->method('getById')->with(42)->willReturn([$file, $folder]);
+
+		$this->assertNull($this->getInstance()->getCreatableFolderById('alice', 42));
+	}
+
+	public function testReadLookupDoesNotForceFilesystemSetup(): void {
+		$userFolder = $this->createMock(IUserFolder::class);
+		$this->root->method('getUserFolder')->with('alice')->willReturn($userFolder);
+		$userFolder->method('getById')->willReturn([]);
+		$this->setupManager->expects($this->never())->method('setupForUser');
+
+		$this->getInstance()->getReadableNodeById('alice', 42);
 	}
 
 	public function testGetContainerFolderAsUnauthenticatedWhenUserIdIsInvalid():void {

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -10,7 +10,6 @@ namespace OCA\Libresign\Tests\Unit\Service;
  */
 
 use DateTime;
-use OC\User\NoUserException;
 use OCA\Libresign\BackgroundJob\SignSingleFileJob;
 use OCA\Libresign\Db\File;
 use OCA\Libresign\Db\FileElement;
@@ -65,9 +64,6 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
-use OCP\Files\IUserFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Http\Client\IClientService;
@@ -79,6 +75,7 @@ use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Security\ICredentialsManager;
 use OCP\Security\ISecureRandom;
+use OCP\User\Exceptions\UserNotFoundException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -98,7 +95,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IAppConfig $appConfig;
 	private ValidateHelper&MockObject $validateHelper;
 	private SignerElementsService&MockObject $signerElementsService;
-	private IRootFolder&MockObject $root;
 	private IUserSession&MockObject $userSession;
 	private IDateTimeZone $dateTimeZone;
 	private FileElementMapper&MockObject $fileElementMapper;
@@ -148,7 +144,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->appConfig = $this->getMockAppConfigWithReset();
 		$this->validateHelper = $this->createMock(\OCA\Libresign\Helper\ValidateHelper::class);
 		$this->signerElementsService = $this->createMock(SignerElementsService::class);
-		$this->root = $this->createMock(\OCP\Files\IRootFolder::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->dateTimeZone = \OCP\Server::get(IDateTimeZone::class);
 		$this->fileElementMapper = $this->createMock(FileElementMapper::class);
@@ -313,14 +308,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequestB->setId(200);
 		$signRequestB->setUuid('uuid-b');
 
-		$folder = $this->createMock(IUserFolder::class);
-		$folder->method('getFirstNodeById')
-			->with(20)
+		$this->folderService->method('getReadableNodeById')
+			->with('user1', 20)
 			->willReturn($this->createMock(\OCP\Files\File::class));
-
-		$this->root->method('getUserFolder')
-			->with('user1')
-			->willReturn($folder);
 
 		$this->jobList->expects($this->once())
 			->method('add')
@@ -353,11 +343,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest->setId(200);
 		$signRequest->setUuid('uuid-b');
 
-		$folder = $this->createMock(IUserFolder::class);
-		$folder->method('getFirstNodeById')
-			->with(20)
+		$this->folderService->method('getReadableNodeById')
+			->with('user1', 20)
 			->willReturn($this->createMock(\OCP\Files\File::class));
-		$this->root->method('getUserFolder')->willReturn($folder);
 
 		$this->credentialsManager->expects($this->once())
 			->method('store')
@@ -461,7 +449,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$this->appConfig,
 					$this->validateHelper,
 					$this->signerElementsService,
-					$this->root,
 					$this->userSession,
 					$this->dateTimeZone,
 					$this->fileElementMapper,
@@ -506,7 +493,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->appConfig,
 			$this->validateHelper,
 			$this->signerElementsService,
-			$this->root,
 			$this->userSession,
 			$this->dateTimeZone,
 			$this->fileElementMapper,
@@ -595,11 +581,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 		$file = new \OCA\Libresign\Db\File();
 		$file->setUserId('username');
-
-		$userFolder = $this->createMock(IUserFolder::class);
-
-		$this->root->method('getUserFolder')
-			->willReturn($userFolder);
 
 		$signRequest = new \OCA\Libresign\Db\SignRequest();
 		$this->getService()
@@ -855,11 +836,8 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('user1');
 
-		// Mock root folder for verifyFileExists
-		$mockUserFolder = $this->createMock(IUserFolder::class);
 		$mockFile = $this->createMock(\OCP\Files\File::class);
-		$mockUserFolder->method('getFirstNodeById')->willReturn($mockFile);
-		$this->root->method('getUserFolder')->willReturn($mockUserFolder);
+		$this->folderService->method('getReadableNodeById')->willReturn($mockFile);
 
 		$capturedCredentials = [];
 		$this->credentialsManager->expects($this->exactly(2))
@@ -1943,20 +1921,14 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->expectExceptionMessageMatches($exceptionMessage);
 		}
 		$leaf = $this->createMock($typeOfNode);
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->method('getFirstNodeById')->willReturn($leaf);
-		$this->root->method('getUserFolder')->willReturnCallback(function () use ($userFolder, $exceptionMessage) {
-			switch ($exceptionMessage) {
-				case '/User not found/':
-					throw new NoUserException();
-				case '/not have permission/':
-					throw new NotPermittedException();
-				case '/File not found/':
-					return $userFolder;
-				default:
-					return $userFolder;
-			}
+		$this->folderService->method('getReadableNodeById')->willReturnCallback(function () use ($leaf, $exceptionMessage) {
+			return match ($exceptionMessage) {
+				'/User not found/' => throw new UserNotFoundException(),
+				'/not have permission/' => throw new NotPermittedException(),
+				default => $leaf,
+			};
 		});
+
 		$actual = $this->invokePrivate($service, 'getNodeByIdUsingUid', ['', 1]);
 		$this->assertEquals($leaf, $actual);
 	}
@@ -2727,17 +2699,14 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$service = $this->getService();
 
 		if ($scenario === 'exception') {
-			$this->root->method('getUserFolder')
-				->willThrowException(new NoUserException());
+			$this->folderService->method('getReadableNodeById')
+				->willThrowException(new UserNotFoundException());
 		} elseif ($scenario === 'file') {
-			$mockFile = $this->createMock(\OCP\Files\File::class);
-			$mockFolder = $this->createMock(IUserFolder::class);
-			$mockFolder->method('getFirstNodeById')->willReturn($mockFile);
-			$this->root->method('getUserFolder')->willReturn($mockFolder);
+			$this->folderService->method('getReadableNodeById')
+				->willReturn($this->createMock(\OCP\Files\File::class));
 		} elseif ($scenario === 'folder') {
-			$mockFolder = $this->createMock(IUserFolder::class);
-			$mockFolder->method('getFirstNodeById')->willReturn($mockFolder);
-			$this->root->method('getUserFolder')->willReturn($mockFolder);
+			$this->folderService->method('getReadableNodeById')
+				->willReturn($this->createMock(\OCP\Files\Folder::class));
 		}
 
 		$result = self::invokePrivate($service, 'verifyFileExists', [$uid, $nodeId]);
@@ -2766,7 +2735,6 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$originalFile->method('getExtension')->willReturn('pdf');
 		$originalFile->method('getPath')->willReturn('/admin/files/LibreSign/Document.pdf');
 		$originalFile->method('getOwner')->willReturn($owner);
-		$originalFile->method('getParentId')->willReturn(101);
 
 		$libreSignFile = new File();
 		$libreSignFile->setId(61);
@@ -2779,16 +2747,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->with('Document.signed_61.pdf', 'signed-content')
 			->willReturn($createdFile);
 
-		$userFolder = $this->createMock(IUserFolder::class);
-		$userFolder->expects($this->once())
-			->method('getFirstNodeById')
-			->with(101)
+		$originalFile->expects($this->once())
+			->method('getParent')
 			->willReturn($parentFolder);
-
-		$this->root->expects($this->once())
-			->method('getUserFolder')
-			->with('admin')
-			->willReturn($userFolder);
 
 		$this->userSession->expects($this->once())
 			->method('getUser')


### PR DESCRIPTION
## Summary

Nextcloud 36 changes `IRootFolder::getUserFolder()` to return `IUserFolder` and makes the user-filesystem boundary more explicit.

This PR aligns LibreSign with the current `nextcloud/server` master contracts and simplifies filesystem-dependent services and tests.

### Filesystem boundary

- `FolderService::getUserFolder()` returns `IUserFolder`
- read operations use `getById()` and select a node with `isReadable()` instead of relying on `getFirstNodeById()`
- write targets use a separate `getCreatableFolderById()` path and require `Folder::isCreatable()`
- full filesystem setup with `ISetupManager` is kept only for write paths that need to restore/prepare a user's filesystem
- normal read paths use the lazy `IUserFolder` behavior provided by Nextcloud 36

### Reduced coupling

Direct `IRootFolder` dependencies were removed where the service only needed user-scoped file lookup, including:

- `MetadataLoader`
- `FileContentProvider`
- `EnvelopeAssembler`
- `FileListService`
- `AccountService`
- `FileService`
- `SignFileService`

Envelope folder resolution also uses the explicit LibreSign filesystem boundary instead of mutating `FolderService` user context before looking up the folder.

### Public API contracts

`SignFileService` and `ValidateHelper` now use `OCP\User\Exceptions\UserNotFoundException`, which is the public exception documented by `IRootFolder`, instead of depending on the internal `OC\User\NoUserException` implementation.

## Why

The Nextcloud Node API allows the same file ID to be visible through multiple mounts. The `Folder::getFirstNodeById()` contract warns that the selected node can have fewer permissions than another representation of the same file. LibreSign now uses `getById()` and explicitly selects a readable or creatable representation according to the operation.

Nextcloud 36 can also return a lazy user folder when the filesystem is not fully set up. This lets LibreSign avoid forcing global filesystem setup for normal reads. We still prepare the filesystem explicitly before relevant write operations because LibreSign must preserve the existing behavior of restoring a missing user filesystem before writing.

## Tests

The refactor updates mirrored unit tests to mock the LibreSign filesystem boundary instead of reproducing the `IRootFolder -> IUserFolder -> Node` hierarchy where that infrastructure is not the behavior under test.

Coverage includes:

- selecting a readable node when multiple mounts expose the same ID
- returning no node when none of the representations is readable
- selecting a creatable folder for write operations
- rejecting envelope folders without create permission
- ensuring read lookups do not force full filesystem setup
- preserving filesystem preparation for write paths
- file selection rules in `AccountService`
- user/file/permission error behavior in `SignFileService`
- envelope relocation and stored envelope-folder resolution

Validation performed while rebuilding the branch:

- `composer run cs:fix`
- `git diff --check`
- `php -l` for every changed PHP file

Focused PHPUnit could not be executed in the standalone app runner because LibreSign's PHPUnit bootstrap requires a complete Nextcloud checkout (`lib/base.php`). The normal PR PHPUnit workflows provide that environment and are the functional validation for the Nextcloud 36/master integration.

The historical migration is intentionally unchanged.