### PR TITLE
refactor: migrate services and middleware away from ValidateHelper

### DIFF
--- a/lib/Middleware/InjectionMiddleware.php
+++ b/lib/Middleware/InjectionMiddleware.php
@@ -18,7 +18,6 @@ use OCA\Libresign\Enum\SignRequestStatus;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Helper\JSActions;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\CanSignRequestUuid;
 use OCA\Libresign\Middleware\Attribute\PrivateValidation;
 use OCA\Libresign\Middleware\Attribute\RequireFileAccess;
@@ -32,6 +31,8 @@ use OCA\Libresign\Service\Policy\PolicyService;
 use OCA\Libresign\Service\Policy\Provider\ValidationAccess\ValidationAccessPolicy;
 use OCA\Libresign\Service\SignFileService;
 use OCA\Libresign\Service\UuidResolverService;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -59,7 +60,8 @@ class InjectionMiddleware extends Middleware {
 		private IRequest $request,
 		private ISession $session,
 		private IUserSession $userSession,
-		private ValidateHelper $validateHelper,
+		private SigningRequestValidator $signingRequestValidator,
+		private SignerValidator $signerValidator,
 		private SignRequestMapper $signRequestMapper,
 		private CertificateEngineFactory $certificateEngineFactory,
 		private FileMapper $fileMapper,
@@ -278,7 +280,7 @@ class InjectionMiddleware extends Middleware {
 			// TRANSLATORS: Error shown when an anonymous user tries to create a signature request, an action allowed only for authenticated users with permission.
 			throw new \Exception($this->l10n->t('You are not allowed to create signature requests'), Http::STATUS_UNPROCESSABLE_ENTITY);
 		}
-		$this->validateHelper->canRequestSign($user);
+		$this->signingRequestValidator->canRequestSign($user);
 	}
 
 	private function requireSigner(): void {
@@ -291,7 +293,7 @@ class InjectionMiddleware extends Middleware {
 			if ($isIdDocApproval) {
 				$this->uuidResolverService->resolveUuidForUser($uuid, $user);
 			} else {
-				$this->validateHelper->validateSigner($uuid, $user);
+				$this->signerValidator->validateSigner($uuid, $user);
 			}
 		} catch (LibresignException $e) {
 			throw new LibresignException($e->getMessage());
@@ -302,7 +304,7 @@ class InjectionMiddleware extends Middleware {
 		$uuid = $this->getUuidFromRequest();
 
 		try {
-			$this->validateHelper->validateSignerUuid($uuid);
+			$this->signerValidator->validateSignerUuid($uuid);
 		} catch (LibresignException $e) {
 			throw new LibresignException($e->getMessage());
 		}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -24,10 +24,11 @@ use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\Crl\CrlService;
 use OCA\Libresign\Service\Policy\PolicyAuthorizationService;
 use OCA\Libresign\Service\Policy\RequestSignAuthorizationService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -69,7 +70,8 @@ class AccountService {
 		private NewUserMailHelper $newUserMail,
 		private IdentifyMethodService $identifyMethodService,
 		private IdentifyMethodMapper $identifyMethodMapper,
-		private ValidateHelper $validateHelper,
+		private IdentityDocumentValidator $identityDocumentValidator,
+		private FileInputValidator $fileInputValidator,
 		private IURLGenerator $urlGenerator,
 		private Pkcs12Handler $pkcs12Handler,
 		private IGroupManager $groupManager,
@@ -213,7 +215,7 @@ class AccountService {
 		$info['identificationDocumentsFlow'] = $this->idDocsPolicyService->isIdentificationDocumentsEnabled($user);
 		$info['hasSignatureFile'] = $this->hasSignatureFile($user);
 		$info['phoneNumber'] = $this->getPhoneNumber($user);
-		$info['isApprover'] = $this->validateHelper->userCanApproveValidationDocuments($user, false);
+		$info['isApprover'] = $this->identityDocumentValidator->userCanApproveValidationDocuments($user, false);
 		$info['id_docs_filters'] = $this->getUserConfigIdDocsFilters($user);
 		$info['id_docs_sort'] = $this->getUserConfigIdDocsSort($user);
 		$info['crl_filters'] = $this->getUserConfigCrlFilters($user);
@@ -349,7 +351,7 @@ class AccountService {
 	}
 
 	private function getUserConfigIdDocsSort(?IUser $user): array {
-		if (!$user || !$this->validateHelper->userCanApproveValidationDocuments($user, false)) {
+		if (!$user || !$this->identityDocumentValidator->userCanApproveValidationDocuments($user, false)) {
 			return ['sortBy' => null, 'sortOrder' => null];
 		}
 
@@ -517,10 +519,10 @@ class AccountService {
 				// TRANSLATORS Error when uploading a visible signature element file that is empty.
 				throw new \Exception($this->l10n->t('Empty file'));
 			}
-			$this->validateHelper->validateBase64($content, ValidateHelper::TYPE_VISIBLE_ELEMENT_USER);
+			$this->fileInputValidator->validateBase64($content, FileInputValidator::TYPE_VISIBLE_ELEMENT_USER);
 			return $content;
 		}
-		$this->validateHelper->validateBase64($data['file']['base64'], ValidateHelper::TYPE_VISIBLE_ELEMENT_USER);
+		$this->fileInputValidator->validateBase64($data['file']['base64'], FileInputValidator::TYPE_VISIBLE_ELEMENT_USER);
 		$withMime = explode(',', (string)$data['file']['base64']);
 		if (count($withMime) === 2) {
 			$content = base64_decode($withMime[1]);

--- a/lib/Service/RequestSignatureService.php
+++ b/lib/Service/RequestSignatureService.php
@@ -19,7 +19,6 @@ use OCA\Libresign\Events\SignRequestCanceledEvent;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\DocMdpHandler;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\DocMdp\ConfigService as DocMdpConfigService;
 use OCA\Libresign\Service\Envelope\EnvelopeFileRelocator;
 use OCA\Libresign\Service\Envelope\EnvelopeService;
@@ -28,6 +27,9 @@ use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
 use OCA\Libresign\Service\Policy\FilePolicyApplier;
 use OCA\Libresign\Service\SignerGeolocation\SignerGeolocationPolicyService;
 use OCA\Libresign\Service\SignRequest\SignRequestService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Node;
@@ -54,7 +56,9 @@ class RequestSignatureService {
 		protected FileElementMapper $fileElementMapper,
 		protected FolderService $folderService,
 		protected IMimeTypeDetector $mimeTypeDetector,
-		protected ValidateHelper $validateHelper,
+		protected FileInputValidator $fileInputValidator,
+		protected SigningRequestValidator $signingRequestValidator,
+		protected SignerValidator $signerValidator,
 		protected IClientService $client,
 		protected DocMdpHandler $docMdpHandler,
 		protected LoggerInterface $logger,
@@ -441,7 +445,7 @@ class RequestSignatureService {
 	}
 
 	private function deleteIdentifyMethodIfNotExits(array $signers, FileEntity $file): void {
-		$normalizedSigners = $this->validateHelper->normalizeRequestSigners($signers);
+		$normalizedSigners = $this->signerValidator->normalizeRequestSigners($signers);
 		$signRequests = $this->signRequestMapper->getByFileId($file->getId());
 		foreach ($signRequests as $key => $signRequest) {
 			$identifyMethods = $this->identifyMethod->getIdentifyMethodsFromSignRequestId($signRequest->getId());
@@ -482,7 +486,7 @@ class RequestSignatureService {
 	private function associateToSigners(array $data, FileEntity $file): array {
 		$return = [];
 		if (!empty($data['signers'])) {
-			$normalizedSigners = $this->validateHelper->normalizeRequestSigners($data['signers']);
+			$normalizedSigners = $this->signerValidator->normalizeRequestSigners($data['signers']);
 			$this->deleteIdentifyMethodIfNotExits($normalizedSigners, $file);
 			$this->identifyMethod->clearCache();
 
@@ -571,7 +575,7 @@ class RequestSignatureService {
 	public function validateNewRequestToFile(array $data): void {
 		$this->validateNewFile($data);
 		$this->validateSigners($data);
-		$this->validateHelper->validateFileStatus($data);
+		$this->signingRequestValidator->validateFileStatus($data);
 	}
 
 	public function validateNewFile(array $data): void {
@@ -579,7 +583,7 @@ class RequestSignatureService {
 			// TRANSLATORS Error shown when creating a signature request without a document file name.
 			throw new \Exception($this->l10n->t('File name is required'));
 		}
-		$this->validateHelper->validateNewFile($data);
+		$this->fileInputValidator->validateNewFile($data);
 	}
 
 	public function validateSigners(array $data): void {
@@ -596,8 +600,8 @@ class RequestSignatureService {
 			throw new \Exception($this->l10n->t('Signers list needs to be an array'));
 		}
 
-		$this->validateHelper->validateIdentifySigners($data);
-		$normalizedSigners = $this->validateHelper->normalizeRequestSigners($data['signers']);
+		$this->signerValidator->validateIdentifySigners($data);
+		$normalizedSigners = $this->signerValidator->normalizeRequestSigners($data['signers']);
 
 		foreach ($normalizedSigners as $signer) {
 			$this->identifyMethod->setAllEntityData($signer);

--- a/lib/Service/SignFileService.php
+++ b/lib/Service/SignFileService.php
@@ -39,7 +39,6 @@ use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Handler\SignEngine\SignEngineFactory;
 use OCA\Libresign\Handler\SignEngine\SignEngineHandler;
 use OCA\Libresign\Helper\JSActions;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\Envelope\EnvelopeStatusDeterminer;
 use OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod;
 use OCA\Libresign\Service\IdentifyMethod\SignatureMethod\IToken;
@@ -49,6 +48,9 @@ use OCA\Libresign\Service\Policy\Provider\Footer\FooterPolicy;
 use OCA\Libresign\Service\Policy\Provider\Footer\FooterPolicyValue;
 use OCA\Libresign\Service\SignRequest\SignRequestService;
 use OCA\Libresign\Service\SignRequest\StatusService;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -97,7 +99,9 @@ class SignFileService {
 		private IClientService $client,
 		protected LoggerInterface $logger,
 		private IAppConfig $appConfig,
-		protected ValidateHelper $validateHelper,
+		protected IdentityDocumentValidator $identityDocumentValidator,
+		protected SigningRequestValidator $signingRequestValidator,
+		protected SignerValidator $signerValidator,
 		private SignerElementsService $signerElementsService,
 		private IUserSession $userSession,
 		private IDateTimeZone $dateTimeZone,
@@ -1311,7 +1315,7 @@ class SignFileService {
 	}
 
 	private function getOrCreateApproverSignRequest(FileEntity $file, IUser $user): ?SignRequestEntity {
-		if (!$this->validateHelper->userCanApproveValidationDocuments($user, false)) {
+		if (!$this->identityDocumentValidator->userCanApproveValidationDocuments($user, false)) {
 			return null;
 		}
 
@@ -1370,7 +1374,7 @@ class SignFileService {
 	}
 
 	public function getSignRequestToSign(FileEntity $libresignFile, ?string $signRequestUuid, ?IUser $user): SignRequestEntity {
-		$this->validateHelper->fileCanBeSigned($libresignFile);
+		$this->signingRequestValidator->fileCanBeSigned($libresignFile);
 		try {
 			if (!empty($signRequestUuid)) {
 				$signRequest = $this->getSignRequestByUuid($signRequestUuid);
@@ -1615,7 +1619,7 @@ class SignFileService {
 	 * @throws DoesNotExistException
 	 */
 	public function getSignRequestByUuid(string $uuid): SignRequestEntity {
-		$this->validateHelper->validateUuidFormat($uuid);
+		$this->signerValidator->validateUuidFormat($uuid);
 		return $this->signRequestMapper->getByUuid($uuid);
 	}
 
@@ -1683,11 +1687,11 @@ class SignFileService {
 	}
 
 	public function validateSigner(string $uuid, ?IUser $user = null): void {
-		$this->validateHelper->validateSigner($uuid, $user);
+		$this->signerValidator->validateSigner($uuid, $user);
 	}
 
 	public function validateRenewSigner(string $uuid, ?IUser $user = null): void {
-		$this->validateHelper->validateRenewSigner($uuid, $user);
+		$this->signerValidator->validateRenewSigner($uuid, $user);
 	}
 
 	public function getSignerData(?IUser $user, ?SignRequestEntity $signRequest = null): array {

--- a/tests/php/Unit/Middleware/InjectionMiddlewareTest.php
+++ b/tests/php/Unit/Middleware/InjectionMiddlewareTest.php
@@ -13,7 +13,6 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Exception\PageException;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Middleware\Attribute\PrivateValidation;
 use OCA\Libresign\Middleware\Attribute\RequireSignRequestUuid;
 use OCA\Libresign\Middleware\InjectionMiddleware;
@@ -23,6 +22,8 @@ use OCA\Libresign\Service\Policy\PolicyService;
 use OCA\Libresign\Service\Policy\Provider\ValidationAccess\ValidationAccessPolicy;
 use OCA\Libresign\Service\SignFileService;
 use OCA\Libresign\Service\UuidResolverService;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -67,7 +68,8 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private IRequest&MockObject $request;
 	private ISession&MockObject $session;
 	private IUserSession&MockObject $userSession;
-	private ValidateHelper&MockObject $validateHelper;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
+	private SignerValidator&MockObject $signerValidator;
 	private SignRequestMapper&MockObject $signRequestMapper;
 	private CertificateEngineFactory $certificateEngineFactory;
 	private FileMapper&MockObject $fileMapper;
@@ -88,7 +90,8 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
+		$this->signerValidator = $this->createMock(SignerValidator::class);
 		$this->signRequestMapper = $this->createMock(SignRequestMapper::class);
 		$this->certificateEngineFactory = $this->createMock(CertificateEngineFactory::class);
 		$this->fileMapper = $this->createMock(FileMapper::class);
@@ -114,7 +117,8 @@ final class InjectionMiddlewareTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->request,
 			$this->session,
 			$this->userSession,
-			$this->validateHelper,
+			$this->signingRequestValidator,
+			$this->signerValidator,
 			$this->signRequestMapper,
 			$this->certificateEngineFactory,
 			$this->fileMapper,

--- a/tests/php/Unit/Service/AccountServiceTest.php
+++ b/tests/php/Unit/Service/AccountServiceTest.php
@@ -23,7 +23,6 @@ use OCA\Libresign\Enum\FileStatus;
 use OCA\Libresign\Handler\CertificateEngine\CertificateEngineFactory;
 use OCA\Libresign\Handler\SignEngine\Pkcs12Handler;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\AccountService;
 use OCA\Libresign\Service\Crl\CrlService;
 use OCA\Libresign\Service\FolderService;
@@ -38,6 +37,8 @@ use OCA\Libresign\Service\Policy\RequestSignAuthorizationService;
 use OCA\Libresign\Service\RequestSignatureService;
 use OCA\Libresign\Service\SignerElementsService;
 use OCA\Libresign\Service\SignFileService;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;
@@ -80,7 +81,8 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private NewUserMailHelper&MockObject $newUserMail;
 	private IdentifyMethodService&MockObject $identifyMethodService;
 	private IdentifyMethodMapper&MockObject $identifyMethodMapper;
-	private ValidateHelper&MockObject $validateHelper;
+	private IdentityDocumentValidator&MockObject $identityDocumentValidator;
+	private FileInputValidator&MockObject $fileInputValidator;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IGroupManager&MockObject $groupManager;
 	private ISubAdmin&MockObject $subAdmin;
@@ -120,7 +122,8 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->newUserMail = $this->createMock(NewUserMailHelper::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
 		$this->identifyMethodMapper = $this->createMock(IdentifyMethodMapper::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->identityDocumentValidator = $this->createMock(IdentityDocumentValidator::class);
+		$this->fileInputValidator = $this->createMock(FileInputValidator::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->pkcs12Handler = $this->createMock(Pkcs12Handler::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
@@ -158,7 +161,8 @@ final class AccountServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->newUserMail,
 			$this->identifyMethodService,
 			$this->identifyMethodMapper,
-			$this->validateHelper,
+			$this->identityDocumentValidator,
+			$this->fileInputValidator,
 			$this->urlGenerator,
 			$this->pkcs12Handler,
 			$this->groupManager,

--- a/tests/php/Unit/Service/RequestSignatureServiceTest.php
+++ b/tests/php/Unit/Service/RequestSignatureServiceTest.php
@@ -19,7 +19,6 @@ use OCA\Libresign\Db\SignRequestMapper;
 use OCA\Libresign\Exception\LibresignException;
 use OCA\Libresign\Handler\DocMdpHandler;
 use OCA\Libresign\Helper\FileUploadHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\DocMdp\ConfigService as DocMdpConfigService;
 use OCA\Libresign\Service\Envelope\EnvelopeFileRelocator;
 use OCA\Libresign\Service\Envelope\EnvelopeService;
@@ -37,6 +36,9 @@ use OCA\Libresign\Service\SignRequest\SignRequestService;
 use OCA\Libresign\Service\SignRequest\StatusCacheService;
 use OCA\Libresign\Service\SignRequest\StatusService;
 use OCA\Libresign\Service\SignRequest\StatusUpdatePolicy;
+use OCA\Libresign\Service\Validation\FileInputValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
@@ -60,7 +62,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 	private IClientService&MockObject $clientService;
 	private IUserManager&MockObject $userManager;
 	private FolderService&MockObject $folderService;
-	private ValidateHelper&MockObject $validateHelper;
+	private FileInputValidator&MockObject $fileInputValidator;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
+	private SignerValidator&MockObject $signerValidator;
 	private FileElementMapper&MockObject $fileElementMapper;
 	private FileElementService&MockObject $fileElementService;
 	private IdentifyMethodService&MockObject $identifyMethodService;
@@ -96,7 +100,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->folderService = $this->createMock(FolderService::class);
-		$this->validateHelper = $this->createMock(ValidateHelper::class);
+		$this->fileInputValidator = $this->createMock(FileInputValidator::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
+		$this->signerValidator = $this->createMock(SignerValidator::class);
 		$this->fileElementMapper = $this->createMock(FileElementMapper::class);
 		$this->fileElementService = $this->createMock(FileElementService::class);
 		$this->identifyMethodService = $this->createMock(IdentifyMethodService::class);
@@ -134,7 +140,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 					$this->fileElementMapper,
 					$this->folderService,
 					$this->mimeTypeDetector,
-					$this->validateHelper,
+					$this->fileInputValidator,
+					$this->signingRequestValidator,
+					$this->signerValidator,
 					$this->client,
 					$this->docMdpHandler,
 					$this->loggerInterface,
@@ -167,7 +175,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 			$this->fileElementMapper,
 			$this->folderService,
 			$this->mimeTypeDetector,
-			$this->validateHelper,
+			$this->fileInputValidator,
+			$this->signingRequestValidator,
+			$this->signerValidator,
 			$this->client,
 			$this->docMdpHandler,
 			$this->loggerInterface,
@@ -343,7 +353,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 
 	public function testValidateSignersRejectsLegacyIdentifyPayload(): void {
 		$this->expectExceptionMessage('No identify methods for signer');
-		$this->validateHelper
+		$this->signerValidator
 			->method('validateIdentifySigners')
 			->willThrowException(new LibresignException('No identify methods for signer'));
 
@@ -374,7 +384,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 			]],
 		];
 
-		$this->validateHelper
+		$this->signerValidator
 			->method('normalizeRequestSigners')
 			->willReturnCallback(static fn (array $signers): array => $signers);
 
@@ -453,7 +463,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 			]],
 		];
 
-		$this->validateHelper
+		$this->signerValidator
 			->method('normalizeRequestSigners')
 			->willReturnCallback(static fn (array $signers): array => $signers);
 
@@ -525,7 +535,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 			]],
 		];
 
-		$this->validateHelper
+		$this->signerValidator
 			->method('normalizeRequestSigners')
 			->willReturnCallback(static fn (array $signers): array => $signers);
 
@@ -596,7 +606,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 		$identifyMethod = $this->createMock(\OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod::class);
 		$identifyMethod->method('getEntity')->willReturn($entity);
 
-		$this->validateHelper
+		$this->signerValidator
 			->expects($this->once())
 			->method('normalizeRequestSigners')
 			->with([['identifyMethods' => [['method' => 'email', 'value' => 'john@example.com']]]])
@@ -628,7 +638,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 				$this->fileElementMapper,
 				$this->folderService,
 				$this->mimeTypeDetector,
-				$this->validateHelper,
+				$this->fileInputValidator,
+				$this->signingRequestValidator,
+				$this->signerValidator,
 				$this->client,
 				$this->docMdpHandler,
 				$this->loggerInterface,
@@ -670,7 +682,7 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 		$identifyMethod = $this->createMock(\OCA\Libresign\Service\IdentifyMethod\IIdentifyMethod::class);
 		$identifyMethod->method('getEntity')->willReturn($entity);
 
-		$this->validateHelper
+		$this->signerValidator
 			->expects($this->once())
 			->method('normalizeRequestSigners')
 			->with([['identifyMethods' => [['method' => 'email', 'value' => 'john@example.com']]]])
@@ -702,7 +714,9 @@ final class RequestSignatureServiceTest extends \OCA\Libresign\Tests\Unit\TestCa
 				$this->fileElementMapper,
 				$this->folderService,
 				$this->mimeTypeDetector,
-				$this->validateHelper,
+				$this->fileInputValidator,
+				$this->signingRequestValidator,
+				$this->signerValidator,
 				$this->client,
 				$this->docMdpHandler,
 				$this->loggerInterface,

--- a/tests/php/Unit/Service/SignFileServiceTest.php
+++ b/tests/php/Unit/Service/SignFileServiceTest.php
@@ -38,7 +38,6 @@ use OCA\Libresign\Handler\SignEngine\Pkcs7Handler;
 use OCA\Libresign\Handler\SignEngine\SignEngineFactory;
 use OCA\Libresign\Handler\SignEngine\SignEngineHandler;
 use OCA\Libresign\Helper\JavaHelper;
-use OCA\Libresign\Helper\ValidateHelper;
 use OCA\Libresign\Service\CertificateValidityPolicy;
 use OCA\Libresign\Service\Envelope\EnvelopeStatusDeterminer;
 use OCA\Libresign\Service\FileStatusService;
@@ -60,6 +59,9 @@ use OCA\Libresign\Service\SignRequest\SignRequestService;
 use OCA\Libresign\Service\SignRequest\StatusService;
 use OCA\Libresign\Service\SubjectAlternativeNameService;
 use OCA\Libresign\Service\TsaValidationService;
+use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
+use OCA\Libresign\Service\Validation\SignerValidator;
+use OCA\Libresign\Service\Validation\SigningRequestValidator;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
@@ -93,7 +95,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private FolderService&MockObject $folderService;
 	private LoggerInterface&MockObject $logger;
 	private IAppConfig $appConfig;
-	private ValidateHelper&MockObject $validateHelper;
+	private IdentityDocumentValidator&MockObject $identityDocumentValidator;
+	private SigningRequestValidator&MockObject $signingRequestValidator;
+	private SignerValidator&MockObject $signerValidator;
 	private SignerElementsService&MockObject $signerElementsService;
 	private IUserSession&MockObject $userSession;
 	private IDateTimeZone $dateTimeZone;
@@ -142,7 +146,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->folderService = $this->createMock(FolderService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig = $this->getMockAppConfigWithReset();
-		$this->validateHelper = $this->createMock(\OCA\Libresign\Helper\ValidateHelper::class);
+		$this->identityDocumentValidator = $this->createMock(IdentityDocumentValidator::class);
+		$this->signingRequestValidator = $this->createMock(SigningRequestValidator::class);
+		$this->signerValidator = $this->createMock(SignerValidator::class);
 		$this->signerElementsService = $this->createMock(SignerElementsService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->dateTimeZone = \OCP\Server::get(IDateTimeZone::class);
@@ -447,7 +453,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 					$this->clientService,
 					$this->logger,
 					$this->appConfig,
-					$this->validateHelper,
+					$this->identityDocumentValidator,
+					$this->signingRequestValidator,
+					$this->signerValidator,
 					$this->signerElementsService,
 					$this->userSession,
 					$this->dateTimeZone,
@@ -491,7 +499,9 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->clientService,
 			$this->logger,
 			$this->appConfig,
-			$this->validateHelper,
+			$this->identityDocumentValidator,
+			$this->signingRequestValidator,
+			$this->signerValidator,
 			$this->signerElementsService,
 			$this->userSession,
 			$this->dateTimeZone,
@@ -2092,10 +2102,10 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest->setFileId(10);
 		$signRequest->setSigningOrder(0);
 
-		$this->validateHelper->expects($this->once())
+		$this->signingRequestValidator->expects($this->once())
 			->method('fileCanBeSigned')
 			->with($file);
-		$this->validateHelper->expects($this->once())
+		$this->signerValidator->expects($this->once())
 			->method('validateUuidFormat')
 			->with($uuid);
 		$this->signRequestMapper->expects($this->once())
@@ -2130,10 +2140,10 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$signRequest->setFileId(10);
 		$signRequest->setSigningOrder(0);
 
-		$this->validateHelper->expects($this->once())
+		$this->signingRequestValidator->expects($this->once())
 			->method('fileCanBeSigned')
 			->with($file);
-		$this->validateHelper->expects($this->once())
+		$this->identityDocumentValidator->expects($this->once())
 			->method('userCanApproveValidationDocuments')
 			->with($user, false)
 			->willReturn(true);
@@ -2234,10 +2244,10 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$identifyMethodB->setIdentifierKey(IdentifyMethodService::IDENTIFY_EMAIL);
 		$identifyMethodB->setIdentifierValue('other@example.test');
 
-		$this->validateHelper->expects($this->once())
+		$this->signingRequestValidator->expects($this->once())
 			->method('fileCanBeSigned')
 			->with($file);
-		$this->validateHelper->method('userCanApproveValidationDocuments')
+		$this->identityDocumentValidator->method('userCanApproveValidationDocuments')
 			->willReturn(false);
 		$this->signRequestMapper->expects($this->once())
 			->method('getByFileId')
@@ -2290,10 +2300,10 @@ final class SignFileServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$identifyMethod->setIdentifierKey(IdentifyMethodService::IDENTIFY_ACCOUNT);
 		$identifyMethod->setIdentifierValue('approver');
 
-		$this->validateHelper->expects($this->once())
+		$this->signingRequestValidator->expects($this->once())
 			->method('fileCanBeSigned')
 			->with($file);
-		$this->validateHelper->expects($this->once())
+		$this->identityDocumentValidator->expects($this->once())
 			->method('userCanApproveValidationDocuments')
 			->with($user, false)
 			->willReturn(true);


### PR DESCRIPTION
Resolves: #8355

## 📝 Summary

Replaces the `ValidateHelper` compatibility façade with the focused validators in the four remaining central consumers, following the mapping defined in the issue:

| consumer | validators injected | calls migrated |
| --- | --- | --- |
| `RequestSignatureService` | `FileInputValidator`, `SigningRequestValidator`, `SignerValidator` | `validateNewFile`, `validateFileStatus`, `validateIdentifySigners`, `normalizeRequestSigners` (×3, same `SignerValidator` instance) |
| `AccountService` | `IdentityDocumentValidator`, `FileInputValidator` | `userCanApproveValidationDocuments` (×2), `validateBase64` (×2), constant `TYPE_VISIBLE_ELEMENT_USER` now read from `FileInputValidator` |
| `SignFileService` | `IdentityDocumentValidator`, `SigningRequestValidator`, `SignerValidator` | `userCanApproveValidationDocuments`, `fileCanBeSigned`, `validateUuidFormat`, `validateSigner`, `validateRenewSigner` |
| `InjectionMiddleware` | `SigningRequestValidator`, `SignerValidator` | `canRequestSign`, `validateSigner`, `validateSignerUuid` |

Dependency migration only:

- no validation rule moves between validators;
- no new façade, wrapper or interface;
- `SignFileService::validateSigner()` and `validateRenewSigner()` keep their signatures and only change the delegate;
- `InjectionMiddleware` attributes, authorization flow, exception handling and redirects are untouched;
- the new constructor parameters take the position the `ValidateHelper` parameter had, so the positional constructor calls in the tests stay readable.

After this change the only `ValidateHelper` consumers left in `lib/` are the three controllers covered by #8353, plus the façade itself. In `tests/`, only `PageControllerTest` (for `PageController`, also #8353) and `ValidateHelperTest` still reference it.

## 🧪 How to test

Ran in the devcontainer (PHP 8.3):

| check | result |
| --- | --- |
| `php -l` on the 8 files | clean |
| `php-cs-fixer --dry-run` on the 8 files | nothing to fix |
| `psalm` on the 4 production files, before vs. after | same 8 pre-existing `MissingDependency` errors (local `psr/*` stubs), no new issue |
| `RequestSignatureServiceTest` + `AccountServiceTest` + `SignFileServiceTest` + `InjectionMiddlewareTest` | OK, 214 tests, 554 assertions |
| `ValidateHelperTest` + `PageControllerTest` + `Validation/*` | OK |

Search to confirm the remaining references:

```bash
grep -rln ValidateHelper lib tests
```

## ⚙️ API / Back‑end changes

- [x] Constructor dependencies of the four classes changed from `ValidateHelper` to the focused validators (container-resolved; no public API change)
- [x] Unit tests updated: the `ValidateHelper` mock is replaced by one mock per focused validator, every existing expectation moved to the validator that owns the method, no assertion removed or weakened

### 🚧 Tasks

- [ ] Decide the merge order with #8142, which adds five expectations on `$this->validateHelper` in `AccountServiceTest` (`userCanApproveValidationDocuments`, `validateBase64` with `ValidateHelper::TYPE_VISIBLE_ELEMENT_USER`). Whichever merges second needs a small rebase; I can do it on either side.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Commit signed off (DCO).
- [x] No new façade, wrapper or interface; no validation rule moved; no test removed or weakened.

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
