### PR TITLE
refactor: migrate file input validation consumers

### DIFF
--- a/lib/Service/File/MimeService.php
+++ b/lib/Service/File/MimeService.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Service\File;
 
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCP\Files\IMimeTypeDetector;
 
 class MimeService {
@@ -17,7 +17,7 @@ class MimeService {
 
 	public function __construct(
 		private IMimeTypeDetector $mimeTypeDetector,
-		private ValidateHelper $validateHelper,
+		private FileInputValidator $fileInputValidator,
 	) {
 	}
 
@@ -27,7 +27,7 @@ class MimeService {
 	 * @throws \Exception if MIME type is not accepted
 	 */
 	public function setMimeType(string $mimetype): void {
-		$this->validateHelper->validateMimeTypeAcceptedByMime($mimetype);
+		$this->fileInputValidator->validateMimeTypeAcceptedByMime($mimetype);
 		$this->mimetype = $mimetype;
 	}
 

--- a/lib/Service/File/UploadProcessor.php
+++ b/lib/Service/File/UploadProcessor.php
@@ -11,9 +11,9 @@ namespace OCA\Libresign\Service\File;
 
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\File\Pdf\PdfValidator;
 use OCA\Libresign\Service\FolderService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCP\Files\Node;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
@@ -24,7 +24,7 @@ class UploadProcessor {
 		private FolderService $folderService,
 		private MimeService $mimeService,
 		private PdfValidator $pdfValidator,
-		private ValidateHelper $validateHelper,
+		private FileInputValidator $fileInputValidator,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -86,7 +86,7 @@ class UploadProcessor {
 
 				$createdNodes[] = $node;
 
-				$this->validateHelper->validateNewFile([
+				$this->fileInputValidator->validateNewFile([
 					'file' => ['fileId' => $node->getId()],
 					'userManager' => $user,
 				]);

--- a/tests/php/Unit/Service/File/MimeServiceTest.php
+++ b/tests/php/Unit/Service/File/MimeServiceTest.php
@@ -9,25 +9,25 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Unit\Service\File;
 
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\File\MimeService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCP\Files\IMimeTypeDetector;
 use PHPUnit\Framework\MockObject\MockObject;
 
 final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IMimeTypeDetector|MockObject $mimeTypeDetector;
-	private ValidateHelper|MockObject $validateHelper;
+	private FileInputValidator|MockObject $fileInputValidator;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->fileInputValidator = $this->createMock(FileInputValidator::class);
 	}
 
 	private function getService(): MimeService {
 		return new MimeService(
 			$this->mimeTypeDetector,
-			$this->validateHelper,
+			$this->fileInputValidator,
 		);
 	}
 
@@ -41,7 +41,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->with($content)
 			->willReturn($expectedMime);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->expects($this->once())
 			->method('validateMimeTypeAcceptedByMime')
 			->with($expectedMime);
@@ -61,7 +61,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->method('detectString')
 			->willReturn($expectedMime);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->expects($this->once())
 			->method('validateMimeTypeAcceptedByMime');
 
@@ -91,7 +91,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'txt' => ['text/plain'],
 			]);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateMimeTypeAcceptedByMime');
 
 		$service = $this->getService();
@@ -115,7 +115,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'pdf' => ['application/pdf'],
 			]);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateMimeTypeAcceptedByMime');
 
 		$service = $this->getService();
@@ -139,7 +139,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 				'txt' => ['text/plain'],
 			]);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateMimeTypeAcceptedByMime');
 
 		$service = $this->getService();
