### PR TITLE
fix: store identification documents of external signers under the file owner

### DIFF
--- a/lib/Service/IdDocsService.php
+++ b/lib/Service/IdDocsService.php
@@ -25,6 +25,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IUser;
+use OCP\IUserManager;
 use Sabre\DAV\UUIDUtil;
 
 class IdDocsService {
@@ -41,6 +42,7 @@ class IdDocsService {
 		private IdentifyMethodMapper $identifyMethodMapper,
 		private ITimeFactory $timeFactory,
 		private IAppConfig $appConfig,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -120,14 +122,34 @@ class IdDocsService {
 		foreach ($files as $fileIndex => $file) {
 			$this->validateTypeOfFile($fileIndex, $file);
 		}
+		// Store the documents under the owner of the file being signed, where
+		// later lookups by the stored user_id expect them; without an IUser the
+		// node would be written to the unauthenticated appdata folder instead.
+		$owner = $this->getOwnerOfSignedFile($signRequest);
 		foreach ($files as $fileData) {
 			$dataToSave = $fileData;
 			$dataToSave['signRequest'] = $signRequest;
 			$dataToSave['name'] = $fileData['name'] ?? $fileData['type'];
+			if ($owner instanceof IUser) {
+				$dataToSave['userManager'] = $owner;
+			}
 			$file = $this->requestSignatureService->saveFile($dataToSave);
 
 			$this->idDocsMapper->save($file->getId(), $signRequest->getId(), null, $fileData['type']);
 		}
+	}
+
+	private function getOwnerOfSignedFile(SignRequest $signRequest): ?IUser {
+		$signedFileId = $signRequest->getFileId();
+		if (!$signedFileId) {
+			return null;
+		}
+		try {
+			$signedFile = $this->fileMapper->getById($signedFileId);
+		} catch (\Throwable) {
+			return null;
+		}
+		return $this->userManager->get($signedFile->getUserId());
 	}
 
 	public function list(array $filter, ?int $page = null, ?int $length = null, array $sort = []): array {

--- a/lib/Service/IdDocsService.php
+++ b/lib/Service/IdDocsService.php
@@ -146,7 +146,7 @@ class IdDocsService {
 		}
 		try {
 			$signedFile = $this->fileMapper->getById($signedFileId);
-		} catch (\Throwable) {
+		} catch (\OCP\AppFramework\Db\DoesNotExistException) {
 			return null;
 		}
 		return $this->userManager->get($signedFile->getUserId());

--- a/tests/php/Unit/Service/IdDocsServiceTest.php
+++ b/tests/php/Unit/Service/IdDocsServiceTest.php
@@ -21,6 +21,8 @@ use OCA\Libresign\Service\Validation\FileInputValidator;
 use OCA\Libresign\Service\Validation\IdentityDocumentValidator;
 use OCP\IAppConfig;
 use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -39,6 +41,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 	private RequestSignatureService&MockObject $requestSignatureService;
 	private TimeFactory&MockObject $timeFactory;
 	private IAppConfig&MockObject $appConfig;
+	private IUserManager&MockObject $userManager;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -56,6 +59,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 		$this->requestSignatureService = $this->createMock(RequestSignatureService::class);
 		$this->timeFactory = $this->createMock(TimeFactory::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 	}
 
 	private function getIdDocsService(): IdDocsService {
@@ -71,6 +75,7 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$this->identifyMethodMapper,
 			$this->timeFactory,
 			$this->appConfig,
+			$this->userManager,
 		);
 	}
 
@@ -193,5 +198,85 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 
 		$service = $this->getIdDocsService();
 		$service->deleteIdDocBySignRequest(123, $signRequest);
+	}
+	public function testAddFilesToDocumentFolderStoresFilesUnderTheOwnerOfTheSignedFile(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setId(55);
+		$signRequest->setFileId(10);
+
+		$signedFile = new \OCA\Libresign\Db\File();
+		$signedFile->setUserId('owner');
+		$this->fileMapper->method('getById')
+			->with(10)
+			->willReturn($signedFile);
+
+		$owner = $this->createMock(IUser::class);
+		$this->userManager->method('get')
+			->with('owner')
+			->willReturn($owner);
+
+		$this->fileTypeMapper->method('getTypes')
+			->willReturn(['IDENTIFICATION' => ['type' => 'IDENTIFICATION']]);
+
+		$savedFile = new \OCA\Libresign\Db\File();
+		$savedFile->setId(77);
+		$this->requestSignatureService->expects($this->once())
+			->method('saveFile')
+			->with($this->callback(function (array $data) use ($owner, $signRequest): bool {
+				$this->assertSame($owner, $data['userManager']);
+				$this->assertSame($signRequest, $data['signRequest']);
+				$this->assertSame('id-front.pdf', $data['name']);
+				return true;
+			}))
+			->willReturn($savedFile);
+
+		$this->idDocsMapper->expects($this->once())
+			->method('save')
+			->with(77, 55, null, 'IDENTIFICATION');
+
+		$service = $this->getIdDocsService();
+		$service->addFilesToDocumentFolder(
+			[['type' => 'IDENTIFICATION', 'name' => 'id-front.pdf', 'base64' => 'ZmFrZQ==']],
+			$signRequest,
+		);
+	}
+
+	public function testAddFilesToDocumentFolderWithoutResolvableOwnerKeepsCurrentBehaviour(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setId(55);
+		$signRequest->setFileId(10);
+
+		$signedFile = new \OCA\Libresign\Db\File();
+		$signedFile->setUserId('deleted-owner');
+		$this->fileMapper->method('getById')
+			->with(10)
+			->willReturn($signedFile);
+
+		$this->userManager->method('get')
+			->with('deleted-owner')
+			->willReturn(null);
+
+		$this->fileTypeMapper->method('getTypes')
+			->willReturn(['IDENTIFICATION' => ['type' => 'IDENTIFICATION']]);
+
+		$savedFile = new \OCA\Libresign\Db\File();
+		$savedFile->setId(77);
+		$this->requestSignatureService->expects($this->once())
+			->method('saveFile')
+			->with($this->callback(function (array $data): bool {
+				$this->assertArrayNotHasKey('userManager', $data);
+				return true;
+			}))
+			->willReturn($savedFile);
+
+		$this->idDocsMapper->expects($this->once())
+			->method('save')
+			->with(77, 55, null, 'IDENTIFICATION');
+
+		$service = $this->getIdDocsService();
+		$service->addFilesToDocumentFolder(
+			[['type' => 'IDENTIFICATION', 'base64' => 'ZmFrZQ==']],
+			$signRequest,
+		);
 	}
 }

