### PR TITLE
refactor: migrate remaining validation consumers across signing flows

### DIFF
--- a/lib/Activity/Settings/FileSigned.php
+++ b/lib/Activity/Settings/FileSigned.php
@@ -10,7 +10,7 @@ namespace OCA\Libresign\Activity\Settings;
 
 use OCA\Libresign\Events\SignedEvent;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -18,7 +18,7 @@ use OCP\IUserSession;
 class FileSigned extends LibresignActivitySettings {
 	public function __construct(
 		protected IL10N $l,
-		protected ValidateHelper $validateHelper,
+		protected SigningRequestValidator $signingRequestValidator,
 		protected IUserSession $userSession,
 	) {
 	}
@@ -57,7 +57,7 @@ class FileSigned extends LibresignActivitySettings {
 			return true;
 		}
 		try {
-			$this->validateHelper->canrequestSign($this->userSession->getUser());
+			$this->signingRequestValidator->canRequestSign($this->userSession->getUser());
 		} catch (LibresignException) {
 			return false;
 		}
@@ -73,7 +73,7 @@ class FileSigned extends LibresignActivitySettings {
 			return true;
 		}
 		try {
-			$this->validateHelper->canrequestSign($this->userSession->getUser());
+			$this->signingRequestValidator->canRequestSign($this->userSession->getUser());
 		} catch (LibresignException) {
 			return false;
 		}

--- a/lib/Activity/Settings/SignRequestCanceled.php
+++ b/lib/Activity/Settings/SignRequestCanceled.php
@@ -9,15 +9,11 @@ declare(strict_types=1);
 namespace OCA\Libresign\Activity\Settings;
 
 use OCA\Libresign\Events\SignRequestCanceledEvent;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCP\IL10N;
-use OCP\IUserSession;
 
 class SignRequestCanceled extends LibresignActivitySettings {
 	public function __construct(
 		protected IL10N $l,
-		protected ValidateHelper $validateHelper,
-		protected IUserSession $userSession,
 	) {
 	}
 

--- a/lib/Activity/Settings/SignatureRejected.php
+++ b/lib/Activity/Settings/SignatureRejected.php
@@ -9,15 +9,11 @@ declare(strict_types=1);
 namespace OCA\Libresign\Activity\Settings;
 
 use OCA\Libresign\Events\SignatureRejectedEvent;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCP\IL10N;
-use OCP\IUserSession;
 
 class SignatureRejected extends LibresignActivitySettings {
 	public function __construct(
 		protected IL10N $l,
-		protected ValidateHelper $validateHelper,
-		protected IUserSession $userSession,
 	) {
 	}
 

--- a/lib/Controller/SignFileController.php
+++ b/lib/Controller/SignFileController.php
@@ -15,7 +15,6 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\SigningErrorHandler;
 use OCA\Libresign\Helper\JSActions;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\CanSignRequestUuid;
 use OCA\Libresign\Middleware\Attribute\RequireManager;
 use OCA\Libresign\Middleware\Attribute\RequireSigner;
@@ -28,6 +27,10 @@ use OCA\Libresign\Service\RequestMetadataService;
 use OCA\Libresign\Service\SignatureRejection\SignatureRejectionService;
 use OCA\Libresign\Service\SignerGeolocation\SignerGeolocationMetadataValidator;
 use OCA\Libresign\Service\SignFileService;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
+use OCA\Libresign\Service\Validation\VisibleElementValidator;
 use OCA\Libresign\Service\Worker\WorkerHealthService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -56,7 +59,10 @@ class SignFileController extends AEnvironmentAwareController implements ISignatu
 		protected IL10N $l10n,
 		private SignRequestMapper $signRequestMapper,
 		protected IUserSession $userSession,
-		private ValidateHelper $validateHelper,
+		private IdentityDocumentValidator $identityDocumentValidator,
+		private VisibleElementValidator $visibleElementValidator,
+		private SignerValidator $signerValidator,
+		private SigningRequestValidator $signingRequestValidator,
 		protected SignFileService $signFileService,
 		private IdentifyMethodService $identifyMethodService,
 		private FileService $fileService,
@@ -150,13 +156,13 @@ class SignFileController extends AEnvironmentAwareController implements ISignatu
 				$signRequest = $this->signFileService->getSignRequestToSign($libreSignFile, $signRequestUuid, $user);
 			}
 
-			$this->validateHelper->canSignWithIdentificationDocumentStatus(
+			$this->identityDocumentValidator->canSignWithIdentificationDocumentStatus(
 				$user,
 				$this->settingsLoader->getIdentificationDocumentsStatus($user, $signRequest)
 			);
 
-			$this->validateHelper->validateVisibleElementsRelation($elements, $signRequest, $user);
-			$this->validateHelper->validateCredentials($signRequest, $method, $identifyValue, $token);
+			$this->visibleElementValidator->validateVisibleElementsRelation($elements, $signRequest, $user);
+			$this->signerValidator->validateCredentials($signRequest, $method, $identifyValue, $token);
 
 			$userIdentifier = $this->identifyMethodService->getUserIdentifier($signRequest->getId());
 			$metadata = $this->requestMetadataService->collectMetadata();
@@ -434,7 +440,7 @@ class SignFileController extends AEnvironmentAwareController implements ISignatu
 	private function getCode(SignRequest $signRequest): DataResponse {
 		try {
 			$libreSignFile = $this->signFileService->getFile($signRequest->getFileId());
-			$this->validateHelper->fileCanBeSigned($libreSignFile);
+			$this->signingRequestValidator->fileCanBeSigned($libreSignFile);
 			$this->signFileService->requestCode(
 				signRequest: $signRequest,
 				identifyMethodName: $this->request->getParam('identifyMethod', ''),

--- a/lib/Files/TemplateLoader.php
+++ b/lib/Files/TemplateLoader.php
@@ -12,10 +12,10 @@ use OCA\Files\Event\LoadSidebar;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\Policy\PolicyService;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
@@ -32,7 +32,7 @@ class TemplateLoader implements IEventListener {
 		private IUserSession $userSession,
 		private AccountService $accountService,
 		private IInitialState $initialState,
-		private ValidateHelper $validateHelper,
+		private SigningRequestValidator $signingRequestValidator,
 		private IdentifyMethodService $identifyMethodService,
 		private CertificateEngineFactory $certificateEngineFactory,
 		private PolicyService $policyService,
@@ -76,7 +76,7 @@ class TemplateLoader implements IEventListener {
 
 	private function canRequestSign(): bool {
 		try {
-			$this->validateHelper->canRequestSign($this->userSession->getUser());
+			$this->signingRequestValidator->canRequestSign($this->userSession->getUser());
 			return true;
 		} catch (LibresignException) {
 			return false;

--- a/lib/Helper/ValidateHelper.php
+++ b/lib/Helper/ValidateHelper.php
@@ -28,10 +28,7 @@ class ValidateHelper {
 	public const TYPE_VISIBLE_ELEMENT_PDF = FileInputValidator::TYPE_VISIBLE_ELEMENT_PDF;
 	public const TYPE_VISIBLE_ELEMENT_USER = FileInputValidator::TYPE_VISIBLE_ELEMENT_USER;
 	public const TYPE_ACCOUNT_DOCUMENT = FileInputValidator::TYPE_ACCOUNT_DOCUMENT;
-	public const VALID_MIMETIPE = [
-		'application/pdf',
-		'image/png',
-	];
+	public const VALID_MIMETIPE = FileInputValidator::VALID_MIMETIPE;
 
 	public function __construct(
 		private FileInputValidator $fileInputValidator,

--- a/lib/Listener/BeforeNodeDeletedListener.php
+++ b/lib/Listener/BeforeNodeDeletedListener.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Libresign\Listener;
 
 use OCA\Libresign\Enum\FileStatus;
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -35,7 +35,7 @@ class BeforeNodeDeletedListener implements IEventListener {
 			if (!$node instanceof File && !$node instanceof Folder) {
 				return;
 			}
-			if ($node instanceof File && !in_array($node->getMimeType(), ValidateHelper::VALID_MIMETIPE)) {
+			if ($node instanceof File && !in_array($node->getMimeType(), FileInputValidator::VALID_MIMETIPE)) {
 				return;
 			}
 

--- a/lib/Service/NotifyService.php
+++ b/lib/Service/NotifyService.php
@@ -11,8 +11,10 @@ namespace OCA\Libresign\Service;
 use OCA\Libresign\AppInfo\Application;
 use OCA\Libresign\Db\SignRequest;
 use OCA\Libresign\Db\SignRequestMapper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
 use OCP\IUser;
@@ -21,7 +23,9 @@ use OCP\Notification\IManager;
 
 class NotifyService {
 	public function __construct(
-		private ValidateHelper $validateHelper,
+		private SigningRequestValidator $signingRequestValidator,
+		private FileInputValidator $fileInputValidator,
+		private IdentityDocumentValidator $identityDocumentValidator,
 		private IUserSession $userSession,
 		private SignRequestMapper $signRequestMapper,
 		private IdentifyMethodService $identifyMethodService,
@@ -34,25 +38,25 @@ class NotifyService {
 	}
 
 	public function signer(int $fileId, int $signRequestId): void {
-		$this->validateHelper->canRequestSign($this->userSession->getUser());
-		$this->validateHelper->validateLibreSignFileId($fileId);
-		$this->validateHelper->validateWorkflowIsNotClosedByFileId($fileId);
+		$this->signingRequestValidator->canRequestSign($this->userSession->getUser());
+		$this->fileInputValidator->validateLibreSignFileId($fileId);
+		$this->signingRequestValidator->validateWorkflowIsNotClosedByFileId($fileId);
 		$signRequest = $this->signRequestMapper->getByFileIdAndSignRequestId($fileId, $signRequestId);
-		$this->validateHelper->iRequestedSignThisFile($this->userSession->getUser(), $fileId);
+		$this->signingRequestValidator->iRequestedSignThisFile($this->userSession->getUser(), $fileId);
 		$this->notify($signRequest);
 	}
 
 	public function signers(int $fileId, array $signers): void {
-		$this->validateHelper->canRequestSign($this->userSession->getUser());
-		$this->validateHelper->validateLibreSignFileId($fileId);
-		$this->validateHelper->validateWorkflowIsNotClosedByFileId($fileId);
+		$this->signingRequestValidator->canRequestSign($this->userSession->getUser());
+		$this->fileInputValidator->validateLibreSignFileId($fileId);
+		$this->signingRequestValidator->validateWorkflowIsNotClosedByFileId($fileId);
 		$signRequests = $this->signRequestMapper->getByFileId($fileId);
 		if (!empty($signRequests)) {
-			$this->validateHelper->iRequestedSignThisFile($this->userSession->getUser(), $fileId);
+			$this->signingRequestValidator->iRequestedSignThisFile($this->userSession->getUser(), $fileId);
 		}
 		$signRequestIndex = $this->signerIndexProvider->build($signRequests);
 		foreach ($signers as $signer) {
-			$this->validateHelper->haveValidMail($signer);
+			$this->identityDocumentValidator->haveValidMail($signer);
 			$this->validateSignerForNotification($signer, $signRequestIndex);
 		}
 		// @todo refactor this code

--- a/lib/Service/Validation/FileInputValidator.php
+++ b/lib/Service/Validation/FileInputValidator.php
@@ -24,6 +24,10 @@ class FileInputValidator {
 	public const TYPE_VISIBLE_ELEMENT_PDF = 2;
 	public const TYPE_VISIBLE_ELEMENT_USER = 3;
 	public const TYPE_ACCOUNT_DOCUMENT = 4;
+	public const VALID_MIMETIPE = [
+		'application/pdf',
+		'image/png',
+	];
 
 	public function __construct(
 		private IL10N $l10n,

--- a/tests/php/Unit/Activity/FileSignedTest.php
+++ b/tests/php/Unit/Activity/FileSignedTest.php
@@ -11,7 +11,7 @@ namespace OCA\Libresign\Tests\Unit\Activity;
 use OCA\Libresign\Activity\Settings\FileSigned;
 use OCA\Libresign\Events\SignedEvent;
 use OCA\Libresign\Exception\LibresignException;
-use OCA\Libresign\Helper\ValidateHelper;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -19,19 +19,19 @@ use PHPUnit\Framework\TestCase;
 
 class FileSignedTest extends TestCase {
 	private $l10nMock;
-	private $validateHelperMock;
+	private $signingRequestValidatorMock;
 	private $userSessionMock;
 
 	protected function setUp(): void {
 		$this->l10nMock = $this->createMock(IL10N::class);
-		$this->validateHelperMock = $this->createMock(ValidateHelper::class);
+		$this->signingRequestValidatorMock = $this->createMock(SigningRequestValidator::class);
 		$this->userSessionMock = $this->createMock(IUserSession::class);
 	}
 
 	private function getClass(): FileSigned {
 		return new FileSigned(
 			$this->l10nMock,
-			$this->validateHelperMock,
+			$this->signingRequestValidatorMock,
 			$this->userSessionMock
 		);
 	}
@@ -43,7 +43,7 @@ class FileSignedTest extends TestCase {
 	public function testCanChangeNotificationSuccess(): void {
 		$userMock = $this->createMock(IUser::class);
 		$this->userSessionMock->method('getUser')->willReturn($userMock);
-		$this->validateHelperMock->method('canrequestSign')->with($userMock);
+		$this->signingRequestValidatorMock->method('canRequestSign')->with($userMock);
 
 		$this->assertTrue($this->getClass()->canChangeNotification());
 	}
@@ -51,7 +51,7 @@ class FileSignedTest extends TestCase {
 	public function testCanChangeNotificationFailure(): void {
 		$userMock = $this->createMock(IUser::class);
 		$this->userSessionMock->method('getUser')->willReturn($userMock);
-		$this->validateHelperMock->method('canrequestSign')
+		$this->signingRequestValidatorMock->method('canRequestSign')
 			->willThrowException(new LibresignException());
 
 		$this->assertFalse($this->getClass()->canChangeNotification());
@@ -60,7 +60,7 @@ class FileSignedTest extends TestCase {
 	public function testCanChangeMailSuccess(): void {
 		$userMock = $this->createMock(IUser::class);
 		$this->userSessionMock->method('getUser')->willReturn($userMock);
-		$this->validateHelperMock->method('canrequestSign')->with($userMock);
+		$this->signingRequestValidatorMock->method('canRequestSign')->with($userMock);
 
 		$this->assertTrue($this->getClass()->canChangeMail());
 	}
@@ -68,7 +68,7 @@ class FileSignedTest extends TestCase {
 	public function testCanChangeMailFailure(): void {
 		$userMock = $this->createMock(IUser::class);
 		$this->userSessionMock->method('getUser')->willReturn($userMock);
-		$this->validateHelperMock->method('canrequestSign')
+		$this->signingRequestValidatorMock->method('canRequestSign')
 			->willThrowException(new LibresignException());
 
 		$this->assertFalse($this->getClass()->canChangeMail());

--- a/tests/php/Unit/Activity/Settings/SignatureRejectedTest.php
+++ b/tests/php/Unit/Activity/Settings/SignatureRejectedTest.php
@@ -10,9 +10,7 @@ namespace OCA\Libresign\Tests\Unit\Activity\Settings;
 
 use OCA\Libresign\Activity\Settings\SignatureRejected;
 use OCA\Libresign\Events\SignatureRejectedEvent;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCP\IL10N;
-use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 
 final class SignatureRejectedTest extends TestCase {
@@ -20,11 +18,7 @@ final class SignatureRejectedTest extends TestCase {
 		$l10n = $this->createMock(IL10N::class);
 		$l10n->method('t')->willReturnArgument(0);
 
-		return new SignatureRejected(
-			$l10n,
-			$this->createMock(ValidateHelper::class),
-			$this->createMock(IUserSession::class),
-		);
+		return new SignatureRejected($l10n);
 	}
 
 	public function testGetIdentifier(): void {

--- a/tests/php/Unit/Files/TemplateLoaderTest.php
+++ b/tests/php/Unit/Files/TemplateLoaderTest.php
@@ -14,10 +14,10 @@ use OCA\Libresign\Files\TemplateLoader;
 use OCA\Libresign\Files\TemplateLoaderAssets;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Handler\CertificateEngine\IEngineHandler;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\IdentifyMethodService;
 use OCA\Libresign\Service\Policy\PolicyService;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCA\Libresign\Tests\Unit\TestCase;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
@@ -31,7 +31,7 @@ final class TemplateLoaderTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private AccountService&MockObject $accountService;
 	private IInitialState&MockObject $initialState;
-	private ValidateHelper&MockObject $validateHelper;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
 	private IdentifyMethodService&MockObject $identifyMethodService;
 	private CertificateEngineFactory&MockObject $certificateEngineFactory;
 	private PolicyService&MockObject $policyService;
@@ -44,7 +44,7 @@ final class TemplateLoaderTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->initialState = $this->createMock(IInitialState::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
 		$this->certificateEngineFactory = $this->createMock(CertificateEngineFactory::class);
 		$this->policyService = $this->createMock(PolicyService::class);
@@ -67,7 +67,7 @@ final class TemplateLoaderTest extends TestCase {
 			->method('getIdentifyMethodsSettings')
 			->willReturn([]);
 
-		$this->validateHelper
+		$this->signingRequestValidator
 			->method('canRequestSign');
 
 		$user = $this->createMock(IUser::class);
@@ -157,7 +157,7 @@ final class TemplateLoaderTest extends TestCase {
 			->method('getIdentifyMethodsSettings')
 			->willReturn([]);
 
-		$this->validateHelper
+		$this->signingRequestValidator
 			->method('canRequestSign')
 			->willThrowException(new \OCA\Libresign\Exception\LibresignException('no'));
 
@@ -217,7 +217,7 @@ final class TemplateLoaderTest extends TestCase {
 			$this->userSession,
 			$this->accountService,
 			$this->initialState,
-			$this->validateHelper,
+			$this->signingRequestValidator,
 			$this->identifyMethodService,
 			$this->certificateEngineFactory,
 			$this->policyService,


### PR DESCRIPTION
## Context

#8334 split `ValidateHelper` into focused validators while keeping the helper as a compatibility facade. #8336, #8337 and #8343 progressively migrated consumers.

This PR takes a broader migration step. Instead of focusing on a single small domain, it removes `ValidateHelper` from several independent consumers where validator ownership is already clear, while keeping behavior unchanged.

## Changes

- migrate `SignFileController` to the focused validators it actually uses:
  - `IdentityDocumentValidator` for identification document status;
  - `VisibleElementValidator` for visible element relations;
  - `SignerValidator` for signer credentials;
  - `SigningRequestValidator` for signable-file checks.
- migrate `NotifyService` to:
  - `SigningRequestValidator` for request permissions and workflow state;
  - `FileInputValidator` for LibreSign file ID validation;
  - `IdentityDocumentValidator` for signer email validation.
- migrate `TemplateLoader` and `FileSigned` directly to `SigningRequestValidator`.
- remove unused `ValidateHelper` constructor dependencies from `SignatureRejected` and `SignRequestCanceled`.
- move the valid MIME type list to `FileInputValidator`, where the file-input constants already live.
- migrate `BeforeNodeDeletedListener` to use the MIME list from `FileInputValidator`.
- keep `ValidateHelper::VALID_MIMETIPE` as a compatibility alias so the facade remains backward-compatible while other consumers still exist.
- update the affected activity tests to use the focused validator or remove obsolete mocks.

No validation behavior or public API is intentionally changed. `ValidateHelper` remains because additional production consumers still depend on it.

## Follow-up

The remaining migration is now concentrated in larger consumers, especially:

- `RequestSignatureService`;
- `AccountService` and `AccountController`;
- `SignFileService`;
- `FileController` and `PageController`;
- `InjectionMiddleware`;
- related unit tests that instantiate these services directly.

After those consumers are migrated, a final cleanup PR can remove `ValidateHelper` and its compatibility aliases after a complete code search confirms that no real consumers remain.