### PR TITLE
feat: explain when signer has no visible signature field

### DIFF
--- a/playwright/e2e/sign-herself-with-click-to-sign.spec.ts
+++ b/playwright/e2e/sign-herself-with-click-to-sign.spec.ts
@@ -53,6 +53,7 @@ test('sign herself with click to sign', async ({ page }) => {
 	await expect(page.getByLabel('PDF document to sign')).toBeVisible({ timeout: 15_000 })
 	const signButton = page.locator('.sign-pdf-sidebar .button-wrapper').getByRole('button', { name: 'Sign document' })
 	await expect(signButton).toBeVisible({ timeout: 15_000 })
+	await expect(page.getByText('No visible signature is required')).toBeVisible()
 	await signButton.click({ force: true })
 	const signResponsePromise = page.waitForResponse((response) =>
 		response.request().method() === 'POST'

--- a/src/tests/views/SignPDF/Sign.spec.ts
+++ b/src/tests/views/SignPDF/Sign.spec.ts
@@ -884,7 +884,8 @@ describe('Sign.vue - signWithTokenCode', () => {
 
 			expect(wrapper.text()).toContain('Try signing again')
 			expect(wrapper.text()).not.toContain('Sign document')
-			expect(wrapper.findAll('.nc-note-card-stub')).toHaveLength(1)
+			// One card for the blocking error, one for the missing visible signature field.
+			expect(wrapper.findAll('.nc-note-card-stub')).toHaveLength(2)
 		})
 	})
 
@@ -2265,5 +2266,41 @@ describe('Sign.vue - required device geolocation', () => {
 		expect(wrapper.vm.requiresDeviceGeolocation).toBe(false)
 		expect(geolocationHelper.collectDeviceGeolocation).not.toHaveBeenCalled()
 		expect(submitSignatureMock.mock.calls[0]?.[0]).not.toHaveProperty('geolocation')
+	})
+})
+
+describe('Sign.vue - no visible signature notice', () => {
+	it('detects a visible signature field when the signer has one', async () => {
+		setActivePinia(createPinia())
+		const SignComponent = await import('../../../views/SignPDF/_partials/Sign.vue')
+		const { useSignStore } = await import('../../../store/sign.js')
+		const signStore = useSignStore()
+		signStore.document = createSignDocument({
+			nodeType: 'file',
+			signers: [
+				{ signRequestId: 501, me: true },
+			],
+			visibleElements: [
+				{ elementId: 201, fileId: 1, signRequestId: 501, type: 'signature', coordinates: { page: 1, left: 10, top: 20, width: 30, height: 40 } },
+			],
+		})
+		const wrapper = mount(SignComponent.default, createSignMountOptions())
+		expect(wrapper.vm.hasVisibleSignatureField).toBe(true)
+	})
+
+	it('detects no visible signature field when the signer has none', async () => {
+		setActivePinia(createPinia())
+		const SignComponent = await import('../../../views/SignPDF/_partials/Sign.vue')
+		const { useSignStore } = await import('../../../store/sign.js')
+		const signStore = useSignStore()
+		signStore.document = createSignDocument({
+			nodeType: 'file',
+			signers: [
+				{ signRequestId: 501, me: true },
+			],
+			visibleElements: [],
+		})
+		const wrapper = mount(SignComponent.default, createSignMountOptions())
+		expect(wrapper.vm.hasVisibleSignatureField).toBe(false)
 	})
 })

--- a/src/tests/views/SignPDF/Sign.spec.ts
+++ b/src/tests/views/SignPDF/Sign.spec.ts
@@ -884,8 +884,7 @@ describe('Sign.vue - signWithTokenCode', () => {
 
 			expect(wrapper.text()).toContain('Try signing again')
 			expect(wrapper.text()).not.toContain('Sign document')
-			// One card for the blocking error, one for the missing visible signature field.
-			expect(wrapper.findAll('.nc-note-card-stub')).toHaveLength(2)
+			expect(wrapper.findAll('.nc-note-card-stub')).toHaveLength(1)
 		})
 	})
 
