### PR TITLE
refactor: migrate identity document validation consumers

### DIFF
--- a/lib/Controller/IdDocsController.php
+++ b/lib/Controller/IdDocsController.php
@@ -10,10 +10,10 @@ namespace OCA\Libresign\Controller;
 
 use Exception;
 use OCA\Libresign\AppInfo\Application;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\RequireSignRequestUuid;
 use OCA\Libresign\Service\IdDocsService;
 use OCA\Libresign\Service\SignFileService;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -43,7 +43,7 @@ class IdDocsController extends AEnvironmentAwareController implements ISignature
 		protected IL10N $l10n,
 		protected IdDocsService $idDocsService,
 		protected IUserSession $userSession,
-		protected ValidateHelper $validateHelper,
+		protected IdentityDocumentValidator $identityDocumentValidator,
 		protected LoggerInterface $logger,
 	) {
 		parent::__construct(Application::APP_ID, $request);
@@ -210,7 +210,7 @@ class IdDocsController extends AEnvironmentAwareController implements ISignature
 		?string $sortOrder = null,
 	): DataResponse {
 		try {
-			$this->validateHelper->userCanApproveValidationDocuments($this->userSession->getUser());
+			$this->identityDocumentValidator->userCanApproveValidationDocuments($this->userSession->getUser());
 			$filter = array_filter([
 				'userId' => $userId,
 				'signRequestId' => $signRequestId,

--- a/lib/Service/IdDocsService.php
+++ b/lib/Service/IdDocsService.php
@@ -19,7 +19,8 @@ use OCA\Libresign\Db\SignRequest as SignRequestEntity;
 use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Enum\IdentifyMethodRequirement;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -31,7 +32,8 @@ class IdDocsService {
 	public function __construct(
 		private IL10N $l10n,
 		private FileTypeMapper $fileTypeMapper,
-		private ValidateHelper $validateHelper,
+		private FileInputValidator $fileInputValidator,
+		private IdentityDocumentValidator $identityDocumentValidator,
 		private RequestSignatureService $requestSignatureService,
 		private IdDocsMapper $idDocsMapper,
 		private FileMapper $fileMapper,
@@ -66,9 +68,9 @@ class IdDocsService {
 		}
 
 		try {
-			$this->validateHelper->validateFileTypeExists($file['type']);
-			$this->validateHelper->validateNewFile($file, ValidateHelper::TYPE_ACCOUNT_DOCUMENT, $user);
-			$this->validateHelper->validateUserHasNoFileWithThisType($user->getUID(), $file['type']);
+			$this->identityDocumentValidator->validateFileTypeExists($file['type']);
+			$this->fileInputValidator->validateNewFile($file, FileInputValidator::TYPE_ACCOUNT_DOCUMENT, $user);
+			$this->identityDocumentValidator->validateUserHasNoFileWithThisType($user->getUID(), $file['type']);
 		} catch (\Exception $e) {
 			throw new LibresignException(json_encode([
 				'type' => 'danger',
@@ -141,10 +143,10 @@ class IdDocsService {
 	}
 
 	public function deleteIdDoc(int $nodeId, IUser $user): void {
-		if ($this->validateHelper->userCanApproveValidationDocuments($user, false)) {
+		if ($this->identityDocumentValidator->userCanApproveValidationDocuments($user, false)) {
 			$idDocs = $this->idDocsMapper->getByNodeId($nodeId);
 		} else {
-			$this->validateHelper->validateIdDocIsOwnedByUser($nodeId, $user->getUID());
+			$this->identityDocumentValidator->validateIdDocIsOwnedByUser($nodeId, $user->getUID());
 			$idDocs = $this->idDocsMapper->getByUserIdAndNodeId($user->getUID(), $nodeId);
 		}
 		$this->idDocsMapper->delete($idDocs);
@@ -153,7 +155,7 @@ class IdDocsService {
 	}
 
 	public function deleteIdDocBySignRequest(int $nodeId, SignRequest $signRequest): void {
-		$this->validateHelper->validateIdDocBelongsToSignRequest($nodeId, $signRequest->getId());
+		$this->identityDocumentValidator->validateIdDocBelongsToSignRequest($nodeId, $signRequest->getId());
 		$idDocs = $this->idDocsMapper->getBySignRequestIdAndNodeId($signRequest->getId(), $nodeId);
 		$this->idDocsMapper->delete($idDocs);
 		$file = $this->fileMapper->getById($idDocs->getFileId());

--- a/tests/php/Unit/Service/IdDocsServiceTest.php
+++ b/tests/php/Unit/Service/IdDocsServiceTest.php
@@ -74,6 +74,30 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		);
 	}
 
+	public function testValidateIdDocsUsesFocusedValidators(): void {
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('getUID')->willReturn('user1');
+		$file = [
+			'type' => 'IDENTIFICATION',
+			'file' => ['base64' => 'encoded'],
+		];
+
+		$this->fileTypeMapper->method('getTypes')->willReturn([
+			'IDENTIFICATION' => [],
+		]);
+		$this->identityDocumentValidator->expects($this->once())
+			->method('validateFileTypeExists')
+			->with('IDENTIFICATION');
+		$this->fileInputValidator->expects($this->once())
+			->method('validateNewFile')
+			->with($file, FileInputValidator::TYPE_ACCOUNT_DOCUMENT, $user);
+		$this->identityDocumentValidator->expects($this->once())
+			->method('validateUserHasNoFileWithThisType')
+			->with('user1', 'IDENTIFICATION');
+
+		$this->getIdDocsService()->validateIdDocs([$file], $user);
+	}
+
 	public function testDeleteIdDocAsApproverBypassesOwnershipCheck(): void {
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('approver1');

--- a/tests/php/Unit/Service/IdDocsServiceTest.php
+++ b/tests/php/Unit/Service/IdDocsServiceTest.php
@@ -15,9 +15,10 @@ use OCA\Libresign\Db\IdDocsMapper;
 use OCA\Libresign\Db\IdentifyMethodMapper;
 use OCA\Libresign\Db\SignRequest;
 use OCA\Libresign\Db\SignRequestMapper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\IdDocsService;
 use OCA\Libresign\Service\RequestSignatureService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -33,7 +34,8 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private FileMapper&MockObject $fileMapper;
 	private SignRequestMapper&MockObject $signRequestMapper;
 	private IdentifyMethodMapper&MockObject $identifyMethodMapper;
-	private ValidateHelper&MockObject $validateHelper;
+	private FileInputValidator&MockObject $fileInputValidator;
+	private IdentityDocumentValidator&MockObject $identityDocumentValidator;
 	private RequestSignatureService&MockObject $requestSignatureService;
 	private TimeFactory&MockObject $timeFactory;
 	private IAppConfig&MockObject $appConfig;
@@ -49,7 +51,8 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->identifyMethodMapper = $this->createMock(IdentifyMethodMapper::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->fileInputValidator = $this->createMock(FileInputValidator::class);
+		$this->identityDocumentValidator = $this->createMock(IdentityDocumentValidator::class);
 		$this->requestSignatureService = $this->createMock(RequestSignatureService::class);
 		$this->timeFactory = $this->createMock(TimeFactory::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
@@ -59,7 +62,8 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		return new IdDocsService(
 			$this->l10n,
 			$this->fileTypeMapper,
-			$this->validateHelper,
+			$this->fileInputValidator,
+			$this->identityDocumentValidator,
 			$this->requestSignatureService,
 			$this->idDocsMapper,
 			$this->fileMapper,
@@ -74,7 +78,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('approver1');
 
-		$this->validateHelper->method('userCanApproveValidationDocuments')
+		$this->identityDocumentValidator->method('userCanApproveValidationDocuments')
 			->with($user, false)
 			->willReturn(true);
 
@@ -101,11 +105,11 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$user = $this->createMock(\OCP\IUser::class);
 		$user->method('getUID')->willReturn('user1');
 
-		$this->validateHelper->method('userCanApproveValidationDocuments')
+		$this->identityDocumentValidator->method('userCanApproveValidationDocuments')
 			->with($user, false)
 			->willReturn(false);
 
-		$this->validateHelper->expects($this->once())
+		$this->identityDocumentValidator->expects($this->once())
 			->method('validateIdDocIsOwnedByUser')
 			->with(123, 'user1');
 
@@ -129,7 +133,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest = new SignRequest();
 		$signRequest->setId(55);
 
-		$this->validateHelper->expects($this->once())
+		$this->identityDocumentValidator->expects($this->once())
 			->method('validateIdDocBelongsToSignRequest')
 			->with(123, 55);
 
@@ -156,7 +160,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest = new SignRequest();
 		$signRequest->setId(55);
 
-		$this->validateHelper->method('validateIdDocBelongsToSignRequest')
+		$this->identityDocumentValidator->method('validateIdDocBelongsToSignRequest')
 			->with(123, 55)
 			->willThrowException(new \OCA\Libresign\Exception\LibresignException('Not allowed'));
 


### PR DESCRIPTION
## Context

#8334 split `ValidateHelper` into focused validators while keeping the helper as a compatibility facade.

This PR starts the consumer migration with the identity document domain. The scope is intentionally small so the architectural change remains easy to review and low risk.

## Changes

- migrate `IdDocsService` from `ValidateHelper` to:
  - `IdentityDocumentValidator` for identity document ownership, type, approval and duplicate-type rules;
  - `FileInputValidator` for uploaded identity document input validation.
- migrate `IdDocsController` directly to `IdentityDocumentValidator` for approval authorization.
- update `IdDocsServiceTest` to mock the focused validators instead of the facade.
- add a focused unit test that verifies identity document validation is delegated to the two responsible validators.
- use `FileInputValidator::TYPE_ACCOUNT_DOCUMENT` instead of the compatibility constant from `ValidateHelper`.

No validation behavior or public API is intentionally changed. `ValidateHelper` remains in place because other consumers still depend on it.

## Validation

The focused unit tests and the full project CI should confirm that the dependency migration preserves behavior and introduces no static analysis or lint regressions.

## Follow-up

Other domains still have direct `ValidateHelper` consumers and should be migrated in later, focused PRs:

- request/signature workflow and authorization;
- signing;
- visible elements;
- upload/file validation;
- notification/activity and UI integration consumers;
- account-related consumers.

`ValidateHelper` should only be removed after a later code search confirms that no real consumers remain.