### PR TITLE
feat(account): add the missing visible signature warning preference

### DIFF
--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -227,6 +227,7 @@ class AccountService {
 		$info['policy_workbench_catalog_compact_view'] = $this->getUserConfigByKey('policy_workbench_catalog_compact_view', $user) === '1';
 		$info['policy_workbench_catalog_collapsed'] = $this->getUserConfigByKey('policy_workbench_catalog_collapsed', $user) === '1';
 		$info['policy_workbench_category_collapsed_state'] = $this->getUserConfigJsonByKey('policy_workbench_category_collapsed_state', $user);
+		$info['warn_without_visible_signature_fields'] = $this->getUserConfigByKey('warn_without_visible_signature_fields', $user) !== '0';
 		$info['can_manage_group_policies'] = $this->policyAuthorizationService->canUserManageGroupPolicies($user);
 		$info['manageable_policy_group_ids'] = $this->policyAuthorizationService->getManageablePolicyGroupIds($user);
 

--- a/tests/integration/features/settings/user-config.feature
+++ b/tests/integration/features/settings/user-config.feature
@@ -95,6 +95,14 @@ Feature: settings/user-config
       | key                 | value                               |
       | (jq).ocs.data.key   | id_docs_sort                        |
 
+    And sending "put" to ocs "/apps/libresign/api/v1/account/config/warn_without_visible_signature_fields"
+      | value | 0 |
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key                 | value                                 |
+      | (jq).ocs.data.key   | warn_without_visible_signature_fields |
+      | (jq).ocs.data.value | 0                                     |
+
     # Update all configs and validate returned value
     And sending "put" to ocs "/apps/libresign/api/v1/account/config/files_list_grid_view"
       | value | 0 |
@@ -178,6 +186,14 @@ Feature: settings/user-config
     And the response should be a JSON array with the following mandatory values
       | key                 | value                              |
       | (jq).ocs.data.key   | id_docs_sort                       |
+
+    And sending "put" to ocs "/apps/libresign/api/v1/account/config/warn_without_visible_signature_fields"
+      | value | 1 |
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key                 | value                                 |
+      | (jq).ocs.data.key   | warn_without_visible_signature_fields |
+      | (jq).ocs.data.value | 1                                     |
 
     # Delete all configs (empty string) and validate returned value
     And sending "put" to ocs "/apps/libresign/api/v1/account/config/files_list_grid_view"
@@ -267,3 +283,11 @@ Feature: settings/user-config
       | key                 | value       |
       | (jq).ocs.data.key   | id_docs_sort |
       | (jq).ocs.data.value |             |
+
+    And sending "put" to ocs "/apps/libresign/api/v1/account/config/warn_without_visible_signature_fields"
+      | value | |
+    Then the response should have a status code 200
+    And the response should be a JSON array with the following mandatory values
+      | key                 | value                                 |
+      | (jq).ocs.data.key   | warn_without_visible_signature_fields |
+      | (jq).ocs.data.value |                                       |

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -277,6 +277,38 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->assertSame($storedCollapsedState, $config['policy_workbench_category_collapsed_state']);
 	}
 