@@ -151,7 +151,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	public function testSetMimeTypeValidatesAndSets(): void {
 		$mime = 'application/pdf';
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->expects($this->once())
 			->method('validateMimeTypeAcceptedByMime')
 			->with($mime);
@@ -170,7 +170,7 @@ final class MimeServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			->method('detectString')
 			->willReturn($mime);
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateMimeTypeAcceptedByMime');
 
 		$service = $this->getService();

--- a/tests/php/Unit/Service/File/UploadProcessorTest.php
+++ b/tests/php/Unit/Service/File/UploadProcessorTest.php
@@ -11,11 +11,11 @@ namespace OCA\Libresign\Tests\Unit\Service\File;
 
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\File\MimeService;
 use OCA\Libresign\Service\File\Pdf\PdfValidator;
 use OCA\Libresign\Service\File\UploadProcessor;
 use OCA\Libresign\Service\FolderService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\IUser;
@@ -27,7 +27,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private FolderService|MockObject $folderService;
 	private MimeService|MockObject $mimeService;
 	private PdfValidator|MockObject $pdfValidator;
-	private ValidateHelper|MockObject $validateHelper;
+	private FileInputValidator|MockObject $fileInputValidator;
 	private LoggerInterface|MockObject $logger;
 
 	public function setUp(): void {
@@ -36,7 +36,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->folderService = $this->createMock(FolderService::class);
 		$this->mimeService = $this->createMock(MimeService::class);
 		$this->pdfValidator = $this->createMock(PdfValidator::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->fileInputValidator = $this->createMock(FileInputValidator::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 	}
 
@@ -46,7 +46,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->folderService,
 			$this->mimeService,
 			$this->pdfValidator,
-			$this->validateHelper,
+			$this->fileInputValidator,
 			$this->logger,
 		);
 	}
@@ -173,7 +173,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->uploadHelper->method('readUploadedFile')->willReturn('content');
 		$this->mimeService->method('getExtension')->willReturn('pdf');
 		$this->pdfValidator->method('validate');
-		$this->validateHelper->method('validateNewFile');
+		$this->fileInputValidator->method('validateNewFile');
 
 		$targetFolder = $this->createMock(Folder::class);
 		$this->folderService->method('getFolderForFile')->willReturn($targetFolder);
@@ -205,7 +205,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->mimeService->method('getExtension')->willReturn('pdf');
 		$this->pdfValidator->method('validate');
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->expects($this->once())
 			->method('validateNewFile')
 			->with([
@@ -237,7 +237,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->mimeService->method('getExtension')->willReturn('pdf');
 		$this->pdfValidator->method('validate');
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateNewFile')
 			->willThrowException(new LibresignException('Invalid file'));
 
@@ -271,7 +271,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->mimeService->method('getExtension')->willReturn('pdf');
 		$this->pdfValidator->method('validate');
 
-		$this->validateHelper
+		$this->fileInputValidator
 			->method('validateNewFile')
 			->willThrowException(new LibresignException('Invalid file'));
 
@@ -312,7 +312,7 @@ final class UploadProcessorTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->uploadHelper->method('readUploadedFile')->willReturn('content');
 		$this->mimeService->method('getExtension')->willReturn('pdf');
 		$this->pdfValidator->method('validate');
-		$this->validateHelper->method('validateNewFile');
+		$this->fileInputValidator->method('validateNewFile');
 
 		$targetFolder = $this->createMock(Folder::class);
 		$this->folderService->method('getFolderForFile')->willReturn($targetFolder);


### PR DESCRIPTION
## Context

#8334 split `ValidateHelper` into focused validators while keeping the helper as a compatibility facade.

This PR continues the consumer migration with the file input validation domain. The scope stays small and behavior-preserving.

## Changes

- migrate `MimeService` directly to `FileInputValidator` for MIME type validation;
- migrate `UploadProcessor` directly to `FileInputValidator` for new file validation;
- update the related unit tests to mock `FileInputValidator` instead of `ValidateHelper`.

No validation behavior or public API is intentionally changed. `ValidateHelper` remains in place because other consumers still depend on it.

## Validation

The existing `MimeServiceTest` and `UploadProcessorTest` already cover the validator calls affected by this migration, including MIME validation, new-file validation and rollback after validation failure. Their mocks were updated without weakening those assertions.

## Follow-up

Other domains still have direct `ValidateHelper` consumers and should be migrated in later focused PRs:

- request/signature workflow and authorization;
- signing;
- visible elements;
- notification/activity and UI integration consumers;
- account-related consumers.

`ValidateHelper` should only be removed after a later code search confirms that no real consumers remain.