--- a/tests/php/Unit/Service/IdDocsServiceTest.php
+++ b/tests/php/Unit/Service/IdDocsServiceTest.php
@@ -279,4 +279,59 @@ final class IdDocsServiceTest extends \OCA\Libresign\Tests\Unit\TestCase {
 			$signRequest,
 		);
 	}
+
+	public function testAddFilesToDocumentFolderWithoutSignedFileRowKeepsCurrentBehaviour(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setId(55);
+		$signRequest->setFileId(10);
+
+		$this->fileMapper->method('getById')
+			->with(10)
+			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('missing'));
+
+		$this->userManager->expects($this->never())
+			->method('get');
+
+		$this->fileTypeMapper->method('getTypes')
+			->willReturn(['IDENTIFICATION' => ['type' => 'IDENTIFICATION']]);
+
+		$savedFile = new \OCA\Libresign\Db\File();
+		$savedFile->setId(77);
+		$this->requestSignatureService->expects($this->once())
+			->method('saveFile')
+			->with($this->callback(function (array $data): bool {
+				$this->assertArrayNotHasKey('userManager', $data);
+				return true;
+			}))
+			->willReturn($savedFile);
+
+		$service = $this->getIdDocsService();
+		$service->addFilesToDocumentFolder(
+			[['type' => 'IDENTIFICATION', 'base64' => 'ZmFrZQ==']],
+			$signRequest,
+		);
+	}
+
+	public function testAddFilesToDocumentFolderDoesNotHideUnexpectedFailuresWhenResolvingTheOwner(): void {
+		$signRequest = new SignRequest();
+		$signRequest->setId(55);
+		$signRequest->setFileId(10);
+
+		$this->fileMapper->method('getById')
+			->with(10)
+			->willThrowException(new \RuntimeException('database unavailable'));
+
+		$this->fileTypeMapper->method('getTypes')
+			->willReturn(['IDENTIFICATION' => ['type' => 'IDENTIFICATION']]);
+
+		$this->requestSignatureService->expects($this->never())
+			->method('saveFile');
+
+		$service = $this->getIdDocsService();
+		$this->expectException(\RuntimeException::class);
+		$service->addFilesToDocumentFolder(
+			[['type' => 'IDENTIFICATION', 'base64' => 'ZmFrZQ==']],
+			$signRequest,
+		);
+	}
 }