+	#[DataProvider('provideWarnWithoutVisibleSignatureFieldsCases')]
+	public function testGetConfigIncludesWarnWithoutVisibleSignatureFieldsPreference(string $storedValue, bool $expected): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('preference-user');
+
+		$this->userConfig
+			->expects($this->atLeastOnce())
+			->method('getValueString')
+			->willReturnCallback(static function (string $uid, string $appId, string $key, string $default = '') use ($storedValue): string {
+				if ($uid === 'preference-user'
+					&& $appId === Application::APP_ID
+					&& $key === 'warn_without_visible_signature_fields') {
+					return $storedValue;
+				}
+
+				return $default;
+			});
+
+		$config = $this->getService()->getConfig($user);
+
+		$this->assertArrayHasKey('warn_without_visible_signature_fields', $config);
+		$this->assertSame($expected, $config['warn_without_visible_signature_fields']);
+	}
+
+	public static function provideWarnWithoutVisibleSignatureFieldsCases(): array {
+		return [
+			'stored 1 shows the warning' => ['1', true],
+			'stored 0 hides the warning' => ['0', false],
+			'no stored value falls back to the default' => ['', true],
+		];
+	}
+
 	#[DataProvider('provideValidateCertificateDataCases')]
 	public function testValidateCertificateDataUsingDataProvider($arguments, $expectedErrorMessage):void {
 		if (is_callable($arguments)) {


### PR DESCRIPTION
Resolves: #8322

Part of #8321.

## 📝 Summary

Adds the `warn_without_visible_signature_fields` user preference to `AccountService::getConfig()`, so a requester can turn off the warning about signers without a visible signature field.

```php
$info['warn_without_visible_signature_fields'] =
    $this->getUserConfigByKey('warn_without_visible_signature_fields', $user) !== '0';
```

No endpoint was added: `PUT /apps/libresign/api/v1/account/config/{key}` already stores any key for the authenticated user, and the empty value it accepts is what makes the reset work. No migration is needed.

### Why `!== '0'` instead of the `=== '1'` used by the other booleans

The three preferences the issue points at — `files_list_grid_view`, `policy_workbench_catalog_compact_view` and `policy_workbench_catalog_collapsed` — map the stored value with `=== '1'`. `getUserConfigByKey()` returns `''` when nothing is stored, so that expression **defaults to `false`**.

This preference has to default to `true`. Mapping it with `!== '0'` gives the three behaviours the issue asks for with one expression:

| stored value | result | why |
| --- | --- | --- |
| `'1'` | `true` | warning shown |
| `'0'` | `false` | warning hidden |
| `''` (never set, or reset) | `true` | default |

I checked that this is not theoretical: implementing it with `=== '1'` and running the new tests fails exactly the default case with `Failed asserting that false is identical to true`, so the test does guard the distinction.

Also relevant: `getConfig()` ends with `array_filter($info, fn ($value) => $value !== null && $value !== '')`, whose callback keeps `false`. A bare `array_filter()` would drop it and the key would vanish from the payload when the user disables the warning — see the backport notes below.

## 🧪 How to test

```sh
vendor/bin/phpunit -c tests/php/phpunit.xml --no-coverage --testsuite unit --filter AccountServiceTest
composer psalm
composer cs:check
```

Manually, as any user:

```sh
# hide the warning
curl -u user:pass -X PUT -H 'OCS-APIRequest: true' \
  'http://localhost/ocs/v2.php/apps/libresign/api/v1/account/config/warn_without_visible_signature_fields' \
  -d 'value=0'

# reset it, which restores the default
curl -u user:pass -X PUT -H 'OCS-APIRequest: true' \
  'http://localhost/ocs/v2.php/apps/libresign/api/v1/account/config/warn_without_visible_signature_fields' \
  -d 'value='
```

Run locally in the devcontainer:

| command | result |
| --- | --- |
| `AccountServiceTest` | OK, 36 tests, 86 assertions (3 new) |
| psalm on `AccountService` and `AccountController` | 4 errors before, 4 after — no new error |
| `php-cs-fixer` on the two changed PHP files | 0 of 2 files need fixing |

`tests/integration` has no vendor directory installed locally and the suite needs a running server, so Behat was left to CI.

## ⚙️ API / Back‑end changes

- [x] `warn_without_visible_signature_fields` added to `AccountService::getConfig()`
- [x] Existing `PUT /account/config/{key}` endpoint reused, no new controller or route
- [x] Unit and integration tests added – *required for backend changes*
- [ ] Capabilities updated – not applicable, this is a user preference, not a capability
- [ ] Documentation updated – not applicable, no user-visible behaviour yet; the warning itself comes with the rest of #8321
- [ ] `composer openapi` – not applicable, no endpoint, parameter or response type changed

### Tests

**PHPUnit** — `testGetConfigIncludesWarnWithoutVisibleSignatureFieldsPreference`, a DataProvider with the three cases the issue lists: stored `1` returns `true`, stored `0` returns `false`, nothing stored returns the default `true`.

**Behat** — `warn_without_visible_signature_fields` added to the three blocks of the existing CRUD scenario in `tests/integration/features/settings/user-config.feature`, in the file's own style: saved as `0`, updated to `1`, reset with an empty value.

One item from the issue's Behat list is covered by PHPUnit instead, and I would rather say so than quietly skip it. Item 4 asks to *confirm the returned user configuration uses the default `true` after reset*, but no OCS endpoint exposes `getConfig()`: `/account/me` returns `getSettings()` (`canRequestSign`, `hasSignatureFile`, `phoneNumber`), and `getConfig()` only reaches the frontend through `initialState` in `PageController`, which Behat does not read. So Behat covers the API contract — save, update, reset — and the default after reset is asserted in the unit test, where the mapping actually lives. If you would rather have an endpoint that exposes the user config so Behat can assert it end to end, that is a larger change and I would open it separately.

## 🔁 Backport notes

The cherry-pick applies cleanly to **`stable35` only**. It conflicts on `stable32`, `stable33` and `stable34`, and there is a functional reason behind the conflict rather than just drifting context:

```php
// main and stable35
return array_filter($info, static fn (mixed $value): bool => $value !== null && $value !== '');

// stable32, stable33, stable34
return array_filter($info);
```

The bare `array_filter()` on those branches drops every falsy value, so `warn_without_visible_signature_fields = false` would be removed from the payload entirely. The frontend would see the key missing and show the warning again — the opposite of what the user asked for. Backporting there would need the filter changed too, which is outside this issue.

Since this is part of #8321 and has no user-visible effect on its own, I would suggest `stable35` at most, but that is your call.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Commit signed off (DCO).
- [x] No new endpoint, controller, migration, policy or group configuration.
- [x] No unrelated user configuration behaviour changed.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
