### PR TITLE
refactor: migrate request and visible element validation

### DIFF
--- a/lib/Controller/FileElementController.php
+++ b/lib/Controller/FileElementController.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 namespace OCA\Libresign\Controller;
 
 use OCA\Libresign\AppInfo\Application;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\ResponseDefinitions;
 use OCA\Libresign\Service\FileElementService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -31,7 +33,8 @@ class FileElementController extends AEnvironmentAwareController {
 		IRequest $request,
 		private FileElementService $fileElementService,
 		private IUserSession $userSession,
-		private ValidateHelper $validateHelper,
+		private VisibleElementValidator $visibleElementValidator,
+		private SigningRequestValidator $signingRequestValidator,
 		private LoggerInterface $logger,
 	) {
 		parent::__construct(Application::APP_ID, $request);
@@ -68,8 +71,8 @@ class FileElementController extends AEnvironmentAwareController {
 			'fileId' => $fileId,
 		];
 		try {
-			$this->validateHelper->validateVisibleElement($visibleElement, ValidateHelper::TYPE_VISIBLE_ELEMENT_PDF);
-			$this->validateHelper->validateExistingFile([
+			$this->visibleElementValidator->validateVisibleElement($visibleElement, FileInputValidator::TYPE_VISIBLE_ELEMENT_PDF);
+			$this->signingRequestValidator->validateExistingFile([
 				'uuid' => $uuid,
 				'userManager' => $this->userSession->getUser()
 			]);
@@ -129,11 +132,11 @@ class FileElementController extends AEnvironmentAwareController {
 	#[ApiRoute(verb: 'DELETE', url: '/api/{apiVersion}/file-element/{uuid}/{elementId}', requirements: ['apiVersion' => '(v1)'])]
 	public function deleteVisibleElement(string $uuid, int $elementId): DataResponse {
 		try {
-			$this->validateHelper->validateExistingFile([
+			$this->signingRequestValidator->validateExistingFile([
 				'uuid' => $uuid,
 				'userManager' => $this->userSession->getUser()
 			]);
-			$this->validateHelper->validateAuthenticatedUserIsOwnerOfPdfVisibleElement($elementId, $this->userSession->getUser()->getUID());
+			$this->visibleElementValidator->validateAuthenticatedUserIsOwnerOfPdfVisibleElement($elementId, $this->userSession->getUser()->getUID());
 			$this->fileElementService->deleteVisibleElement($elementId);
 			return new DataResponse();
 		} catch (\Throwable $th) {

--- a/lib/Controller/RequestSignatureController.php
+++ b/lib/Controller/RequestSignatureController.php
@@ -10,11 +10,11 @@ namespace OCA\Libresign\Controller;
 
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\RequireManager;
 use OCA\Libresign\Service\File\FileListService;
 use OCA\Libresign\Service\RequestSignatureService;
 use OCA\Libresign\Service\RequestSignatureWorkflowService;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -42,7 +42,7 @@ class RequestSignatureController extends AEnvironmentAwareController {
 		protected IL10N $l10n,
 		protected IUserSession $userSession,
 		protected FileListService $fileListService,
-		protected ValidateHelper $validateHelper,
+		protected SigningRequestValidator $signingRequestValidator,
 		protected RequestSignatureService $requestSignatureService,
 		private RequestSignatureWorkflowService $requestSignatureWorkflowService,
 	) {
@@ -234,9 +234,9 @@ class RequestSignatureController extends AEnvironmentAwareController {
 					'fileId' => $fileId
 				]
 			];
-			$this->validateHelper->validateExistingFile($data);
-			$this->validateHelper->validateWorkflowIsNotClosedByFileId($fileId);
-			$this->validateHelper->validateIsSignerOfFile($signRequestId, $fileId);
+			$this->signingRequestValidator->validateExistingFile($data);
+			$this->signingRequestValidator->validateWorkflowIsNotClosedByFileId($fileId);
+			$this->signingRequestValidator->validateIsSignerOfFile($signRequestId, $fileId);
 			$this->requestSignatureService->unassociateToUser($fileId, $signRequestId);
 		} catch (\Throwable $th) {
 			return new DataResponse(
@@ -280,7 +280,7 @@ class RequestSignatureController extends AEnvironmentAwareController {
 					'fileId' => $fileId
 				]
 			];
-			$this->validateHelper->validateExistingFile($data);
+			$this->signingRequestValidator->validateExistingFile($data);
 			$this->requestSignatureService->deleteRequestSignature($data);
 		} catch (\Throwable $th) {
 			return new DataResponse(

--- a/lib/Controller/SignatureElementsController.php
+++ b/lib/Controller/SignatureElementsController.php
@@ -9,13 +9,14 @@ declare(strict_types=1);
 namespace OCA\Libresign\Controller;
 
 use OCA\Libresign\AppInfo\Application;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\RequireSignRequestUuid;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\SessionService;
 use OCA\Libresign\Service\SignatureTextService;
 use OCA\Libresign\Service\SignerElementsService;
 use OCA\Libresign\Service\SignFileService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -54,7 +55,7 @@ class SignatureElementsController extends AEnvironmentAwareController implements
 		private IPreview $preview,
 		protected IMimeIconProvider $mimeIconProvider,
 		protected IURLGenerator $urlGenerator,
-		private ValidateHelper $validateHelper,
+		private VisibleElementValidator $visibleElementValidator,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}
@@ -76,7 +77,7 @@ class SignatureElementsController extends AEnvironmentAwareController implements
 	#[ApiRoute(verb: 'POST', url: '/api/{apiVersion}/signature/elements', requirements: ['apiVersion' => '(v1)'])]
 	public function createSignatureElement(array $elements): DataResponse {
 		try {
-			$this->validateHelper->validateVisibleElements($elements, $this->validateHelper::TYPE_VISIBLE_ELEMENT_USER);
+			$this->visibleElementValidator->validateVisibleElements($elements, FileInputValidator::TYPE_VISIBLE_ELEMENT_USER);
 			$this->accountService->saveVisibleElements(
 				elements: $elements,
 				sessionId: $this->sessionService->getSessionId(),
@@ -252,7 +253,7 @@ class SignatureElementsController extends AEnvironmentAwareController implements
 			if ($file) {
 				$element['file'] = $file;
 			}
-			$this->validateHelper->validateVisibleElement($element, $this->validateHelper::TYPE_VISIBLE_ELEMENT_USER);
+			$this->visibleElementValidator->validateVisibleElement($element, FileInputValidator::TYPE_VISIBLE_ELEMENT_USER);
 			$user = $this->userSession->getUser();
 			if ($user instanceof IUser) {
 				$userElement = $this->signerElementsService->getUserElementByNodeId(
@@ -318,7 +319,7 @@ class SignatureElementsController extends AEnvironmentAwareController implements
 		}
 		return new DataResponse(
 			[
-				// TRANSLATORS Success message shown after removing a visible signature or initials element from the document.
+				// TRANSLATORS Message shown after deleting the stored visible signature element.
 				'message' => $this->l10n->t('Visible element deleted')
 			],
 			Http::STATUS_OK

--- a/lib/Service/RequestSignatureWorkflowService.php
+++ b/lib/Service/RequestSignatureWorkflowService.php
@@ -11,7 +11,10 @@ namespace OCA\Libresign\Service;
 use OCA\Libresign\Db\File as FileEntity;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCP\IL10N;
 use OCP\IUser;
 
@@ -19,7 +22,9 @@ final class RequestSignatureWorkflowService {
 	public function __construct(
 		private IL10N $l10n,
 		private RequestSignatureService $requestSignatureService,
-		private ValidateHelper $validateHelper,
+		private SigningRequestValidator $signingRequestValidator,
+		private SignerValidator $signerValidator,
+		private VisibleElementValidator $visibleElementValidator,
 		private FileMapper $fileMapper,
 	) {
 	}
@@ -139,12 +144,12 @@ final class RequestSignatureWorkflowService {
 			$data['status'] = $status;
 		}
 
-		$this->validateHelper->validateExistingFile($data);
-		$this->validateHelper->validateWorkflowIsNotClosedByUuid($uuid);
-		$this->validateHelper->validateFileStatus($data);
-		$this->validateHelper->validateIdentifySigners($data);
+		$this->signingRequestValidator->validateExistingFile($data);
+		$this->signingRequestValidator->validateWorkflowIsNotClosedByUuid($uuid);
+		$this->signingRequestValidator->validateFileStatus($data);
+		$this->signerValidator->validateIdentifySigners($data);
 		if (!empty($visibleElements)) {
-			$this->validateHelper->validateVisibleElements($visibleElements, ValidateHelper::TYPE_VISIBLE_ELEMENT_PDF);
+			$this->visibleElementValidator->validateVisibleElements($visibleElements, FileInputValidator::TYPE_VISIBLE_ELEMENT_PDF);
 		}
 		$fileEntity = $this->requestSignatureService->save($data);
 

--- a/tests/php/Unit/Controller/RequestSignatureControllerTest.php
+++ b/tests/php/Unit/Controller/RequestSignatureControllerTest.php
@@ -13,10 +13,12 @@ use OCA\Libresign\Controller\RequestSignatureController;
 use OCA\Libresign\Db\File as FileEntity;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\File\FileListService;
 use OCA\Libresign\Service\RequestSignatureService;
 use OCA\Libresign\Service\RequestSignatureWorkflowService;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCP\AppFramework\Http;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -32,7 +34,9 @@ final class RequestSignatureControllerTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private IUserSession&MockObject $userSession;
 	private FileListService&MockObject $fileListService;
-	private ValidateHelper&MockObject $validateHelper;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
+	private SignerValidator&MockObject $signerValidator;
+	private VisibleElementValidator&MockObject $visibleElementValidator;
 	private RequestSignatureService&MockObject $requestSignatureService;
 	private FileMapper&MockObject $fileMapper;
 	private RequestSignatureWorkflowService $requestSignatureWorkflowService;
@@ -43,7 +47,9 @@ final class RequestSignatureControllerTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->fileListService = $this->createMock(FileListService::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
+		$this->signerValidator = $this->createMock(SignerValidator::class);
+		$this->visibleElementValidator = $this->createMock(VisibleElementValidator::class);
 		$this->requestSignatureService = $this->createMock(RequestSignatureService::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->user = $this->createMock(IUser::class);
@@ -53,7 +59,9 @@ final class RequestSignatureControllerTest extends TestCase {
 		$this->requestSignatureWorkflowService = new RequestSignatureWorkflowService(
 			$this->l10n,
 			$this->requestSignatureService,
-			$this->validateHelper,
+			$this->signingRequestValidator,
+			$this->signerValidator,
+			$this->visibleElementValidator,
 			$this->fileMapper,
 		);
 
@@ -62,7 +70,7 @@ final class RequestSignatureControllerTest extends TestCase {
 			$this->l10n,
 			$this->userSession,
 			$this->fileListService,
-			$this->validateHelper,
+			$this->signingRequestValidator,
 			$this->requestSignatureService,
 			$this->requestSignatureWorkflowService,
 		);
@@ -259,11 +267,15 @@ final class RequestSignatureControllerTest extends TestCase {
 		$file->setId(20);
 		$file->setParentFileId(88);
 
-		$this->validateHelper
+		$this->signingRequestValidator
 			->expects($this->once())
 			->method('validateExistingFile');
 
-		$this->validateHelper
+		$this->signingRequestValidator
+			->expects($this->once())
+			->method('validateWorkflowIsNotClosedByUuid');
+
+		$this->signingRequestValidator
 			->expects($this->once())
 			->method('validateFileStatus')
 			->with($this->callback(static function (array $payload) use ($expectStatusKey, $status): bool {
@@ -277,7 +289,7 @@ final class RequestSignatureControllerTest extends TestCase {
 				return true;
 			}));
 
-		$this->validateHelper
+		$this->signerValidator
 			->expects($this->once())
 			->method('validateIdentifySigners');
 

--- a/tests/php/Unit/Service/RequestSignatureWorkflowServiceTest.php
+++ b/tests/php/Unit/Service/RequestSignatureWorkflowServiceTest.php
@@ -11,9 +11,12 @@ namespace OCA\Libresign\Tests\Unit\Service;
 use OCA\Libresign\Db\File as FileEntity;
 use OCA\Libresign\Db\FileMapper;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\RequestSignatureService;
 use OCA\Libresign\Service\RequestSignatureWorkflowService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCP\IL10N;
 use OCP\IUser;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -23,7 +26,9 @@ use PHPUnit\Framework\TestCase;
 final class RequestSignatureWorkflowServiceTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private RequestSignatureService&MockObject $requestSignatureService;
-	private ValidateHelper&MockObject $validateHelper;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
+	private SignerValidator&MockObject $signerValidator;
+	private VisibleElementValidator&MockObject $visibleElementValidator;
 	private FileMapper&MockObject $fileMapper;
 	private RequestSignatureWorkflowService $service;
 	private IUser&MockObject $user;
@@ -33,7 +38,9 @@ final class RequestSignatureWorkflowServiceTest extends TestCase {
 
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->requestSignatureService = $this->createMock(RequestSignatureService::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
+		$this->signerValidator = $this->createMock(SignerValidator::class);
+		$this->visibleElementValidator = $this->createMock(VisibleElementValidator::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
 		$this->user = $this->createMock(IUser::class);
 		$this->l10n->method('t')->willReturnCallback(static fn (string $message): string => $message);
@@ -41,7 +48,9 @@ final class RequestSignatureWorkflowServiceTest extends TestCase {
 		$this->service = new RequestSignatureWorkflowService(
 			$this->l10n,
 			$this->requestSignatureService,
-			$this->validateHelper,
+			$this->signingRequestValidator,
+			$this->signerValidator,
+			$this->visibleElementValidator,
 			$this->fileMapper,
 		);
 	}
@@ -154,12 +163,13 @@ final class RequestSignatureWorkflowServiceTest extends TestCase {
 		$child = new FileEntity();
 		$child->setId(22);
 
-		$this->validateHelper->expects($this->once())->method('validateExistingFile');
-		$this->validateHelper->expects($this->once())->method('validateFileStatus');
-		$this->validateHelper->expects($this->once())->method('validateIdentifySigners');
-		$this->validateHelper->expects($this->once())
+		$this->signingRequestValidator->expects($this->once())->method('validateExistingFile');
+		$this->signingRequestValidator->expects($this->once())->method('validateWorkflowIsNotClosedByUuid')->with('uuid-1');
+		$this->signingRequestValidator->expects($this->once())->method('validateFileStatus');
+		$this->signerValidator->expects($this->once())->method('validateIdentifySigners');
+		$this->visibleElementValidator->expects($this->once())
 			->method('validateVisibleElements')
-			->with([['fileId' => 22]], ValidateHelper::TYPE_VISIBLE_ELEMENT_PDF);
+			->with([['fileId' => 22]], FileInputValidator::TYPE_VISIBLE_ELEMENT_PDF);
 
 		$this->requestSignatureService->expects($this->once())
 			->method('save')
@@ -196,10 +206,11 @@ final class RequestSignatureWorkflowServiceTest extends TestCase {
 		$fileEntity->setId(40);
 		$fileEntity->setParentFileId(99);
 
-		$this->validateHelper->expects($this->once())->method('validateExistingFile');
-		$this->validateHelper->expects($this->once())->method('validateFileStatus');
-		$this->validateHelper->expects($this->once())->method('validateIdentifySigners');
-		$this->validateHelper->expects($this->never())->method('validateVisibleElements');
+		$this->signingRequestValidator->expects($this->once())->method('validateExistingFile');
+		$this->signingRequestValidator->expects($this->once())->method('validateWorkflowIsNotClosedByUuid')->with('uuid-2');
+		$this->signingRequestValidator->expects($this->once())->method('validateFileStatus');
+		$this->signerValidator->expects($this->once())->method('validateIdentifySigners');
+		$this->visibleElementValidator->expects($this->never())->method('validateVisibleElements');
 
 		$this->requestSignatureService->expects($this->once())
 			->method('save')


### PR DESCRIPTION
## Context

#8334 split `ValidateHelper` into focused validators while keeping the helper as a compatibility facade. #8336 and #8337 started migrating consumers in small domain-focused steps.

This PR takes a broader step across the request-signature and visible-element flows. The goal is to remove the facade from consumers that already have clear ownership boundaries without changing validation behavior.

## Changes

- migrate `FileElementController` to:
  - `VisibleElementValidator` for visible element rules and ownership;
  - `SigningRequestValidator` for file/request validation.
- migrate `SignatureElementsController` directly to `VisibleElementValidator`.
- migrate `RequestSignatureWorkflowService` to:
  - `SigningRequestValidator` for workflow/file state rules;
  - `SignerValidator` for signer identification rules;
  - `VisibleElementValidator` for visible element validation.
- migrate `RequestSignatureController` directly to `SigningRequestValidator`.
- update the related unit tests to mock the focused validators instead of `ValidateHelper`.
- make the existing workflow tests explicitly assert `validateWorkflowIsNotClosedByUuid()`, which was already executed by production code but was not asserted by these tests.

The visible-element input type constants continue to come from `FileInputValidator` because they select the file-input validation mode used by `VisibleElementValidator`. No compatibility alias from `ValidateHelper` is used by the migrated consumers.

No validation behavior or public API is intentionally changed. `ValidateHelper` remains in place because other consumers still depend on it.

## Follow-up

Remaining consumers should be migrated in later focused changes, especially:

- the signing execution flow, including `SignFileController`;
- notification, activity and UI integration consumers;
- account/file controllers and middleware;
- any remaining service-level consumers.

After those migrations, a final code search should confirm that no real consumers remain before removing `ValidateHelper` and its compatibility constants.