### PR TITLE
refactor: extract PKCS#12 credentials to separate interface

### DIFF
--- a/lib/Handler/SignEngine/IPkcs12SignEngineHandler.php
+++ b/lib/Handler/SignEngine/IPkcs12SignEngineHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Rolf39
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Libresign\Handler\SignEngine;
+
+interface IPkcs12SignEngineHandler extends ISignEngineHandler {
+	public function setCertificate(string $certificate): self;
+	public function getCertificate(): string;
+	public function readCertificate(): array;
+	public function setPassword(string $password): self;
+	public function getPassword(): string;
+}

--- a/lib/Handler/SignEngine/ISignEngineHandler.php
+++ b/lib/Handler/SignEngine/ISignEngineHandler.php
@@ -13,11 +13,6 @@ use OCP\Files\File;
 interface ISignEngineHandler {
 	public function setInputFile(File $inputFile): self;
 	public function getInputFile(): File;
-	public function setCertificate(string $certificate): self;
-	public function getCertificate(): string;
-	public function readCertificate(): array;
-	public function setPassword(string $password): self;
-	public function getPassword(): string;
 	public function sign(): File;
 	public function getSignedContent(): string;
 	public function getSignatureParams(): array;

--- a/lib/Handler/SignEngine/SignEngineHandler.php
+++ b/lib/Handler/SignEngine/SignEngineHandler.php
@@ -24,7 +24,7 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
-abstract class SignEngineHandler implements ISignEngineHandler {
+abstract class SignEngineHandler implements IPkcs12SignEngineHandler {
 	private File $inputFile;
 	protected string $certificate = '';
 	private string $pfxFilename = 'signature.pfx';

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -36,6 +36,7 @@ use OCA\Libresign\Handler\FooterHandler;
 use OCA\Libresign\Handler\PdfTk\Pdf;
 use OCA\Libresign\Handler\SignEngine\ISignEngineHandler;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
+use OCP\Libresign\Handler\SignEngine\IPkcs12SignEngineHandler;
 use OCA\Libresign\Handler\SignEngine\SignEngineFactory;
 use OCA\Libresign\Handler\SignEngine\SignEngineHandler;
 use OCA\Libresign\Helper\JSActions;
@@ -85,7 +86,7 @@ class SignFileService {
 	private string $userUniqueIdentifier = '';
 	private string $friendlyName = '';
 	private ?IUser $user = null;
-	private ?ISignEngineHandler $engine = null;
+	private ?IPkcs12SignEngineHandler $engine = null;
 
 	public function __construct(
 		protected IL10N $l10n,


### PR DESCRIPTION
Refactored PKCS#12 credential handling methods into a dedicated `IPkcs12SignEngineHandler` interface to separate concerns from `ISignEngineHandler`.

### 📋 Checklist
- [x] I have read and followed the contribution guide.

### 🤖 AI
- [x] The content of this PR was partially or fully generated using AI.