### PR TITLE
fix: populate signer visible elements in validation responses

### DIFF
--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -589,6 +589,9 @@ namespace OCA\Libresign;
  *     url: string,
  *     resolution: LibresignValidationPageResolution,
  * }
+ * @psalm-type LibresignValidatedChildSigner = LibresignSignerSummary&array{
+ *     visibleElements?: LibresignVisibleElement[],
+ * }
  * @psalm-type LibresignValidatedChildFile = array{
  *     id: int,
  *     uuid: string,
@@ -599,7 +602,7 @@ namespace OCA\Libresign;
  *     totalPages?: non-negative-int,
  *     size: non-negative-int,
  *     pdfVersion?: string,
- *     signers: list<LibresignSignerSummary>,
+ *     signers: list<LibresignValidatedChildSigner>,
  *     file?: string,
  *     metadata: LibresignValidateMetadata,
  * }

--- a/lib/Service/File/EnvelopeAssembler.php
+++ b/lib/Service/File/EnvelopeAssembler.php
@@ -119,19 +119,25 @@ class EnvelopeAssembler {
 			$signer->statusText = $this->signRequestMapper->getTextOfSignerStatus($signRequest->getStatus());
 			$signer->identifyMethods = $identifyMethodsArray;
 			$signer->metadata = $signRequest->getMetadata();
+			$signer->visibleElements = [];
 			$fileData->signers[] = $signer;
 		}
 
 		if ($options->isShowVisibleElements()) {
 			$childMetadata = $childFile->getMetadata();
-			foreach ($this->signRequestMapper->getVisibleElementsFromSigners($signRequests) as $row) {
+			$formattedElementsBySigner = [];
+			foreach ($this->signRequestMapper->getVisibleElementsFromSigners($signRequests) as $signRequestId => $row) {
 				if (empty($row)) {
 					continue;
 				}
+				$formattedElementsBySigner[$signRequestId] = $this->fileElementService->formatVisibleElements($row, $childMetadata);
 				$fileData->visibleElements = array_merge(
-					$this->fileElementService->formatVisibleElements($row, $childMetadata),
+					$formattedElementsBySigner[$signRequestId],
 					$fileData->visibleElements
 				);
+			}
+			foreach ($fileData->signers as $signer) {
+				$signer->visibleElements = $formattedElementsBySigner[$signer->signRequestId] ?? [];
 			}
 		}
 

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -520,16 +520,21 @@ class FileService {
 
 		$signers = $this->signRequestMapper->getByMultipleFileId($fileIds);
 		$fileMetadata = $this->file->getMetadata();
-		foreach ($this->signRequestMapper->getVisibleElementsFromSigners($signers) as $visibleElements) {
+		$formattedElementsBySigner = [];
+		foreach ($this->signRequestMapper->getVisibleElementsFromSigners($signers) as $signRequestId => $visibleElements) {
 			if (empty($visibleElements)) {
 				continue;
 			}
 			$elementFileId = $visibleElements[0]->getFileId();
 			$metadata = $childMetadataMap[$elementFileId] ?? $fileMetadata;
+			$formattedElementsBySigner[$signRequestId] = $this->fileElementService->formatVisibleElements($visibleElements, $metadata);
 			$this->fileData->visibleElements = array_merge(
-				$this->fileElementService->formatVisibleElements($visibleElements, $metadata),
+				$formattedElementsBySigner[$signRequestId],
 				$this->fileData->visibleElements
 			);
+		}
+		foreach ($this->fileData->signers as $signer) {
+			$signer->visibleElements = $formattedElementsBySigner[$signer->signRequestId ?? null] ?? [];
 		}
 	}
 

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -53,7 +53,7 @@ use TypeError;
 /**
  * @psalm-import-type LibresignValidatedFile from ResponseDefinitions
  * @psalm-import-type LibresignSignerDetail from ResponseDefinitions
- * @psalm-import-type LibresignSignerSummary from ResponseDefinitions
+ * @psalm-import-type LibresignValidatedChildSigner from ResponseDefinitions
  * @psalm-import-type LibresignIdentifyMethod from ResponseDefinitions
  */
 class FileService {
@@ -648,7 +648,7 @@ class FileService {
 
 	/**
 	 * @param LibresignSignerDetail[] $signers
-	 * @return LibresignSignerSummary[]
+	 * @return LibresignValidatedChildSigner[]
 	 */
 	private function mapSignerDetailsToSummary(array $signers): array {
 		$summaries = [];
@@ -680,8 +680,11 @@ class FileService {
 			if ($identifyMethods !== null) {
 				$summary['identifyMethods'] = $identifyMethods;
 			}
+			if (isset($signerData['visibleElements'])) {
+				$summary['visibleElements'] = $signerData['visibleElements'];
+			}
 
-			/** @var LibresignSignerSummary $summary */
+			/** @var LibresignValidatedChildSigner $summary */
 			$summaries[] = $summary;
 		}
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -3629,7 +3629,7 @@
                     "signers": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/SignerSummary"
+                            "$ref": "#/components/schemas/ValidatedChildSigner"
                         }
                     },
                     "file": {
@@ -3639,6 +3639,24 @@
                         "$ref": "#/components/schemas/ValidateMetadata"
                     }
                 }
+            },
+            "ValidatedChildSigner": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SignerSummary"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "visibleElements": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/VisibleElement"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "ValidatedFile": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -2927,7 +2927,7 @@
                     "signers": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/SignerSummary"
+                            "$ref": "#/components/schemas/ValidatedChildSigner"
                         }
                     },
                     "file": {
@@ -2937,6 +2937,24 @@
                         "$ref": "#/components/schemas/ValidateMetadata"
                     }
                 }