@@ -2270,37 +2269,59 @@ describe('Sign.vue - required device geolocation', () => {
 })
 
 describe('Sign.vue - no visible signature notice', () => {
-	it('detects a visible signature field when the signer has one', async () => {
+	const mountWithVisibleElementFor = async (signRequestId: number) => {
 		setActivePinia(createPinia())
+
 		const SignComponent = await import('../../../views/SignPDF/_partials/Sign.vue')
 		const { useSignStore } = await import('../../../store/sign.js')
 		const signStore = useSignStore()
+
 		signStore.document = createSignDocument({
-			nodeType: 'file',
+			status: FILE_STATUS.ABLE_TO_SIGN,
 			signers: [
-				{ signRequestId: 501, me: true },
+				{ signRequestId: 501, me: true, status: SIGN_REQUEST_STATUS.ABLE_TO_SIGN },
+				{ signRequestId: 502 },
 			],
 			visibleElements: [
-				{ elementId: 201, fileId: 1, signRequestId: 501, type: 'signature', coordinates: { page: 1, left: 10, top: 20, width: 30, height: 40 } },
+				{ elementId: 201, fileId: 1, signRequestId, type: 'signature', coordinates: { page: 1, left: 10, top: 20, width: 30, height: 40 } },
 			],
 		})
-		const wrapper = mount(SignComponent.default, createSignMountOptions())
-		expect(wrapper.vm.hasVisibleSignatureField).toBe(true)
+
+		const base = createSignMountOptions()
+		const options = {
+			...base,
+			global: {
+				...base.global,
+				stubs: {
+					...base.global.stubs,
+					NcNoteCard: { template: '<div class="nc-note-card-stub"><slot /></div>' },
+					NcButton: { template: '<button><slot /></button>' },
+				},
+			},
+		}
+
+		const wrapper = mount(SignComponent.default, options)
+		await flushPromises()
+
+		return wrapper
+	}
+
+	it('shows the notice when only another signer has a visible element', async () => {
+		const wrapper = await mountWithVisibleElementFor(502)
+
+		expect(wrapper.text()).toContain('Your digital signature will still be added')
 	})
 
-	it('detects no visible signature field when the signer has none', async () => {
-		setActivePinia(createPinia())
-		const SignComponent = await import('../../../views/SignPDF/_partials/Sign.vue')
-		const { useSignStore } = await import('../../../store/sign.js')
-		const signStore = useSignStore()
-		signStore.document = createSignDocument({
-			nodeType: 'file',
-			signers: [
-				{ signRequestId: 501, me: true },
-			],
-			visibleElements: [],
-		})
-		const wrapper = mount(SignComponent.default, createSignMountOptions())
-		expect(wrapper.vm.hasVisibleSignatureField).toBe(false)
+	it('does not show the notice when the current signer has a visible element', async () => {
+		const wrapper = await mountWithVisibleElementFor(501)
+
+		expect(wrapper.text()).not.toContain('Your digital signature will still be added')
+	})
+
+	it('keeps Sign document available while the notice is shown', async () => {
+		const wrapper = await mountWithVisibleElementFor(502)
+
+		expect(wrapper.text()).toContain('Your digital signature will still be added')
+		expect(wrapper.text()).toContain('Sign document')
 	})
 })

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -37,7 +37,7 @@
 				<NcRichText :text="error.message"
 					:use-markdown="true" />
 			</NcNoteCard>
-			<NcNoteCard v-if="!hasVisibleSignatureField"
+			<NcNoteCard v-if="!hasVisibleSignatureField && !hasBlockingSignError"
 					:heading="t('libresign', 'No visible signature is required')"
 					type="info">
 				<p>
@@ -962,7 +962,6 @@ defineExpose({
 	hasSignatures,
 	needCreateSignature,
 	canCreateSignature,
-	hasVisibleSignatureField,
 	submitSignature,
 	signWithTokenCode,
 	requiresDeviceGeolocation,

--- a/src/views/SignPDF/_partials/Sign.vue
+++ b/src/views/SignPDF/_partials/Sign.vue
@@ -37,6 +37,14 @@
 				<NcRichText :text="error.message"
 					:use-markdown="true" />
 			</NcNoteCard>
+			<NcNoteCard v-if="!hasVisibleSignatureField"
+					:heading="t('libresign', 'No visible signature is required')"
+					type="info">
+				<p>
+					<!-- TRANSLATORS Informational message shown when the current signer has no visible signature field in the document. -->
+					{{ t('libresign', 'Your digital signature will still be added to the PDF and can be validated after signing.') }}
+				</p>
+			</NcNoteCard>
 			<div v-if="needCreateSignature" class="no-signature-warning">
 				<p>
 					<!-- TRANSLATORS Warning shown when the signer has not created any reusable signature yet. -->
@@ -587,6 +595,7 @@ const needCreateSignature = computed(() => {
 	}
 	return hasVisibleElementsForCurrentUser(visibleElementsDocument.value)
 })
+const hasVisibleSignatureField = computed(() => hasVisibleElementsForCurrentUser(visibleElementsDocument.value))
 const needIdentificationDocuments = computed(() => identificationDocumentStore.showDocumentsComponent())
 const canCreateSignature = computed(() => {
 	const capabilities = getCapabilities() as LibresignCapabilities
@@ -953,6 +962,7 @@ defineExpose({
 	hasSignatures,
 	needCreateSignature,
 	canCreateSignature,
+	hasVisibleSignatureField,
 	submitSignature,
 	signWithTokenCode,
 	requiresDeviceGeolocation,


### PR DESCRIPTION
Resolves: #8325

## 📝 Summary

Shows an NcNoteCard in the signing sidebar when the current signer has no visible signature field, so the page does not look incomplete.

Reuses hasVisibleElementsForCurrentUser(). I could not reuse needCreateSignature, it also returns false when the instance disallows creating signatures or when the user already has one.

The card is a sibling of the existing v-if chain, not part of it, so "Sign document" stays available.

## 🧪 How to test

1. Upload a PDF in LibreSign
2. Add yourself as signer, but do not place a visible signature element
3. Request signatures and open the document to sign
4. The sidebar shows the note card above the "Sign document" button
5. Signing still works normally

```bash
npx vitest run src/tests/views/SignPDF/Sign.spec.ts -t "no visible signature notice"
npx playwright test sign-herself-with-click-to-sign
```

## 🎨 UI / Front-end changes

- [x] Informational note card when the signer has no visible signature field
- [x] Screenshots before/after

🏚️ Before | 🏡 After
--- | ---
<img width="325" alt="before" src="https://github.com/user-attachments/assets/51f51d3f-885d-420d-98ab-a7bd6ccb3965" /> | <img width="325" alt="after" src="https://github.com/user-attachments/assets/631f9e7e-f0fc-4306-9db1-e971b2a66330" />

- [ ] Tested in multiple browsers (Chrome, Firefox, Safari)
- [x] Components, Unit (with vitest) and/or e2e (with Playwright) tests added
- [ ] Accessibility verified (contrast, keyboard navigation, screen reader friendly)
- [ ] Design review approved
- [ ] Documentation updated (if applicable)

Tests: component tests for both cases in Sign.spec.ts, and extended sign-herself-with-click-to-sign which already signs without a visible field.

One thing worth your review: the card also shows while a non-retriable certificate error blocks signing, so "Sign.vue - API error handling" now expects 2 note cards instead of 1. The issue describes the condition without exceptions so I kept it, but tell me if you want it hidden there.

## ✅ Checklist

- [x] I have read and followed the [contribution guide](CONTRIBUTING.md).
- [x] Conventional commits with DCO sign-off
- [x] npm test, npm run lint and npm run ts:check pass

## 🤖 AI (if applicable)

- [x] The content of this PR was partially generated using AI