### PR DESCRIPTION
Resolves: #8364

## 📝 Summary

When an unauthenticated (external) signer uploads an identification document, `IdDocsService::addFilesToDocumentFolder()` called `RequestSignatureService::saveFile()` without a `userManager`. `FileService::getNodeFromData()` only sets the `FolderService` user id from that key, so the node was written to `appdata_<id>/libresign/unauthenticated/`. In the same call, `saveFile()` sets `File.user_id` to the owner of the signed file — and `AccountService::getPdfByUuid()` later uses that `user_id` to look the node up in the owner's folder, where it never was. Result: intact file on disk, empty viewer and 404 on download in the validation UI.

The fix resolves the owner of the signed file with the same lookup `saveFile()` already uses for `user_id` (`SignRequest::getFileId()` → `FileMapper::getById()` → `getUserId()` → `IUserManager::get()`) and passes it as `userManager`, mirroring `addIdDocs()`. If the owner cannot be resolved (no file id, missing row, deleted account) nothing is passed and the current behaviour is kept.

`IUserManager` is appended at the end of the constructor so the change applies to the stable branches, whose constructor differs from `main` after #8336.

## 🧪 How to test

Unit tests in `IdDocsServiceTest`:

- `testAddFilesToDocumentFolderStoresFilesUnderTheOwnerOfTheSignedFile` — fails on `main` with `Failed asserting that null is identical to an object of class IUser`, passes with the fix;
- `testAddFilesToDocumentFolderWithoutResolvableOwnerKeepsCurrentBehaviour` — `userManager` is not set when the owner cannot be resolved.

Local checks in the devcontainer: `IdDocsServiceTest` OK (7 tests, 18 assertions); psalm on `IdDocsService` unchanged (2 pre-existing `MissingDependency`); php-cs-fixer clean.

Manual, as in the issue: enable **Require identification documents**, request a signature from an email recipient without an account, upload the document as that signer, then as an `approval_group` admin open it in **Documents Validation** — the viewer shows the pages and download works. The node now lives in the owner's LibreSign folder.

## ⚙️ API / Back‑end changes

- [x] `IdDocsService` gains an `IUserManager` dependency (container-resolved); no API change
- [x] Unit tests added

## 🚧 Backport

Bug present on `stable32`–`stable35`; the cherry-pick applies cleanly to all four (checked locally on each branch).

## Not covered on purpose

- Documents already written to the appdata folder on affected installs stay unreachable through the UI; a repair command is a separate change (offered in the issue).
- The file name shown without extension is a different symptom.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Commit signed off (DCO).

## 🤖 AI (if applicable)

- [x] The content of this PR was partially or fully generated using AI