+            },
+            "ValidatedChildSigner": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SignerSummary"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "visibleElements": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/VisibleElement"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "ValidatedFile": {
                 "type": "object",

--- a/src/types/openapi/openapi-full.ts
+++ b/src/types/openapi/openapi-full.ts
@@ -2207,9 +2207,12 @@ export type components = {
             /** Format: int64 */
             size: number;
             pdfVersion?: string;
-            signers: components["schemas"]["SignerSummary"][];
+            signers: components["schemas"]["ValidatedChildSigner"][];
             file?: string;
             metadata: components["schemas"]["ValidateMetadata"];
+        };
+        ValidatedChildSigner: components["schemas"]["SignerSummary"] & {
+            visibleElements?: components["schemas"]["VisibleElement"][];
         };
         ValidatedFile: {
             /** Format: int64 */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1746,9 +1746,12 @@ export type components = {
             /** Format: int64 */
             size: number;
             pdfVersion?: string;
-            signers: components["schemas"]["SignerSummary"][];
+            signers: components["schemas"]["ValidatedChildSigner"][];
             file?: string;
             metadata: components["schemas"]["ValidateMetadata"];
+        };
+        ValidatedChildSigner: components["schemas"]["SignerSummary"] & {
+            visibleElements?: components["schemas"]["VisibleElement"][];
         };
         ValidatedFile: {
             /** Format: int64 */

--- a/tests/integration/features/file/validate.feature
+++ b/tests/integration/features/file/validate.feature
@@ -26,6 +26,8 @@ Feature: validate
       | (jq).ocs.data.visibleElements \| length | 1 |
       | (jq)(.ocs.data.signers[0].visibleElements == .ocs.data.visibleElements) | true |
       | (jq).ocs.data.signers[1].visibleElements | [] |
+      | (jq)(.ocs.data.files[0].signers[0].visibleElements == .ocs.data.signers[0].visibleElements) | true |
+      | (jq)(.ocs.data.files[0].signers[1].visibleElements == .ocs.data.signers[1].visibleElements) | true |
 
   Scenario: Envelope validation keeps visible elements scoped to each document signer
     Given as user "admin"

--- a/tests/integration/features/file/validate.feature
+++ b/tests/integration/features/file/validate.feature
@@ -1,4 +1,62 @@
 Feature: validate
+  Scenario: Validation assigns visible elements only to their signer
+    Given as user "admin"
+    And user "signer1" exists
+    And sending "post" to ocs "/apps/libresign/api/v1/admin/certificate/openssl"
+      | rootCert | {"commonName":"test"} |
+    When sending "post" to ocs "/apps/libresign/api/v1/request-signature"
+      | file | {"url":"<BASE_URL>/apps/libresign/develop/pdf"} |
+      | signers | [{"identifyMethods":[{"method":"account","value":"admin"}]},{"identifyMethods":[{"method":"account","value":"signer1"}]}] |
+      | status | 0 |
+      | name | Visible elements validation |
+    Then the response should have a status code 200
+    And fetch field "(FILE_UUID)ocs.data.uuid" from previous JSON response
+    When sending "get" to ocs "/apps/libresign/api/v1/file/validate/uuid/<FILE_UUID>"
+    Then the response should have a status code 200
+    And fetch field "(SIGN_REQUEST_ID)ocs.data.signers.0.signRequestId" from previous JSON response
+    When sending "post" to ocs "/apps/libresign/api/v1/file-element/<FILE_UUID>"
+      | signRequestId | <SIGN_REQUEST_ID> |
+      | type | signature |
+      | coordinates | {"page":1,"llx":10,"lly":10,"urx":110,"ury":60} |
+    Then the response should have a status code 200
+    When sending "get" to ocs "/apps/libresign/api/v1/file/validate/uuid/<FILE_UUID>"
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key | value |
+      | (jq).ocs.data.visibleElements \| length | 1 |
+      | (jq)(.ocs.data.signers[0].visibleElements == .ocs.data.visibleElements) | true |
+      | (jq).ocs.data.signers[1].visibleElements | [] |
+
+  Scenario: Envelope validation keeps visible elements scoped to each document signer
+    Given as user "admin"
+    And sending "post" to ocs "/apps/libresign/api/v1/admin/certificate/openssl"
+      | rootCert | {"commonName":"test"} |
+    When sending "post" to ocs "/apps/libresign/api/v1/request-signature"
+      | files | [{"url":"<BASE_URL>/apps/libresign/develop/pdf","name":"First.pdf"},{"url":"<BASE_URL>/apps/libresign/develop/pdf","name":"Second.pdf"}] |
+      | signers | [{"identifyMethods":[{"method":"account","value":"admin"}]}] |
+      | status | 0 |
+      | name | Envelope visible elements |
+    Then the response should have a status code 200
+    And fetch field "(ENVELOPE_UUID)ocs.data.uuid" from previous JSON response
+    When sending "get" to ocs "/apps/libresign/api/v1/file/validate/uuid/<ENVELOPE_UUID>"
+    Then the response should have a status code 200
+    And fetch field "(CHILD_UUID)ocs.data.files.0.uuid" from previous JSON response
+    And fetch field "(SIGN_REQUEST_ID)ocs.data.files.0.signers.0.signRequestId" from previous JSON response
+    When sending "post" to ocs "/apps/libresign/api/v1/file-element/<CHILD_UUID>"
+      | signRequestId | <SIGN_REQUEST_ID> |
+      | type | signature |
+      | coordinates | {"page":1,"llx":10,"lly":10,"urx":110,"ury":60} |
+    Then the response should have a status code 200
+    When sending "get" to ocs "/apps/libresign/api/v1/file/validate/uuid/<ENVELOPE_UUID>"
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key | value |
+      | (jq).ocs.data.visibleElements \| length | 1 |
+      | (jq).ocs.data.files[0].visibleElements \| length | 1 |
+      | (jq)(.ocs.data.files[0].signers[0].visibleElements == .ocs.data.files[0].visibleElements) | true |
+      | (jq).ocs.data.files[1].visibleElements | [] |
+      | (jq).ocs.data.files[1].signers[0].visibleElements | [] |
+
   Scenario: Sign with account, delete the account and validate
     Given as user "admin"
     And sending "post" to ocs "/apps/libresign/api/v1/policies/system/identification_documents"

--- a/tests/php/Unit/Service/File/EnvelopeAssemblerTest.php
+++ b/tests/php/Unit/Service/File/EnvelopeAssemblerTest.php
@@ -123,7 +123,11 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest->setDisplayName('Signer A');
 		$signRequest->setStatus(1);
 
-		$this->signRequestMapper->method('getByFileId')->willReturn([$signRequest]);
+		$otherSignRequest = new DbSignRequest();
+		$otherSignRequest->setId(101);
+		$otherSignRequest->setDisplayName('Signer without elements');
+		$otherSignRequest->setStatus(1);
+		$this->signRequestMapper->method('getByFileId')->willReturn([$otherSignRequest, $signRequest]);
 
 		$element = new \OCA\Libresign\Db\FileElement();
 		$element->setId(1);
@@ -135,7 +139,7 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$element->setUry(200);
 		$element->setMetadata([]);
 
-		$this->signRequestMapper->method('getVisibleElementsFromSigners')->willReturn([
+		$this->signRequestMapper->expects($this->once())->method('getVisibleElementsFromSigners')->willReturn([
 			100 => [$element],
 		]);
 
@@ -167,6 +171,8 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertIsArray($result->visibleElements);
 		$this->assertNotEmpty($result->visibleElements);
 		$this->assertCount(1, $result->visibleElements);
+		$this->assertSame([], $result->signers[0]->visibleElements);
+		$this->assertSame($result->visibleElements, $result->signers[1]->visibleElements);
 	}
 
 	public function testBuildsChildDataWithoutVisibleElementsWhenNotRequested(): void {
@@ -203,6 +209,7 @@ final class EnvelopeAssemblerTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 		$this->assertIsArray($result->visibleElements);
 		$this->assertEmpty($result->visibleElements);
+		$this->assertSame([], $result->signers[0]->visibleElements);
 	}
 
 	public function testBuildsChildDataWithMultipleSigners(): void {

--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -490,6 +490,53 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		}
 	}
 
+	public function testVisibleElementsAreAssignedBySignRequestId(): void {
+		$file = new \OCA\Libresign\Db\File();
+		$file->setId(1);
+		$file->setUuid('test-uuid');
+		$file->setName('test.pdf');
+		$file->setStatus(1);
+		$file->setCreatedAt(new \DateTime());
+		$file->setNodeId(100);
+		$file->setSignatureFlow('');
+		$file->setDocmdpLevel('');
+		$file->setUserId('testuser');
+		$file->setMetadata([]);
+
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('getDisplayName')->willReturn('Test User');
+		$this->userManager->method('get')->willReturn($user);
+		$this->fileMapper->method('getTextOfStatus')->willReturn('Pending');
+		$this->signersLoader->method('loadLibreSignSigners')->willReturnCallback(
+			static function ($file, \stdClass $fileData): void {
+				$fileData->signers = [
+					(object)['signRequestId' => 20, 'visibleElements' => []],
+					(object)['signRequestId' => 10, 'visibleElements' => []],
+					(object)['displayName' => 'Certificate-only signer'],
+				];
+			}
+		);
+		$signRequest = new \OCA\Libresign\Db\SignRequest();
+		$signRequest->setId(10);
+		$signRequest->setFileId(1);
+		$this->signRequestMapper->method('getByMultipleFileId')->with([1])->willReturn([$signRequest]);
+		$element = new \OCA\Libresign\Db\FileElement();
+		$element->setFileId(1);
+		$element->setSignRequestId(10);
+		$this->signRequestMapper->expects($this->once())->method('getVisibleElementsFromSigners')
+			->with([$signRequest])->willReturn([10 => [$element]]);
+		$formatted = [['elementId' => 5, 'signRequestId' => 10, 'fileId' => 1]];
+		$this->fileElementService->expects($this->once())->method('formatVisibleElements')
+			->with([$element], [])->willReturn($formatted);
+
+		$result = $this->createFileService()->setFile($file)->showSigners()->showVisibleElements()->toArray();
+
+		$this->assertSame($formatted, $result['visibleElements']);
+		$this->assertSame([], $result['signers'][0]['visibleElements']);
+		$this->assertSame($formatted, $result['signers'][1]['visibleElements']);
+		$this->assertSame([], $result['signers'][2]['visibleElements']);
+	}
+
 	public static function providerTestVisibleElements(): array {
 		return [
 			'visible elements included when showVisibleElements() called' => [true, true],

--- a/tests/php/Unit/Service/FileServiceTest.php
+++ b/tests/php/Unit/Service/FileServiceTest.php
@@ -535,6 +535,11 @@ final class FileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertSame([], $result['signers'][0]['visibleElements']);
 		$this->assertSame($formatted, $result['signers'][1]['visibleElements']);
 		$this->assertSame([], $result['signers'][2]['visibleElements']);
+		$this->assertCount(2, $result['files'][0]['signers']);
+		foreach ($result['files'][0]['signers'] as $index => $signer) {
+			$this->assertSame($result['signers'][$index]['signRequestId'], $signer['signRequestId']);
+			$this->assertSame($result['signers'][$index]['visibleElements'], $signer['visibleElements']);
+		}
 	}
 
 	public static function providerTestVisibleElements(): array {


### PR DESCRIPTION
## Summary

Backend prerequisite for #8326, as requested in https://github.com/LibreSign/libresign/issues/8326#issuecomment-5619485424. This does not close the frontend issue.

- Populate `signer.visibleElements` in `FileService` and envelope child documents in `EnvelopeAssembler`, keyed by `signRequestId`.
- Reuse the existing mapper result and formatted elements; preserve document-level elements and ordering without adding queries.
- Add unit and Behat coverage for signer/document isolation.
- Describe optional child-signer visible elements in OpenAPI and regenerate the JSON specs and TypeScript types. The field remains optional because single-file summaries share this contract.

No UI, database, PDF or cryptographic validation changes are included.

## How to test

In a disposable configured Nextcloud development environment:

```sh
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --fail-on-warning --filter FileServiceTest tests/php/Unit/Service/FileServiceTest.php
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --fail-on-warning --filter EnvelopeAssemblerTest tests/php/Unit/Service/File/EnvelopeAssemblerTest.php
cd tests/integration
vendor/bin/behat -c config/behat.yml features/file/validate.feature --name "visible elements" --format=progress
```

Local results on PHP 8.3.33 / SQLite: 44 unit tests, 133 assertions; 2 Behat scenarios, 28 steps passed. Focused PHP syntax/style checks and `git diff --check` passed. Full suites and Psalm were not run.

Also rechecked the original signed PDF: validation now returns the existing element both at document level and for its matching signer; `signature_validation.isValid` remains true and CRL validation remains valid. The separately developed local UI changed from No to Yes; that UI is not part of this PR.

## Checklist

- [x] Contribution guide followed; commit includes DCO sign-off.
- [x] Unit and integration tests added.
- [x] OpenAPI specs and TypeScript types regenerated.

## AI

- [x] The content of this PR was partially or fully generated using AI.

Implemented with Codex assistance, independently reviewed with AI assistance, and manually verified by the contributor on the original signed document.