### PR TITLE
refactor(sign-engine): return the sign engine interface from the factory

### DIFF
--- a/lib/Handler/SignEngine/SignEngineFactory.php
+++ b/lib/Handler/SignEngine/SignEngineFactory.php
@@ -16,7 +16,7 @@ class SignEngineFactory {
 	) {
 	}
 
-	public function resolve(string $extension): Pkcs12Handler|Pkcs7Handler {
+	public function resolve(string $extension): ISignEngineHandler {
 		return match (strtolower($extension)) {
 			'pdf' => $this->container->get(Pkcs12Handler::class),
 			default => $this->container->get(Pkcs7Handler::class),

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -35,6 +35,7 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\DocMdpHandler;
 use OCA\Libresign\Handler\FooterHandler;
 use OCA\Libresign\Handler\PdfTk\Pdf;
+use OCA\Libresign\Handler\SignEngine\ISignEngineHandler;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Handler\SignEngine\SignEngineFactory;
 use OCA\Libresign\Handler\SignEngine\SignEngineHandler;
@@ -85,7 +86,7 @@ class SignFileService {
 	private string $userUniqueIdentifier = '';
 	private string $friendlyName = '';
 	private ?IUser $user = null;
-	private ?SignEngineHandler $engine = null;
+	private ?ISignEngineHandler $engine = null;
 
 	public function __construct(
 		protected IL10N $l10n,
@@ -950,7 +951,7 @@ class SignFileService {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
-	protected function identifyEngine(File $file): SignEngineHandler {
+	protected function identifyEngine(File $file): ISignEngineHandler {
 		return $this->signEngineFactory->resolve($file->getExtension());
 	}
 
@@ -1225,7 +1226,7 @@ class SignFileService {
 		return strcasecmp($file->getExtension(), 'pdf') === 0;
 	}
 
-	protected function getEngine(): SignEngineHandler {
+	protected function getEngine(): ISignEngineHandler {
 		if (!$this->engine) {
 			$originalFile = $this->getFileToSign();
 			$this->engine = $this->identifyEngine($originalFile);

--- a/tests/php/Unit/Handler/SignEngine/SignEngineFactoryTest.php
+++ b/tests/php/Unit/Handler/SignEngine/SignEngineFactoryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace OCA\Libresign\Tests\Unit\Handler\SignEngine;
 
+use OCA\Libresign\Handler\SignEngine\ISignEngineHandler;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Handler\SignEngine\Pkcs7Handler;
 use OCA\Libresign\Handler\SignEngine\SignEngineFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -16,11 +18,11 @@ use Psr\Container\ContainerInterface;
  */
 
 final class SignEngineFactoryTest extends \OCA\Libresign\Tests\Unit\TestCase {
-	private ContainerInterface $container;
+	private ContainerInterface&MockObject $container;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->container = \OCP\Server::get(ContainerInterface::class);
+		$this->container = $this->createMock(ContainerInterface::class);
 	}
 
 	private function getInstance(): SignEngineFactory {
@@ -31,17 +33,25 @@ final class SignEngineFactoryTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 	#[DataProvider('providerResolve')]
 	public function testResolve(string $extension, string $instanceOf): void {
-		$instance = $this->getInstance();
+		$handler = $this->createMock($instanceOf);
+		$this->container->expects($this->once())
+			->method('get')
+			->with($instanceOf)
+			->willReturn($handler);
 
-		$signEngine = $instance->resolve($extension);
+		$signEngine = $this->getInstance()->resolve($extension);
 
+		$this->assertSame($handler, $signEngine);
 		$this->assertInstanceOf($instanceOf, $signEngine);
+		$this->assertInstanceOf(ISignEngineHandler::class, $signEngine);
 	}
 
 	public static function providerResolve(): array {
 		return [
 			['pdf', Pkcs12Handler::class],
 			['PDF', Pkcs12Handler::class],
+			['Pdf', Pkcs12Handler::class],
+			['docx', Pkcs7Handler::class],
 			['odt', Pkcs7Handler::class],
 			['ODT', Pkcs7Handler::class],
 			['jpg', Pkcs7Handler::class],


### PR DESCRIPTION
Resolves: #8344

## 📝 Summary

`SignEngineFactory::resolve()` declared its return type with the two concrete handlers, so every new signing path added to the factory would also have to change its public contract. LibreSign already has the `ISignEngineHandler` abstraction that both handlers implement, so the factory can depend on it instead.

```diff
-	public function resolve(string $extension): Pkcs12Handler|Pkcs7Handler {
+	public function resolve(string $extension): ISignEngineHandler {
```

The `match`, the extension matching and the container lookups are untouched, so PDF files still resolve to `Pkcs12Handler`, everything else still resolves to `Pkcs7Handler`, and no signing behaviour changes.

### Why `SignFileService` is in this pull request

Changing only the factory does not pass the psalm job. `SignFileService::identifyEngine()` is the one caller that consumes the factory with a declared type, and it declares the abstract class:

```
ERROR: MoreSpecificReturnType - lib/Service/SignFileService.php:951
  The declared return type 'SignEngineHandler' for SignFileService::identifyEngine
  is more specific than the inferred return type 'ISignEngineHandler'

ERROR: LessSpecificReturnStatement - lib/Service/SignFileService.php:952
  The type 'ISignEngineHandler' is more general than the declared return type
  'SignEngineHandler' for SignFileService::identifyEngine
```

Three declarations carry the resolved engine through that class, and widening them to the interface clears both errors:

| line | before | after |
| --- | --- | --- |
| 89 | `private ?SignEngineHandler $engine` | `private ?ISignEngineHandler $engine` |
| 954 | `identifyEngine(File $file): SignEngineHandler` | `identifyEngine(File $file): ISignEngineHandler` |
| 1229 | `getEngine(): SignEngineHandler` | `getEngine(): ISignEngineHandler` |

Nothing else in the file changes. `PdfSignatureDetectionService`, the other caller, is unaffected: it assigns to a local variable and only calls `getCertificateChain()`, which the interface declares.

This is the only part that goes beyond the file named in the issue. It is not in the issue's "do not change" list, and without it the psalm job fails — but if you prefer a different split, say so and I will rework it.

### What `PfxProvider` tells us

`PfxProvider::getOrGeneratePfx()` keeps taking `SignEngineHandler`, because it calls three methods that are **not** part of `ISignEngineHandler`:

* `setLeafExpiryOverrideInDays()`
* `generateCertificate()`
* `getPfxOfCurrentSigner()`

Psalm reports that as one informational `ArgumentTypeCoercion` at `SignFileService.php:1240`, which does not fail CI at `errorLevel="5"`. I left it visible rather than papering over it: the signing path resolved by the factory is expressible through the interface, but the certificate-provisioning path around it is not, and that looks like useful information for #8335. Making `PfxProvider` accept the interface would require adding those three methods to `ISignEngineHandler`, which this issue's scope rules out.

### Tests

`tests/php/Unit/Handler/SignEngine/SignEngineFactoryTest.php` already existed with a DataProvider, but it resolved the real container with `\OCP\Server::get()`, so it could only assert the resulting class.

It now mocks `ContainerInterface`, which lets it check the rest of the issue's checklist:

* the expected handler class is the one requested from the container (`->with($instanceOf)`);
* `resolve()` returns the very instance the container supplied (`assertSame`);
* the returned value satisfies `ISignEngineHandler`.

The extensions it already covered are kept, and `Pdf` and `docx` from the issue's table were added: `pdf`, `PDF`, `Pdf`, `docx`, `odt`, `ODT`, `jpg`, `JPG`, `png`, `PNG`, `txt`, `TXT`.

## 🧪 How to test

```sh
composer psalm
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --testsuite unit --filter 'SignEngineFactoryTest'
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --testsuite unit --filter 'SignFileServiceTest|PfxProviderTest|PdfSignatureDetectionServiceTest'
composer cs:check
```

Run locally in the devcontainer:

| command | result |
| --- | --- |
| psalm on the four files involved | same 5 pre-existing `MissingDependency` errors as the unmodified branch, no new error |
| `SignEngineFactoryTest` | OK, 12 tests, 48 assertions |
| `SignFileServiceTest` + `PfxProviderTest` + `PdfSignatureDetectionServiceTest` | OK, 165 tests, 386 assertions |
| `php-cs-fixer` on the three changed files | 0 of 3 files need fixing |

## ⚙️ API / Back‑end changes

- [x] `SignEngineFactory::resolve()` returns `ISignEngineHandler`
- [x] The three declarations in `SignFileService` that carry the resolved engine widen to the interface
- [x] Unit tests added – *required for backend changes*
- [ ] Capabilities updated – not applicable, no capability changes
- [ ] Documentation updated – not applicable, no user-visible or API change
- [ ] `composer openapi` – not applicable, no endpoint or payload changes

## 🔁 Backport notes

The cherry-pick applies cleanly to `stable32`, `stable33`, `stable34` and `stable35` (checked with `git merge-tree --write-tree`). `SignEngineFactory.php` and the test file are identical across all four branches, and the three declarations in `SignFileService` exist in all of them, at different line numbers.

That said, this is preparation for #8335 rather than a fix, so whether it should land on the stable lines at all is your call.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Commit signed off (DCO).
- [x] No change to `ISignEngineHandler`, `SignEngineHandler`, `Pkcs12Handler`, `Pkcs7Handler`, the extension mapping, the detached PKCS#7 implementation or any signing workflow.
- [x] No new handler and no external signing code.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
