### PR TITLE
chore(github): use the maintainers team as the default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/appinfo/info.xml        @vitormattos
+* @LibreSign/maintainers


### PR DESCRIPTION
Resolves: #8300

## 📝 Summary

Replaces the single path rule in `.github/CODEOWNERS` with the team default confirmed in the issue:

```diff
-/appinfo/info.xml        @vitormattos
+* @LibreSign/maintainers
```

The individual rule is removed rather than kept alongside the default, as requested. No area-specific rules were added.

Acceptance criteria:

* [x] `.github/CODEOWNERS` uses `@LibreSign/maintainers` as the default code owner.
* [x] Individual GitHub usernames are not used as code owners.
* [x] The rule applies to the whole repository.
* [x] External contributors can continue to propose changes to any repository path — CODEOWNERS never restricts who may open a pull request or which paths it may touch; it only adds a required reviewer to the ones it matches.
* [ ] Members of the Maintainers team can satisfy the Code Owner review requirement — this one is not decidable from the file, see below.

## ⚠️ One prerequisite outside this PR

The rule only takes effect if `@LibreSign/maintainers` exists **and has write access to this repository**. GitHub does not warn when it does not: the entry is silently ignored, the ruleset still requires a Code Owner review, and no one can satisfy it — the same outcome as having no code owner at all. You mentioned you would confirm the team's access; worth doing before or right after merging.

A quick way to check afterwards is to open any pull request and confirm the team is added as a reviewer automatically.

## 📌 Heads-up: one workflow reads the removed line

`.github/workflows/update-nextcloud-ocp.yml` derives who to ping from that exact path (line 63):

```sh
grep '/appinfo/info.xml' .github/CODEOWNERS | cut -f 2- -d ' ' | xargs | awk '{ print "codeowners="$0 }' >> $GITHUB_OUTPUT
```

The value is used only in the body of the issue raised when the `nextcloud/ocp` update fails (line 101). Running that pipeline against both versions of the file:

| CODEOWNERS | step output |
| --- | --- |
| `/appinfo/info.xml        @vitormattos` | `codeowners=@vitormattos` |
| `* @LibreSign/maintainers` | `codeowners=` |

Nothing breaks and no job turns red — `grep` finds nothing, but GNU `xargs` still runs `echo` once, so the step exits 0 with an empty value. The only effect is that the failure issue no longer names anyone to notify.

I left the workflow untouched on purpose: it comes from the `nextcloud/.github` template (its header says so, and the `grep` line arrived in a template bump), so a local edit would be overwritten by the next wholesale sync unless it is carried in a `update-nextcloud-ocp.yml.patch` file. If you want it fixed here, the one-line change is `grep '^\* ' .github/CODEOWNERS`; happy to add it to this PR or open a separate one.

## 🧪 How to test

The change is a single line, so review is mostly reading it:

```sh
cat .github/CODEOWNERS
# * @LibreSign/maintainers
```

After merge, opening any pull request should show `@LibreSign/maintainers` requested as a reviewer automatically — that is the real confirmation that the team resolves and has the required access.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Commit signed off (DCO).
- [x] No area-specific ownership rules added, per the issue.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
